### PR TITLE
feat(core): define gRPC protobuf schemas for RaptorGate services

### DIFF
--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -52,6 +52,7 @@
         "ts-jest": "^29.2.5",
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",
+        "ts-proto": "^2.11.5",
         "tsconfig-paths": "^4.2.0",
         "tsx": "^4.21.0",
         "typescript": "^5.7.3",
@@ -173,6 +174,8 @@
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.11.0", "", {}, "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
@@ -884,6 +887,8 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001778", "", {}, "sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg=="],
 
+    "case-anything": ["case-anything@2.1.13", "", {}, "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng=="],
+
     "caseless": ["caseless@0.12.0", "", {}, "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -1028,6 +1033,8 @@
 
     "detect-indent": ["detect-indent@4.0.0", "", { "dependencies": { "repeating": "^2.0.0" } }, "sha512-BDKtmHlOzwI7iRuEkhzsnPoi5ypEhWAJB5RvHWe1kMr06js3uK5B3734i3ui5Yd+wOJV1cpE4JnivPD283GU/A=="],
 
+    "detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
+
     "detect-newline": ["detect-newline@3.1.0", "", {}, "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="],
 
     "dezalgo": ["dezalgo@1.0.4", "", { "dependencies": { "asap": "^2.0.0", "wrappy": "1" } }, "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig=="],
@@ -1043,6 +1050,8 @@
     "dotenv-expand": ["dotenv-expand@12.0.3", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA=="],
 
     "dotignore": ["dotignore@0.1.2", "", { "dependencies": { "minimatch": "^3.0.4" }, "bin": { "ignored": "bin/ignored" } }, "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw=="],
+
+    "dprint-node": ["dprint-node@1.0.8", "", { "dependencies": { "detect-libc": "^1.0.3" } }, "sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg=="],
 
     "drizzle": ["drizzle@1.4.0", "", { "dependencies": { "deepmerge": "^2.1.1", "eth-block-tracker-es5": "^2.3.2", "is-plain-object": "^2.0.4", "redux": "^4.0.0", "redux-saga": "^0.16.0", "web3": "1.0.0-beta.35" } }, "sha512-4yeBQLIni5chQfvDChNPL0fFs9dGBPUn1MbXuPpam3cgarpLYh4FFM9kkL/XWya8SlIoyv9wmpk5bJNHOxn1Vw=="],
 
@@ -2123,6 +2132,12 @@
     "ts-loader": ["ts-loader@9.5.4", "", { "dependencies": { "chalk": "^4.1.0", "enhanced-resolve": "^5.0.0", "micromatch": "^4.0.0", "semver": "^7.3.4", "source-map": "^0.7.4" }, "peerDependencies": { "typescript": "*", "webpack": "^5.0.0" } }, "sha512-nCz0rEwunlTZiy6rXFByQU1kVVpCIgUpc/psFiKVrUwrizdnIbRFu8w7bxhUF0X613DYwT4XzrZHpVyMe758hQ=="],
 
     "ts-node": ["ts-node@10.9.2", "", { "dependencies": { "@cspotcode/source-map-support": "^0.8.0", "@tsconfig/node10": "^1.0.7", "@tsconfig/node12": "^1.0.7", "@tsconfig/node14": "^1.0.0", "@tsconfig/node16": "^1.0.2", "acorn": "^8.4.1", "acorn-walk": "^8.1.1", "arg": "^4.1.0", "create-require": "^1.1.0", "diff": "^4.0.1", "make-error": "^1.1.1", "v8-compile-cache-lib": "^3.0.1", "yn": "3.1.1" }, "peerDependencies": { "@swc/core": ">=1.2.50", "@swc/wasm": ">=1.2.50", "@types/node": "*", "typescript": ">=2.7" }, "optionalPeers": ["@swc/core", "@swc/wasm"], "bin": { "ts-node": "dist/bin.js", "ts-script": "dist/bin-script-deprecated.js", "ts-node-cwd": "dist/bin-cwd.js", "ts-node-esm": "dist/bin-esm.js", "ts-node-script": "dist/bin-script.js", "ts-node-transpile-only": "dist/bin-transpile.js" } }, "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ=="],
+
+    "ts-poet": ["ts-poet@6.12.0", "", { "dependencies": { "dprint-node": "^1.0.8" } }, "sha512-xo+iRNMWqyvXpFTaOAvLPA5QAWO6TZrSUs5s4Odaya3epqofBu/fMLHEWl8jPmjhA0s9sgj9sNvF1BmaQlmQkA=="],
+
+    "ts-proto": ["ts-proto@2.11.5", "", { "dependencies": { "@bufbuild/protobuf": "^2.10.2", "case-anything": "^2.1.13", "ts-poet": "^6.12.0", "ts-proto-descriptors": "2.1.0" }, "bin": { "protoc-gen-ts_proto": "protoc-gen-ts_proto" } }, "sha512-Ua2Mu92MhCkOCQgOTn00jOZaOE51JHW/Zfmf65Gtp7mOe2DxUVjKvaedayjQ0SVrblyCVSKCm2tAX/2FWgiFzQ=="],
+
+    "ts-proto-descriptors": ["ts-proto-descriptors@2.1.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.0.0" } }, "sha512-S5EZYEQ6L9KLFfjSRpZWDIXDV/W7tAj8uW7pLsihIxyr62EAVSiKuVPwE8iWnr849Bqa53enex1jhDUcpgquzA=="],
 
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,8 @@
     "db:studio": "drizzle-kit studio --host 0.0.0.0 --port ${PORT:-4983}",
     "db:push": "drizzle-kit push",
     "db:migrate": "drizzle-kit migrate",
-    "db:generate": "drizzle-kit generate"
+    "db:generate": "drizzle-kit generate",
+    "proto:generate": "tsx scripts/generate-proto.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
@@ -71,6 +72,7 @@
     "ts-jest": "^29.2.5",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
+    "ts-proto": "^2.11.5",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.21.0",
     "typescript": "^5.7.3",

--- a/backend/scripts/generate-proto.ts
+++ b/backend/scripts/generate-proto.ts
@@ -1,0 +1,113 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdirSync, rmSync } from 'node:fs';
+import path from 'node:path';
+
+type GenerationTarget = {
+  outDir: string;
+  protoFiles: string[];
+  options: string[];
+};
+
+const backendRoot = path.resolve(__dirname, '..');
+const repositoryRoot = path.resolve(backendRoot, '..');
+const protoRoot = path.join(repositoryRoot, 'proto');
+
+const generatedRoot = path.join(
+  backendRoot,
+  'src',
+  'infrastructure',
+  'grpc',
+  'generated',
+);
+
+const bundledProtocPath = path.join(backendRoot, '.protoc', 'bin', 'protoc');
+const bundledProtocIncludePath = path.join(backendRoot, '.protoc', 'include');
+
+const protocPath =
+  process.env.PROTOC_PATH ??
+  (existsSync(bundledProtocPath) ? bundledProtocPath : 'protoc');
+
+const protocIncludePath =
+  process.env.PROTOC_INCLUDE ??
+  (existsSync(bundledProtocIncludePath)
+    ? bundledProtocIncludePath
+    : '/usr/include');
+
+const tsProtoPluginPath = require.resolve('ts-proto/protoc-gen-ts_proto');
+
+const baseOptions = [
+  'esModuleInterop=true',
+  'env=node',
+  'exportCommonSymbols=false',
+  'oneof=unions',
+  'snakeToCamel=keys_json',
+  'useOptionals=messages',
+];
+
+const targets: GenerationTarget[] = [
+  {
+    outDir: path.join(generatedRoot),
+    protoFiles: [
+      path.join(protoRoot, 'common', 'common.proto'),
+      path.join(protoRoot, 'config', 'config_models.proto'),
+      path.join(protoRoot, 'config', 'config_service.proto'),
+      path.join(protoRoot, 'events', 'backend_events.proto'),
+      path.join(protoRoot, 'events', 'firewall_events.proto'),
+      path.join(protoRoot, 'telemetry', 'telemetry_models.proto'),
+      path.join(protoRoot, 'raptorgate.proto'),
+    ],
+    options: [
+      ...baseOptions,
+      'nestJs=true',
+      'outputServices=default',
+    ],
+  }
+];
+
+function prepareOutputDirectory(target: GenerationTarget): void {
+  rmSync(target.outDir, { recursive: true, force: true });
+  mkdirSync(target.outDir, { recursive: true });
+}
+
+function generateTarget(target: GenerationTarget): void {
+  prepareOutputDirectory(target);
+
+  const result = spawnSync(
+    protocPath,
+    [
+      `--plugin=protoc-gen-ts_proto=${tsProtoPluginPath}`,
+      `--proto_path=${protoRoot}`,
+      `--proto_path=${protocIncludePath}`,
+      `--ts_proto_out=${target.outDir}`,
+      `--ts_proto_opt=${target.options.join(',')}`,
+      ...target.protoFiles,
+    ],
+    {
+      cwd: backendRoot,
+      stdio: 'inherit',
+    },
+  );
+
+  if (result.error) {
+    throw new Error(
+      `Proto generation failed: ${result.error.message}`,
+    );
+  }
+
+  if (result.status !== 0) {
+    throw new Error("Proto generation failed");
+  }
+}
+
+function main(): void {
+  mkdirSync(generatedRoot, { recursive: true });
+
+  for (const target of targets) {
+    generateTarget(target);
+  }
+
+  console.log(`Generated gRPC types in ${generatedRoot}`);
+}
+
+main();

--- a/build.rs
+++ b/build.rs
@@ -4,14 +4,10 @@ const CLIENT_PROTO_FILES: &[&str] = &[
     "proto/common/common.proto",
     "proto/config/config_models.proto",
     "proto/config/config_service.proto",
-    "proto/lifecycle/lifecycle_service.proto",
+    "proto/events/backend_events.proto",
+    "proto/events/firewall_events.proto",
     "proto/telemetry/telemetry_models.proto",
-    "proto/telemetry/telemetry_service.proto",
-];
-
-const STATUS_SERVER_PROTO_FILES: &[&str] = &[
-    "proto/common/common.proto",
-    "proto/status/firewall_status_service.proto",
+    "proto/raptorgate.proto",
 ];
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -23,21 +19,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("cargo:rerun-if-changed={file}");
     }
 
-    for file in STATUS_SERVER_PROTO_FILES {
-        println!("cargo:rerun-if-changed={file}");
-    }
-
     println!("cargo:rerun-if-changed=proto");
 
     tonic_prost_build::configure()
         .build_client(true)
         .build_server(false)
         .compile_protos(CLIENT_PROTO_FILES, PROTO_INCLUDE_DIRS)?;
-
-    tonic_prost_build::configure()
-        .build_client(false)
-        .build_server(true)
-        .compile_protos(STATUS_SERVER_PROTO_FILES, PROTO_INCLUDE_DIRS)?;
 
     Ok(())
 }

--- a/proto/common/common.proto
+++ b/proto/common/common.proto
@@ -1,0 +1,93 @@
+syntax = "proto3";
+
+package raptorgate.common;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Enumeracje współdzielone między modułami
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum Severity {
+  SEVERITY_UNSPECIFIED = 0;
+  SEVERITY_INFO        = 1;
+  SEVERITY_LOW         = 2;
+  SEVERITY_MEDIUM      = 3;
+  SEVERITY_HIGH        = 4;
+  SEVERITY_CRITICAL    = 5;
+}
+
+enum DefaultPolicy {
+  DEFAULT_POLICY_UNSPECIFIED = 0;
+  DEFAULT_POLICY_ALLOW       = 1;
+  DEFAULT_POLICY_DROP        = 2;
+}
+
+enum NatRuleType {
+  NAT_RULE_TYPE_UNSPECIFIED = 0;
+  NAT_RULE_TYPE_SNAT        = 1;
+  NAT_RULE_TYPE_DNAT        = 2;
+  NAT_RULE_TYPE_PAT         = 3;
+}
+
+enum CertificateType {
+  CERTIFICATE_TYPE_UNSPECIFIED = 0;
+  CERTIFICATE_TYPE_CA          = 1;
+  CERTIFICATE_TYPE_TLS_SERVER  = 2;
+}
+
+enum IdentitySource {
+  IDENTITY_SOURCE_UNSPECIFIED      = 0;
+  IDENTITY_SOURCE_LOCAL            = 1;
+  IDENTITY_SOURCE_RADIUS           = 2;
+  IDENTITY_SOURCE_ACTIVE_DIRECTORY = 3;
+}
+
+// Tryb działania procesu firewalla — raportowany w HeartbeatEvent.
+enum FirewallMode {
+  FIREWALL_MODE_UNSPECIFIED = 0;
+  // Konfiguracja pobrana od backendu, firewall działa normalnie.
+  FIREWALL_MODE_NORMAL      = 1;
+  // Backend był niedostępny przy starcie; firewall działa na lokalnym snapshotcie Redb.
+  FIREWALL_MODE_EMERGENCY   = 2;
+  // Brak snapshotu Redb; firewall blokuje cały ruch produkcyjny.
+  FIREWALL_MODE_SAFE_DENY   = 3;
+  // Trwa resynchronizacja z backendem.
+  FIREWALL_MODE_RESYNCING   = 4;
+}
+
+enum AlertSource {
+  ALERT_SOURCE_UNSPECIFIED = 0;
+
+  // Wykrywa anomalie flag TCP: Xmas scan, Null scan, SYN flood, pakiety INVALID.
+  ALERT_SOURCE_CONNTRACK = 1;
+
+  // Reguła z akcją DROP + WARN lub przekroczenie progu połączeń per IP.
+  ALERT_SOURCE_POLICY = 2;
+
+  // Wykrywa: cert pinning, nieważne certyfikaty, anomalie TLS handshake.
+  ALERT_SOURCE_TLS = 3;
+
+  // Wykrywa nieznane lub podejrzane protokoły na niestandardowych portach.
+  ALERT_SOURCE_DPI = 4;
+
+  // Wykrywa: trafienie w blacklistę domen, DNS tunneling (entropia/długość subdomeny).
+  ALERT_SOURCE_DNS = 5;
+
+  // Wykrywa: SQL injection, XSS, shellcode, path traversal i inne wzorce Aho-Corasick.
+  ALERT_SOURCE_IPS = 6;
+
+  // Klasyfikuje ruch jako malicious / suspicious na podstawie cech sesji.
+  ALERT_SOURCE_ML = 7;
+}
+
+enum ConfigChangeType {
+  CONFIG_CHANGE_TYPE_UNSPECIFIED   = 0;
+  CONFIG_CHANGE_TYPE_POLICY_UPDATE = 1;
+  CONFIG_CHANGE_TYPE_ROLLBACK      = 2;
+}
+
+enum PolicyFailureCode {
+  POLICY_FAILURE_CODE_UNSPECIFIED       = 0;
+  POLICY_FAILURE_CODE_VALIDATION_FAILED = 1;
+  POLICY_FAILURE_CODE_COMPILE_FAILED    = 2;
+  POLICY_FAILURE_CODE_RUNTIME_FAILED    = 3;
+}

--- a/proto/config/config_models.proto
+++ b/proto/config/config_models.proto
@@ -1,0 +1,216 @@
+syntax = "proto3";
+
+package raptorgate.config;
+
+import "common/common.proto";
+import "google/protobuf/timestamp.proto";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Modele sekcji konfiguracji
+//
+// Każda sekcja posiada własny numer wersji (uint64). Backend inkrementuje
+// wersję sekcji przy każdej zmianie jej zawartości. Firewall przechowuje
+// znane wersje w lokalnym snapshotcie Redb i wysyła je w GetConfigRequest
+// (pole known_versions) aby pobrać tylko zmienione sekcje (delta).
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── Reguły RaptorLang ────────────────────────────────────────────────────────
+
+message Rule {
+  string id           = 1;
+  string name         = 2;
+  string zone_pair_id = 3;
+  uint32 priority     = 4;
+  string content      = 5;  // źródło reguły w języku RaptorLang
+}
+
+message RuleSet {
+  uint64         version  = 1;
+  string         checksum = 2;  // SHA-256 zawartości sekcji
+  repeated Rule  items    = 3;
+}
+
+// ── Strefy sieciowe ──────────────────────────────────────────────────────────
+
+message Zone {
+  string id   = 1;
+  string name = 2;
+}
+
+message ZoneSet {
+  uint64        version = 1;
+  repeated Zone items   = 2;
+}
+
+message ZoneInterface {
+  string          id             = 1;
+  string          zone_id        = 2;
+  string          interface_name = 3;
+  optional uint32 vlan_id        = 4;
+}
+
+message ZoneInterfaceSet {
+  uint64                  version = 1;
+  repeated ZoneInterface  items   = 2;
+}
+
+message ZonePair {
+  string                   id             = 1;
+  string                   src_zone_id    = 2;
+  string                   dst_zone_id    = 3;
+  common.DefaultPolicy     default_policy = 4;
+}
+
+message ZonePairSet {
+  uint64             version = 1;
+  repeated ZonePair  items   = 2;
+}
+
+// ── NAT ──────────────────────────────────────────────────────────────────────
+
+message NatRule {
+  string              id               = 1;
+  common.NatRuleType  type             = 2;
+  string              src_ip           = 3;
+  string              dst_ip           = 4;
+  optional uint32     src_port         = 5;
+  optional uint32     dst_port         = 6;
+  string              translated_ip    = 7;
+  optional uint32     translated_port  = 8;
+  uint32              priority         = 9;
+}
+
+message NatRuleSet {
+  uint64             version = 1;
+  repeated NatRule   items   = 2;
+}
+
+// ── DNS blacklista ────────────────────────────────────────────────────────────
+
+message DnsBlacklistEntry {
+  string id     = 1;
+  string domain = 2;
+}
+
+message DnsBlacklistSet {
+  uint64                      version = 1;
+  repeated DnsBlacklistEntry  items   = 2;
+}
+
+// ── SSL/TLS bypass lista ─────────────────────────────────────────────────────
+
+message SslBypassEntry {
+  string id     = 1;
+  string domain = 2;
+}
+
+message SslBypassSet {
+  uint64                   version = 1;
+  repeated SslBypassEntry  items   = 2;
+}
+
+// ── Sygnatury IPS ────────────────────────────────────────────────────────────
+
+message IpsSignature {
+  string           id       = 1;
+  string           name     = 2;
+  string           category = 3;
+  string           pattern  = 4;
+  common.Severity  severity = 5;
+}
+
+message IpsSignatureSet {
+  uint64                  version = 1;
+  repeated IpsSignature   items   = 2;
+}
+
+// ── Model ML (ONNX) ──────────────────────────────────────────────────────────
+
+message MlModel {
+  uint64 version       = 1;
+  string id            = 2;
+  string name          = 3;
+  string artifact_path = 4;
+  string checksum      = 5;  // SHA-256 pliku modelu
+}
+
+// ── Certyfikaty TLS ──────────────────────────────────────────────────────────
+
+message FirewallCertificate {
+  string                   id              = 1;
+  common.CertificateType   cert_type       = 2;
+  string                   common_name     = 3;
+  string                   fingerprint     = 4;
+  string                   certificate_pem = 5;
+  string                   private_key_ref = 6;
+  google.protobuf.Timestamp expires_at     = 7;
+}
+
+message FirewallCertificateSet {
+  uint64                       version = 1;
+  repeated FirewallCertificate items   = 2;
+}
+
+// ── Tożsamość użytkowników ───────────────────────────────────────────────────
+
+message UserGroup {
+  string                id     = 1;
+  string                name   = 2;
+  common.IdentitySource source = 3;
+}
+
+message IdentityUser {
+  string                id           = 1;
+  string                username     = 2;
+  string                display_name = 3;
+  common.IdentitySource source       = 4;
+  string                external_id  = 5;
+}
+
+message UserGroupMember {
+  string id               = 1;
+  string group_id         = 2;
+  string identity_user_id = 3;
+}
+
+// Aktywna sesja użytkownika uwierzytelnionego przez RADIUS.
+message IdentityManagerUserSession {
+  string                    id                = 1;
+  string                    identity_user_id  = 2;
+  string                    radius_username   = 3;
+  string                    mac_address       = 4;
+  string                    ip_address        = 5;
+  string                    nas_ip            = 6;
+  string                    called_station_id = 7;
+  google.protobuf.Timestamp authenticated_at  = 8;
+  google.protobuf.Timestamp expires_at        = 9;
+}
+
+message IdentityBundle {
+  uint64                              version       = 1;
+  repeated UserGroup                  user_groups   = 2;
+  repeated IdentityUser               identity_users = 3;
+  repeated UserGroupMember            user_group_members = 4;
+  repeated IdentityManagerUserSession user_sessions = 5;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wersje sekcji — używane w mechanizmie delty
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Wersje sekcji znane firewall owi.
+// Backend wysyła daną sekcję tylko gdy jej aktualna wersja jest wyższa
+// niż wartość podana tutaj. Wartość 0 oznacza brak sekcji — backend ją wyśle.
+message ConfigSectionVersions {
+  uint64 rules           = 1;
+  uint64 zones           = 2;
+  uint64 zone_interfaces = 3;
+  uint64 zone_pairs      = 4;
+  uint64 nat_rules       = 5;
+  uint64 dns_blacklist   = 6;
+  uint64 ssl_bypass_list = 7;
+  uint64 ips_signatures  = 8;
+  uint64 ml_model        = 9;
+  uint64 certificates    = 10;
+  uint64 identity        = 11;
+}

--- a/proto/config/config_service.proto
+++ b/proto/config/config_service.proto
@@ -1,0 +1,76 @@
+syntax = "proto3";
+
+package raptorgate.config;
+
+import "config/config_models.proto";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GetActiveConfig — unary RPC pobierania konfiguracji z mechaniizmem delty
+//
+// Firewall wywołuje tę metodę w trzech sytuacjach:
+//   1. Startup normalny (brak snapshotu Redb)        → known_versions puste
+//   2. Startup awaryjny (Redb istnieje) lub resync   → known_versions wypełnione
+//   3. Reakcja na ConfigChangedEvent z event bus     → known_versions wypełnione
+//
+// Backend porównuje known_versions z aktualnymi wersjami sekcji w PostgreSQL
+// i zwraca tylko sekcje które uległy zmianie. Sekcje niezmienione mają
+// wartość null w odpowiedzi.
+// ─────────────────────────────────────────────────────────────────────────────
+
+message GetConfigRequest {
+  // Identyfikator korelacji — pozwala powiązać żądanie z eventem który je wywołał.
+  string correlation_id = 1;
+
+  // Powód żądania — używany przez backend do logowania zdarzenia audytowego.
+  ConfigRequestReason reason = 2;
+
+  // Wersje sekcji aktualnie aktywnych w lokalnym snapshotcie (Redb).
+  // Brak pola (firewall nie ma snapshotu) → backend wysyła pełny bundle.
+  optional ConfigSectionVersions known_versions = 3;
+}
+
+enum ConfigRequestReason {
+  CONFIG_REQUEST_REASON_UNSPECIFIED    = 0;
+  // Pierwszy start, brak snapshotu Redb.
+  CONFIG_REQUEST_REASON_STARTUP        = 1;
+  // Start z lokalnym snapshotem — weryfikacja aktualności przed użyciem.
+  CONFIG_REQUEST_REASON_EMERGENCY      = 2;
+  // Backend wrócił po awarii i zażądał resyncu przez event bus.
+  CONFIG_REQUEST_REASON_RESYNC         = 3;
+  // Reakcja na ConfigChangedEvent (zmiana polityki lub rollback).
+  CONFIG_REQUEST_REASON_CONFIG_CHANGED = 4;
+}
+
+message ConfigResponse {
+  // Globalna wersja aktywnej konfiguracji w backendzie.
+  uint64 config_version = 1;
+
+  // SHA-256 pełnego aktywnego ConfigBundle po stronie backendu.
+  // Firewall może użyć tego checksumu do weryfikacji spójności po zastosowaniu delty
+  // (porównując z lokalnie wyliczonym checksumem po złożeniu pełnego bundla).
+  string bundle_checksum = 2;
+
+  string correlation_id = 3;
+
+  // False gdy known_versions w żądaniu były identyczne z aktualnymi wersjami
+  // backendu — firewall ma aktualną konfigurację, pola sekcji poniżej są null.
+  bool configuration_changed = 4;
+
+  // Wersje wszystkich sekcji po stronie backendu — zawsze wypełnione.
+  // Firewall zapisuje je do Redb i używa przy kolejnych wywołaniach delty.
+  ConfigSectionVersions current_versions = 5;
+
+  // Sekcje ze zmianami. null = sekcja niezmieniona względem known_versions.
+  // Gdy known_versions było puste w żądaniu — wszystkie pola są wypełnione.
+  optional RuleSet               rules                 = 6;
+  optional ZoneSet               zones                 = 7;
+  optional ZoneInterfaceSet      zone_interfaces       = 8;
+  optional ZonePairSet           zone_pairs            = 9;
+  optional NatRuleSet            nat_rules             = 10;
+  optional DnsBlacklistSet       dns_blacklist         = 11;
+  optional SslBypassSet          ssl_bypass_list       = 12;
+  optional IpsSignatureSet       ips_signatures        = 13;
+  optional MlModel               ml_model              = 14;
+  optional FirewallCertificateSet firewall_certificates = 15;
+  optional IdentityBundle        identity              = 16;
+}

--- a/proto/events/backend_events.proto
+++ b/proto/events/backend_events.proto
@@ -1,0 +1,63 @@
+syntax = "proto3";
+
+package raptorgate.events;
+
+import "common/common.proto";
+import "google/protobuf/timestamp.proto";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Koperta zdarzenia wysyłanego przez Backend → Firewall przez EventStream.
+//
+// Znane wartości pola `type`:
+//   "be.heartbeat_ack"    — HeartbeatAck
+//   "be.config_changed"   — ConfigChangedEvent
+//   "be.resync_requested" — ResyncRequestedEvent
+// ─────────────────────────────────────────────────────────────────────────────
+message BackendEvent {
+  // UUID v7.
+  string event_id = 1;
+
+  // Identyfikator typu eventu — determinuje jak deserializować payload.
+  string type = 2;
+
+  // Serializowana wiadomość protobuf odpowiadająca danemu typowi.
+  bytes payload = 3;
+
+  google.protobuf.Timestamp ts = 4;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Payloady
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Typ: "be.heartbeat_ack"
+//
+// Potwierdzenie odebrania HeartbeatEvent.
+message HeartbeatAck {
+  google.protobuf.Timestamp received_at = 1;
+}
+
+// Typ: "be.config_changed"
+//
+// Wysyłany gdy administrator zastosował nową konfigurację lub wykonał rollback.
+// Firewall powinien zareagować wywołując GetActiveConfig z known_versions
+// aby pobrać tylko zmienione sekcje (delta).
+message ConfigChangedEvent {
+  string config_id      = 1;
+  uint64 new_version    = 2;
+  string correlation_id = 3;
+  common.ConfigChangeType change_type = 4;
+  google.protobuf.Timestamp changed_at = 5;
+}
+
+// Typ: "be.resync_requested"
+//
+// Wysyłany gdy backend wraca po awarii i wykrywa że firewall działa
+// w trybie awaryjnym (FIREWALL_MODE_EMERGENCY w HeartbeatEvent).
+// Firewall wywołuje GetActiveConfig z known_versions — jeśli wersja jest
+// aktualna, odpowiada ResyncConfirmedEvent z no_change=true.
+message ResyncRequestedEvent {
+  string correlation_id = 1;
+  string reason         = 2;
+  google.protobuf.Timestamp requested_at = 3;
+}

--- a/proto/events/firewall_events.proto
+++ b/proto/events/firewall_events.proto
@@ -1,0 +1,112 @@
+syntax = "proto3";
+
+package raptorgate.events;
+
+import "common/common.proto";
+import "google/protobuf/timestamp.proto";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Koperta zdarzenia wysyłanego przez Firewall → Backend przez EventStream.
+//
+// Znane wartości pola `type`:
+//   "fw.heartbeat"        — HeartbeatEvent
+//   "fw.metrics"          — MetricsBatch (z telemetry_models.proto)
+//   "fw.alert"            — AlertEvent
+//   "fw.policy_activated" — PolicyActivatedEvent
+//   "fw.policy_failed"    — PolicyFailedEvent
+//   "fw.resync_confirmed" — ResyncConfirmedEvent
+// ─────────────────────────────────────────────────────────────────────────────
+message FirewallEvent {
+  // UUID v7 — monotoniczny, używany do deduplikacji po stronie backendu.
+  string event_id = 1;
+
+  // Identyfikator typu eventu — determinuje jak deserializować payload.
+  string type = 2;
+
+  // Serializowana wiadomość protobuf odpowiadająca danemu typowi.
+  bytes payload = 3;
+
+  google.protobuf.Timestamp ts = 4;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Payloady
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Typ: "fw.heartbeat"
+//
+// Pierwsze HeartbeatEvent po nawiązaniu EventStream jest traktowane przez
+// backend jako sygnał że firewall wystartował poprawnie.
+// Brak kolejnego HeartbeatEvent przez np. >10 s → firewall nie odpowiada.
+// Brak nawiązania EventStream przez np. 30 s od startu backendu → firewall nie wystartował.
+message HeartbeatEvent {
+  // Wersja semantyczna oprogramowania firewalla (semver).
+  string firewall_version      = 1;
+  common.FirewallMode mode     = 2;
+  uint64 active_config_version = 3;
+  uint64 uptime_seconds        = 4;
+}
+
+// Typ: "fw.alert"
+//
+// Wysyłany gdy moduł inspekcji wygeneruje alert (np. IPS lub ML wykryje potencjalne zagrożenie).
+message AlertEvent {
+  string log_id      = 1;
+  string title       = 2;
+  string description = 3;
+
+  common.Severity   severity = 4;
+  common.AlertSource source  = 5;
+
+  // Wypełnione gdy source == IPS.
+  string signature_name = 6;
+
+  // Wypełnione gdy source == ML. Wartość 0.0–1.0.
+  float ml_confidence = 7;
+
+  string src_ip   = 8;
+  string dst_ip   = 9;
+  uint32 src_port = 10;
+  uint32 dst_port = 11;
+  string protocol = 12;
+
+  google.protobuf.Timestamp occurred_at = 13;
+}
+
+// Typ: "fw.policy_activated"
+//
+// Wysyłany po udanym atomowym przełączeniu polityki.
+message PolicyActivatedEvent {
+  string config_id      = 1;
+  uint64 config_version = 2;
+  string correlation_id = 3;
+  google.protobuf.Timestamp activated_at = 4;
+}
+
+// Typ: "fw.policy_failed"
+//
+// Wysyłany gdy kompilacja lub aktywacja nowej polityki zakończyła się błędem.
+// Poprzednia polityka pozostaje aktywna — firewall kontynuuje działanie.
+message PolicyFailedEvent {
+  string config_id      = 1;
+  uint64 config_version = 2;
+  string correlation_id = 3;
+
+  common.PolicyFailureCode failure_code    = 4;
+  string                   failure_message = 5;
+  repeated string          validation_errors = 6;
+
+  google.protobuf.Timestamp failed_at = 7;
+}
+
+// Typ: "fw.resync_confirmed"
+//
+// Wysyłany po zakończeniu resynchronizacji zainicjowanej przez ResyncRequestedEvent.
+message ResyncConfirmedEvent {
+  uint64 previous_version = 1;
+  uint64 current_version  = 2;
+  string correlation_id   = 3;
+  // True gdy wersje konfiguracji były identyczne — nie było potrzeby przeładowania polityki.
+  bool no_change = 4;
+  google.protobuf.Timestamp confirmed_at = 5;
+}

--- a/proto/raptorgate.proto
+++ b/proto/raptorgate.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package raptorgate;
+
+import "events/backend_events.proto";
+import "config/config_service.proto";
+import "events/firewall_events.proto";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RaptorGate gRPC Service
+//
+// Hostowany przez Backend (NestJS / grpc-js).
+// Firewall jest zawsze klientem (Rust / tonic).
+// Transport: gRPC over Unix Domain Socket (np. /var/run/raptorgate/backend.sock)
+//
+// Importowane typy:
+//   raptorgate.config.GetConfigRequest    — config/config_service.proto
+//   raptorgate.config.ConfigResponse      — config/config_service.proto
+//   raptorgate.events.FirewallEvent       — events/firewall_events.proto
+//   raptorgate.events.BackendEvent        — events/backend_events.proto
+// ─────────────────────────────────────────────────────────────────────────────
+service RaptorGateService {
+  // Unary — firewall pobiera konfigurację.
+  //
+  // Mechanizm delty: firewall dołącza wersje sekcji z lokalnego snapshotu Redb
+  // (pole known_versions). Backend odsyła tylko sekcje których wersja jest
+  // nowsza. Sekcje niezmienione mają wartość null w odpowiedzi.
+  // Przy braku known_versions (brak snapshotu) — backend wysyła pełny bundle.
+  rpc GetActiveConfig(raptorgate.config.GetConfigRequest)
+      returns (raptorgate.config.ConfigResponse);
+
+  // Bidirectional streaming — główny event bus.
+  //
+  // Firewall inicjuje połączenie po starcie.
+  // Brak połączenia przez 30 s od startu backendu → firewall nie wystartował.
+  // Po nawiązaniu połączenia: firewall wysyła HeartbeatEvent co np. 10 s.
+  // Brak HeartbeatEvent przez np. >10 s → firewall nie odpowiada.
+  rpc EventStream(stream raptorgate.events.FirewallEvent)
+      returns (stream raptorgate.events.BackendEvent);
+}

--- a/proto/telemetry/telemetry_models.proto
+++ b/proto/telemetry/telemetry_models.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package raptorgate.telemetry;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Modele telemetryczne — używane jako payload eventu "fw.metrics"
+// Wysyłane co np. 10 sekund, równolegle z HeartbeatEvent.
+// ─────────────────────────────────────────────────────────────────────────────
+
+message MetricsBatch {
+  NetworkCounters    network     = 1;
+  ConnectionCounters connections = 2;
+  SystemLoad         system      = 3;
+  InspectionCounters inspection  = 4;
+
+  // Okres pomiarowy w sekundach (zwykle 10).
+  uint32 interval_seconds = 5;
+
+  // Wersja konfiguracji aktywnej podczas pomiaru.
+  uint64 config_version = 6;
+}
+
+message NetworkCounters {
+  uint64 packets_total            = 1;
+  uint64 bytes_total              = 2;
+  double packets_per_sec          = 3;
+  double bytes_per_sec            = 4;
+  uint64 accepted_packets_total   = 5;
+  uint64 dropped_packets_total    = 6;
+  double accepted_packets_per_sec = 7;
+  double dropped_packets_per_sec  = 8;
+}
+
+message ConnectionCounters {
+  uint64 active_connections      = 1;
+  double new_connections_per_sec = 2;
+  uint64 nat_translations_active = 3;
+}
+
+message SystemLoad {
+  double cpu_usage_percent       = 1;
+  double memory_usage_percent    = 2;
+  uint64 memory_usage_bytes      = 3;
+  double conntrack_usage_percent = 4;
+}
+
+message InspectionCounters {
+  double dns_queries_per_sec     = 1;
+  double tls_inspections_per_sec = 2;
+  double ips_matches_per_sec     = 3;
+  double ml_inferences_per_sec   = 4;
+  uint64 alerts_total            = 5;
+  double alerts_per_sec          = 6;
+}


### PR DESCRIPTION
Introduce a set of Protobuf definitions to establish the communication contract between the Backend and Firewall. This includes configuration models with delta-update support, event streaming for heartbeats, alerts, and telemetry metrics.
Key changes:
- add core service definition in raptorgate.proto
- implement configuration models with versioning for delta sync
- define bidirectional event stream for real-time monitoring
- add script and npm command for TypeScript type generation
- update Rust build.rs to include new proto paths

Closes BE-45