### PR TITLE
feat(core): walidacja pakietów – TTL, checksum IPv4/TCP/UDP

### DIFF
--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -23,7 +23,6 @@
         "dotenv": "^17.3.1",
         "drizzle": "^1.4.0",
         "drizzle-orm": "^1.0.0-beta.16-ea816b6",
-        "i": "^0.3.7",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.20.0",
@@ -1357,8 +1356,6 @@
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
-
-    "i": ["i@0.3.7", "", {}, "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod rule_tree;
 mod app_config;
 mod grpc_client;
 mod policy_evaluator;
+mod packet_validator;
 
 #[tokio::main]
 async fn main() {
@@ -147,6 +148,11 @@ async fn handle_packet(iface: &str, data: &[u8], tun: &AsyncDevice, evaluator: &
 
     // Only forward IPv4 packets.
     if !matches!(&packet.net, Some(NetSlice::Ipv4(_))) {
+        return;
+    }
+
+    if let Err(reason) = packet_validator::validate(&packet) {
+        println!("[{iface}] DROP (invalid packet: {reason})");
         return;
     }
 

--- a/src/packet_validator.rs
+++ b/src/packet_validator.rs
@@ -1,0 +1,193 @@
+use etherparse::{NetSlice, SlicedPacket, TransportSlice};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub(crate) enum InvalidReason {
+    #[error("TTL is zero")]
+    TtlZero,
+    #[error("invalid IPv4 header checksum")]
+    BadIpv4Checksum,
+    #[error("invalid TCP checksum")]
+    BadTcpChecksum,
+    #[error("invalid UDP checksum")]
+    BadUdpChecksum,
+    #[error("malformed packet (checksum could not be computed)")]
+    MalformedPacket,
+}
+
+// Sprawdza czy pakiet jest poprawny: TTL, suma kontrolna IPv4 i L4.
+pub(crate) fn validate(packet: &SlicedPacket) -> Result<(), InvalidReason> {
+    let ipv4 = match &packet.net {
+        Some(NetSlice::Ipv4(ipv4)) => ipv4,
+        _ => return Ok(()),
+    };
+
+    let ip_header = ipv4.header().to_header();
+
+    if ip_header.time_to_live == 0 {
+        return Err(InvalidReason::TtlZero);
+    }
+
+    if ip_header.calc_header_checksum() != ip_header.header_checksum {
+        return Err(InvalidReason::BadIpv4Checksum);
+    }
+
+    if packet.is_ip_payload_fragmented() {
+        return Ok(());
+    }
+
+    match &packet.transport {
+        Some(TransportSlice::Tcp(tcp)) => {
+            let tcp_header = tcp.to_header();
+            match tcp_header.calc_checksum_ipv4(&ip_header, tcp.payload()) {
+                Ok(expected) if expected != tcp_header.checksum => {
+                    return Err(InvalidReason::BadTcpChecksum);
+                }
+                Err(_) => return Err(InvalidReason::MalformedPacket),
+                _ => {}
+            }
+        }
+        Some(TransportSlice::Udp(udp)) => {
+            let udp_header = udp.to_header();
+            if udp_header.checksum != 0 {
+                match udp_header.calc_checksum_ipv4(&ip_header, udp.payload()) {
+                    Ok(expected) if expected != udp_header.checksum => {
+                        return Err(InvalidReason::BadUdpChecksum);
+                    }
+                    Err(_) => return Err(InvalidReason::MalformedPacket),
+                    _ => {}
+                }
+            }
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use etherparse::{PacketBuilder, SlicedPacket};
+
+    fn build_tcp_packet(src: [u8; 4], dst: [u8; 4], ttl: u8) -> Vec<u8> {
+        let mut buf = Vec::new();
+        PacketBuilder::ethernet2([1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12])
+            .ipv4(src, dst, ttl)
+            .tcp(12345, 80, 1, 65535)
+            .write(&mut buf, b"hello")
+            .unwrap();
+        buf
+    }
+
+    fn build_udp_packet(src: [u8; 4], dst: [u8; 4], ttl: u8) -> Vec<u8> {
+        let mut buf = Vec::new();
+        PacketBuilder::ethernet2([1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12])
+            .ipv4(src, dst, ttl)
+            .udp(54321, 53)
+            .write(&mut buf, b"query")
+            .unwrap();
+        buf
+    }
+
+    // Przelicza checksumę IPv4 po modyfikacji bajtów.
+    fn fix_ipv4_checksum(buf: &mut [u8]) {
+        buf[24] = 0;
+        buf[25] = 0;
+        let mut sum: u32 = 0;
+        for i in (14..34).step_by(2) {
+            sum += ((buf[i] as u32) << 8) | buf[i + 1] as u32;
+        }
+        while sum >> 16 != 0 {
+            sum = (sum & 0xFFFF) + (sum >> 16);
+        }
+        let cksum = !(sum as u16);
+        buf[24] = (cksum >> 8) as u8;
+        buf[25] = (cksum & 0xFF) as u8;
+    }
+
+    // Sprawdza czy pakiet TCP jest poprawny.
+    #[test]
+    fn valid_tcp_packet_passes() {
+        let buf = build_tcp_packet([10, 0, 0, 1], [10, 0, 0, 2], 64);
+        let packet = SlicedPacket::from_ethernet(&buf).unwrap();
+        assert!(validate(&packet).is_ok());
+    }
+
+    // Sprawdza czy pakiet UDP jest poprawny.
+    #[test]
+    fn valid_udp_packet_passes() {
+        let buf = build_udp_packet([10, 0, 0, 1], [10, 0, 0, 2], 64);
+        let packet = SlicedPacket::from_ethernet(&buf).unwrap();
+        assert!(validate(&packet).is_ok());
+    }
+
+    // Sprawdza czy pakiet z TTL=0 jest odrzucony.
+    #[test]
+    fn ttl_zero_rejected() {
+        let buf = build_tcp_packet([10, 0, 0, 1], [10, 0, 0, 2], 0);
+        let packet = SlicedPacket::from_ethernet(&buf).unwrap();
+        assert!(matches!(validate(&packet), Err(InvalidReason::TtlZero)));
+    }
+
+    // Sprawdza czy pakiet z zepsuta checksuma IPv4 jest odrzucony.
+    #[test]
+    fn bad_ipv4_checksum_rejected() {
+        let mut buf = build_tcp_packet([10, 0, 0, 1], [10, 0, 0, 2], 64);
+        buf[24] ^= 0xFF;
+        let packet = SlicedPacket::from_ethernet(&buf).unwrap();
+        assert!(matches!(validate(&packet), Err(InvalidReason::BadIpv4Checksum)));
+    }
+
+    // Sprawdza czy pakiet z zepsutą sumą kontrolną TCP jest odrzucony.
+    #[test]
+    fn bad_tcp_checksum_rejected() {
+        let mut buf = build_tcp_packet([10, 0, 0, 1], [10, 0, 0, 2], 64);
+        buf[50] ^= 0xFF;
+        let packet = SlicedPacket::from_ethernet(&buf).unwrap();
+        assert!(matches!(validate(&packet), Err(InvalidReason::BadTcpChecksum)));
+    }
+
+    // Sprawdza czy pakiet z zepsutą sumą kontrolną UDP jest odrzucony.
+    #[test]
+    fn bad_udp_checksum_rejected() {
+        let mut buf = build_udp_packet([10, 0, 0, 1], [10, 0, 0, 2], 64);
+        buf[40] ^= 0xFF;
+        let packet = SlicedPacket::from_ethernet(&buf).unwrap();
+        assert!(matches!(validate(&packet), Err(InvalidReason::BadUdpChecksum)));
+    }
+
+    // Sprawdza czy pakiet UDP z sumą kontrolną = 0 przechodzi.
+    #[test]
+    fn udp_zero_checksum_passes() {
+        let mut buf = build_udp_packet([10, 0, 0, 1], [10, 0, 0, 2], 64);
+        buf[40] = 0;
+        buf[41] = 0;
+        let packet = SlicedPacket::from_ethernet(&buf).unwrap();
+        assert!(validate(&packet).is_ok());
+    }
+
+    // Sprawdza czy fragmentowany pakiet omija walidacje L4 (fragmentacja nie jest jeszcze zrobiona)
+    #[test]
+    fn fragmented_packet_passes_validation() {
+        let mut buf = build_tcp_packet([10, 0, 0, 1], [10, 0, 0, 2], 64);
+        buf[20] |= 0x20;
+        fix_ipv4_checksum(&mut buf);
+        let packet = SlicedPacket::from_ethernet(&buf).unwrap();
+        assert!(packet.is_ip_payload_fragmented());
+        assert!(validate(&packet).is_ok());
+    }
+
+    // Sprawdza czy nie ma błędu przy pomijaniu pakietów nie ipv4.
+    #[test]
+    fn non_ipv4_packet_passes() {
+        let mut buf = build_tcp_packet([10, 0, 0, 1], [10, 0, 0, 2], 64);
+        buf[12] = 0x08;
+        buf[13] = 0x06;
+        if let Ok(packet) = SlicedPacket::from_ethernet(&buf) {
+            if packet.net.is_none() {
+                assert!(validate(&packet).is_ok());
+            }
+        }
+    }
+}

--- a/vagrant/vagrantfile
+++ b/vagrant/vagrantfile
@@ -167,9 +167,12 @@ Vagrant.configure("2") do |config|
       netmask: "255.255.255.0",
       libvirt__network_name: "intnet1"
 
+    h1.vm.provision "shell", inline: "apt-get update -qq && apt-get install -y --no-install-recommends hping3 python3 ncat ethtool"
+
     h1.vm.provision "shell", inline: configure_interface("eth1", "192.168.10.10", "24", "192.168.10.254") + <<-SHELL
     ip route del default 2>/dev/null || true
     ip route add default via 192.168.10.254
+    ethtool -K eth1 tx off
     SHELL
   end
 
@@ -181,9 +184,12 @@ Vagrant.configure("2") do |config|
       netmask: "255.255.255.0",
       libvirt__network_name: "intnet2"
 
+    h2.vm.provision "shell", inline: "apt-get update -qq && apt-get install -y --no-install-recommends hping3 python3 ncat ethtool"
+
     h2.vm.provision "shell", inline: configure_interface("eth1", "192.168.20.10", "24", "192.168.20.254") + <<-SHELL
     ip route del default 2>/dev/null || true
     ip route add default via 192.168.20.254
+    ethtool -K eth1 tx off
     SHELL
   end
 


### PR DESCRIPTION
Dodano moduł `packet_validator` sprawdzający poprawność pakietów IPv4 przed przekazaniem ich do ewaluatora reguł. Odrzucane są pakiety z TTL=0, błędną sumą kontrolną nagłówka IPv4 oraz błędną sumą L4 (TCP/UDP). Fragmentowane pakiety omijają walidację L4.

Vagrant: zainstalowano hping3/ncat/ethtool na hostach testowych i wyłączono TX checksum offload (ethtool -K tx off), dzięki czemu ręcznie konstruowane pakiety mają poprawne sumy kontrolne widoczne dla firewalla.