### PR TITLE
feat(core): implement emergency startup modes and reconnection logic

### DIFF
--- a/src/grpc_client.rs
+++ b/src/grpc_client.rs
@@ -1,10 +1,10 @@
 pub mod client;
+pub mod proto_types;
 pub mod active_config;
 pub mod config_snapshot;
 pub mod backend_connection;
+pub mod firewall_mode_state;
 pub mod event_stream_manager;
 
-mod proto_types;
 mod event_type;
 mod event_dispatcher;
-mod firewall_mode_state;

--- a/src/grpc_client/backend_connection.rs
+++ b/src/grpc_client/backend_connection.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
+use std::time::Duration;
 
+use tokio::sync::mpsc::Sender;
 use tokio::sync::RwLock;
 
 use crate::app_config::AppConfig;
@@ -12,31 +14,21 @@ use crate::grpc_client::event_stream_manager::EventStreamManager;
 use crate::grpc_client::client::{current_timestamp, make_firewall_event, GrpcClient};
 use crate::grpc_client::proto_types::raptorgate::{
     common::{FirewallMode, PolicyFailureCode},
-    config::{ConfigRequestReason, GetConfigRequest},
-    events::{ConfigChangedEvent, PolicyActivatedEvent, PolicyFailedEvent},
+    config::{ConfigRequestReason, ConfigResponse, GetConfigRequest},
+    events::{
+        ConfigChangedEvent, FirewallEvent, PolicyActivatedEvent, PolicyFailedEvent,
+        ResyncConfirmedEvent, ResyncRequestedEvent,
+    },
 };
 
 pub struct BackendConnection {
     pub mode: FirewallModeState,
-    pub event_manager: EventStreamManager,
     pub active_config: Arc<RwLock<ActiveConfig>>,
     pub snapshot: Option<Arc<ConfigSnapshot>>,
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum BackendConnectionError {
-    #[error("połączenie UDS: {0}")]
-    Connect(#[from] tonic::transport::Error),
-    #[error("pobieranie konfiguracji: {0}")]
-    ConfigFetch(tonic::Status),
-    #[error("otwarcie EventStream: {0}")]
-    EventStream(tonic::Status),
-}
-
 impl BackendConnection {
-    pub async fn startup(config: &AppConfig) -> Result<Self, BackendConnectionError> {
-        let mode = FirewallModeState::new(FirewallMode::SafeDeny);
-
+    pub async fn startup(config: &AppConfig) -> Self {
         let snapshot: Option<Arc<ConfigSnapshot>> = match ConfigSnapshot::open(&config.redb_snapshot_path) {
             Ok(s) => Some(Arc::new(s)),
             Err(e) => {
@@ -45,135 +37,359 @@ impl BackendConnection {
             }
         };
 
-        let mut client = GrpcClient::connect(&config.grpc_socket_path).await?;
+        // --- próba normalnego startu ---
+        'normal: {
+            let mut client = match GrpcClient::connect(&config.grpc_socket_path).await {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(error = %e, "gRPC niedostępny przy starcie");
+                    break 'normal;
+                }
+            };
 
-        let correlation_id = uuid::Uuid::now_v7().to_string();
-
-        let resp = client
-            .get_active_config(GetConfigRequest {
-                correlation_id: correlation_id.clone(),
+            let resp = match client.get_active_config(GetConfigRequest {
+                correlation_id: uuid::Uuid::now_v7().to_string(),
                 reason: ConfigRequestReason::Startup as i32,
                 known_versions: None,
                 known_version: None,
-            }).await
-            .map_err(BackendConnectionError::ConfigFetch)?;
+            }).await {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(error = %e, "GetActiveConfig nieudany przy starcie");
+                    break 'normal;
+                }
+            };
 
-        let config_version = resp.config_version;
-        let active_config = Arc::new(RwLock::new(ActiveConfig::from_response(resp)));
+            // --- NORMAL ---
+            let config_version = resp.config_version;
+            let active_config = Arc::new(RwLock::new(ActiveConfig::from_response(resp)));
+            let mode = FirewallModeState::new(FirewallMode::Normal);
+            mode.set_config_version(config_version);
 
-        if let Some(ref snap) = snapshot {
-            snap.clone().save_bg(active_config.read().await.to_config_response());
+            if let Some(ref snap) = snapshot {
+                snap.clone().save_bg(active_config.read().await.to_config_response());
+            }
+
+            tracing::info!(version = config_version, "Konfiguracja pobrana, tryb NORMAL");
+
+            let (fw_tx, be_rx) = client.open_event_stream(10_000);
+            let dispatcher = build_dispatcher(
+                client,
+                Arc::clone(&active_config),
+                mode.clone(),
+                fw_tx.clone(),
+                config.firewall_version.clone(),
+                snapshot.clone(),
+            );
+
+            match EventStreamManager::start(
+                fw_tx,
+                be_rx,
+                mode.clone(),
+                config.firewall_version.clone(),
+                config.heartbeat_interval_secs,
+                dispatcher,
+            ).await {
+                Ok(_) => {}
+                Err(e) => tracing::warn!(error = %e, "EventStream nieudany"),
+            }
+
+            return Self { mode, active_config, snapshot };
         }
 
-        mode.set(FirewallMode::Normal);
-        mode.set_config_version(config_version);
+        // --- EMERGENCY lub SAFE-DENY ---
+        let (active_config, mode) = match snapshot.as_ref().and_then(|s| s.load()) {
+            Some(resp) => {
+                let version = resp.config_version;
+                let ac = Arc::new(RwLock::new(ActiveConfig::from_response(resp)));
+                let m = FirewallModeState::new(FirewallMode::Emergency);
+                m.set_config_version(version);
+                tracing::warn!(version, "Backend niedostępny — tryb EMERGENCY (snapshot z Redb)");
+                (ac, m)
+            }
+            None => {
+                let ac = Arc::new(RwLock::new(ActiveConfig::from_response(ConfigResponse::default())));
+                let m = FirewallModeState::new(FirewallMode::SafeDeny);
+                tracing::warn!("Brak snapshotu — tryb SAFE-DENY (DROP wszystkiego)");
+                (ac, m)
+            }
+        };
 
-        tracing::info!(version = config_version, "Konfiguracja pobrana, tryb NORMAL");
-        
-        let (fw_tx, be_rx) = client.open_event_stream(10_000);
-        
-        let handler_client = client.clone();
-
-        let handler_config = Arc::clone(&active_config);
-
-        let handler_mode = mode.clone();
-
-        let handler_fw_tx = fw_tx.clone();
-
-        let fw_version = config.firewall_version.clone();
-
-        let handler_snapshot = snapshot.clone();
-
-        let dispatcher =
-            EventDispatcher::new().on::<ConfigChangedEvent, _, _>(move |event| {
-                let mut client = handler_client.clone();
-
-                let config = Arc::clone(&handler_config);
-
-                let mode = handler_mode.clone();
-
-                let fw_tx = handler_fw_tx.clone();
-
-                let fw_version = fw_version.clone();
-                let correlation = event.correlation_id.clone();
-
-                let snap = handler_snapshot.clone();
-
-                async move {
-                    tracing::info!(correlation_id = %correlation, "config_changed — re-fetch");
-
-                    let known_versions = {
-                        let guard = config.read().await;
-                        Some(guard.section_versions.clone())
-                    };
-
-                    match client
-                        .get_active_config(GetConfigRequest {
-                            correlation_id: correlation.clone(),
-                            reason: ConfigRequestReason::ConfigChanged as i32,
-                            known_versions,
-                            known_version: None,
-                        }).await
-                    {
-                        Ok(resp) => {
-                            let new_version = resp.config_version;
-
-                            config.write().await.merge_delta(resp);
-                            mode.set_config_version(new_version);
-
-                            if let Some(ref s) = snap {
-                                s.clone().save_bg(config.read().await.to_config_response());
-                            }
-
-                            tracing::info!(
-                                version = new_version,
-                                fw_version = %fw_version,
-                                "Polityka zaktualizowana po config_changed"
-                            );
-
-                            let _ = fw_tx.try_send(make_firewall_event(
-                                PolicyActivatedEvent::TYPE,
-                                PolicyActivatedEvent {
-                                    config_version: new_version,
-                                    correlation_id: correlation,
-                                    activated_at: Some(current_timestamp()),
-                                    ..Default::default()
-                                },
-                            ));
-                        }
-                        Err(e) => {
-                            tracing::error!(error = %e, "re-fetch konfiguracji nieudany");
-
-                            let _ = fw_tx.try_send(make_firewall_event(
-                                PolicyFailedEvent::TYPE,
-                                PolicyFailedEvent {
-                                    correlation_id: correlation,
-                                    failure_message: e.message().to_string(),
-                                    failure_code: PolicyFailureCode::Unspecified as i32,
-                                    failed_at: Some(current_timestamp()),
-                                    ..Default::default()
-                                },
-                            ));
-                        }
-                    }
-                }
-            });
-        
-        let event_manager = EventStreamManager::start(
-            fw_tx,
-            be_rx,
-            mode.clone(),
+        spawn_reconnect_task(
+            config.grpc_socket_path.clone(),
             config.firewall_version.clone(),
             config.heartbeat_interval_secs,
-            dispatcher,
-        ).await
-        .map_err(|s| BackendConnectionError::EventStream(s))?;
+            Arc::clone(&active_config),
+            mode.clone(),
+            snapshot.clone(),
+        );
 
-        Ok(Self {
-            mode,
-            event_manager,
-            active_config,
-            snapshot,
-        })
+        Self { mode, active_config, snapshot }
     }
+}
+
+fn build_dispatcher(
+    client: GrpcClient,
+    active_config: Arc<RwLock<ActiveConfig>>,
+    mode: FirewallModeState,
+    fw_tx: Sender<FirewallEvent>,
+    fw_version: String,
+    snapshot: Option<Arc<ConfigSnapshot>>,
+) -> EventDispatcher {
+    // ConfigChangedEvent handler
+    let cc_client = client.clone();
+    let cc_config = Arc::clone(&active_config);
+    let cc_mode = mode.clone();
+    let cc_fw_tx = fw_tx.clone();
+    let cc_fw_version = fw_version.clone();
+    let cc_snapshot = snapshot.clone();
+
+    // ResyncRequestedEvent handler
+    let rr_client = client.clone();
+    let rr_config = Arc::clone(&active_config);
+    let rr_mode = mode.clone();
+    let rr_fw_tx = fw_tx.clone();
+    let rr_snapshot = snapshot.clone();
+
+    EventDispatcher::new()
+        .on::<ConfigChangedEvent, _, _>(move |event| {
+            let mut client = cc_client.clone();
+            let config = Arc::clone(&cc_config);
+            let mode = cc_mode.clone();
+            let fw_tx = cc_fw_tx.clone();
+            let fw_version = cc_fw_version.clone();
+            let correlation = event.correlation_id.clone();
+            let snap = cc_snapshot.clone();
+
+            async move {
+                tracing::info!(correlation_id = %correlation, "config_changed — re-fetch");
+
+                let known_versions = {
+                    let guard = config.read().await;
+                    Some(guard.section_versions.clone())
+                };
+
+                match client.get_active_config(GetConfigRequest {
+                    correlation_id: correlation.clone(),
+                    reason: ConfigRequestReason::ConfigChanged as i32,
+                    known_versions,
+                    known_version: None,
+                }).await {
+                    Ok(resp) => {
+                        let new_version = resp.config_version;
+                        config.write().await.merge_delta(resp);
+                        mode.set_config_version(new_version);
+
+                        if let Some(ref s) = snap {
+                            s.clone().save_bg(config.read().await.to_config_response());
+                        }
+
+                        tracing::info!(
+                            version = new_version,
+                            fw_version = %fw_version,
+                            "Polityka zaktualizowana po config_changed"
+                        );
+
+                        let _ = fw_tx.try_send(make_firewall_event(
+                            PolicyActivatedEvent::TYPE,
+                            PolicyActivatedEvent {
+                                config_version: new_version,
+                                correlation_id: correlation,
+                                activated_at: Some(current_timestamp()),
+                                ..Default::default()
+                            },
+                        ));
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "re-fetch konfiguracji nieudany");
+
+                        let _ = fw_tx.try_send(make_firewall_event(
+                            PolicyFailedEvent::TYPE,
+                            PolicyFailedEvent {
+                                correlation_id: correlation,
+                                failure_message: e.message().to_string(),
+                                failure_code: PolicyFailureCode::Unspecified as i32,
+                                failed_at: Some(current_timestamp()),
+                                ..Default::default()
+                            },
+                        ));
+                    }
+                }
+            }
+        })
+        .on::<ResyncRequestedEvent, _, _>(move |event| {
+            let mut client = rr_client.clone();
+            let config = Arc::clone(&rr_config);
+            let mode = rr_mode.clone();
+            let fw_tx = rr_fw_tx.clone();
+            let snap = rr_snapshot.clone();
+            let correlation = event.correlation_id.clone();
+
+            async move {
+                tracing::info!(correlation_id = %correlation, "resync_requested — re-fetch konfiguracji");
+
+                let (previous_version, known_versions) = {
+                    let guard = config.read().await;
+                    (mode.get_config_version(), Some(guard.section_versions.clone()))
+                };
+
+                mode.set(FirewallMode::Resyncing);
+
+                match client.get_active_config(GetConfigRequest {
+                    correlation_id: correlation.clone(),
+                    reason: ConfigRequestReason::Resync as i32,
+                    known_versions,
+                    known_version: None,
+                }).await {
+                    Ok(resp) => {
+                        let new_version = resp.config_version;
+                        config.write().await.merge_delta(resp);
+                        mode.set_config_version(new_version);
+
+                        if let Some(ref s) = snap {
+                            s.clone().save_bg(config.read().await.to_config_response());
+                        }
+
+                        let _ = fw_tx.try_send(make_firewall_event(
+                            ResyncConfirmedEvent::TYPE,
+                            ResyncConfirmedEvent {
+                                previous_version,
+                                current_version: new_version,
+                                correlation_id: correlation,
+                                no_change: previous_version == new_version,
+                                confirmed_at: Some(current_timestamp()),
+                            },
+                        ));
+
+                        mode.set(FirewallMode::Normal);
+                        tracing::info!(version = new_version, "Resync zakończony, tryb NORMAL");
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "GetActiveConfig podczas resync nieudany");
+                        mode.set(FirewallMode::Emergency);
+                    }
+                }
+            }
+        })
+}
+
+fn spawn_reconnect_task(
+    grpc_socket_path: String,
+    firewall_version: String,
+    heartbeat_interval_secs: u64,
+    active_config: Arc<RwLock<ActiveConfig>>,
+    mode: FirewallModeState,
+    snapshot: Option<Arc<ConfigSnapshot>>,
+) {
+    tokio::spawn(async move {
+        let mut delay_secs = 1u64;
+
+        loop {
+            tokio::time::sleep(Duration::from_secs(delay_secs)).await;
+            delay_secs = (delay_secs * 2).min(60);
+
+            tracing::info!(delay_secs, "Próba reconnect z backendem...");
+
+            let mut client = match GrpcClient::connect(&grpc_socket_path).await {
+                Ok(c) => {
+                    delay_secs = 1;
+                    c
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Reconnect nieudany");
+                    continue;
+                }
+            };
+
+            let previous_version = mode.get_config_version();
+            let reason = if previous_version > 0 {
+                ConfigRequestReason::Emergency
+            } else {
+                ConfigRequestReason::Startup
+            };
+            let known_versions = if previous_version > 0 {
+                let guard = active_config.read().await;
+                Some(guard.section_versions.clone())
+            } else {
+                None
+            };
+
+            let correlation = uuid::Uuid::now_v7().to_string();
+            mode.set(FirewallMode::Resyncing);
+
+            let resp = match client.get_active_config(GetConfigRequest {
+                correlation_id: correlation.clone(),
+                reason: reason as i32,
+                known_versions,
+                known_version: None,
+            }).await {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(error = %e, "GetActiveConfig podczas reconnect nieudany");
+                    mode.set(if previous_version > 0 {
+                        FirewallMode::Emergency
+                    } else {
+                        FirewallMode::SafeDeny
+                    });
+                    continue;
+                }
+            };
+
+            let new_version = resp.config_version;
+            {
+                let mut guard = active_config.write().await;
+                if previous_version > 0 {
+                    guard.merge_delta(resp);
+                } else {
+                    *guard = ActiveConfig::from_response(resp);
+                }
+            }
+            mode.set_config_version(new_version);
+
+            if let Some(ref snap) = snapshot {
+                snap.clone().save_bg(active_config.read().await.to_config_response());
+            }
+
+            let (fw_tx, be_rx) = client.open_event_stream(10_000);
+            let dispatcher = build_dispatcher(
+                client,
+                Arc::clone(&active_config),
+                mode.clone(),
+                fw_tx.clone(),
+                firewall_version.clone(),
+                snapshot.clone(),
+            );
+
+            let _ = fw_tx.try_send(make_firewall_event(
+                ResyncConfirmedEvent::TYPE,
+                ResyncConfirmedEvent {
+                    previous_version,
+                    current_version: new_version,
+                    correlation_id: correlation,
+                    no_change: previous_version == new_version,
+                    confirmed_at: Some(current_timestamp()),
+                },
+            ));
+
+            match EventStreamManager::start(
+                fw_tx,
+                be_rx,
+                mode.clone(),
+                firewall_version.clone(),
+                heartbeat_interval_secs,
+                dispatcher,
+            ).await {
+                Ok(_) => {
+                    mode.set(FirewallMode::Normal);
+                    tracing::info!(version = new_version, "Resync zakończony, tryb NORMAL");
+                    break;
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "EventStream nieudany po reconnect");
+                    mode.set(FirewallMode::Emergency);
+                    // kontynuuj pętlę
+                }
+            }
+        }
+    });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ use tun::AsyncDevice;
 
 use crate::{frame::RealFrame, policy_evaluator::PolicyEvaluator, rule_tree::{ArmEnd, FieldValue, MatchBuilder, MatchKind, Pattern, RuleTree, Verdict}};
 use crate::grpc_client::backend_connection::BackendConnection;
+use crate::grpc_client::firewall_mode_state::FirewallModeState;
+use crate::grpc_client::proto_types::raptorgate::common::FirewallMode;
 
 mod frame;
 mod rule_tree;
@@ -35,16 +37,8 @@ async fn main() {
         }
     };
 
-    let _backend = match BackendConnection::startup(&config).await {
-        Ok(b) => {
-            tracing::info!("Backend połączony, konfiguracja wczytana");
-            Some(b)
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "Brak połączenia z backendem — tryb safe-deny (FW-144/145)");
-            None
-        }
-    };
+    let backend = BackendConnection::startup(&config).await;
+    let mode = Arc::new(backend.mode.clone());
 
     let all_devices = match pcap::Device::list() {
         Ok(list) => list,
@@ -89,6 +83,7 @@ async fn main() {
     for device in devices {
         let tun = Arc::clone(&tun);
         let evaluator = Arc::clone(&evaluator);
+        let mode = Arc::clone(&mode);
         let name = device.name.clone();
         let (tx, rx) = mpsc::channel::<Vec<u8>>(256);
 
@@ -139,7 +134,7 @@ async fn main() {
         let handle = tokio::spawn(async move {
             let mut rx = rx;
             while let Some(data) = rx.recv().await {
-                handle_packet(&handler_name, &data, &tun, &evaluator).await;
+                handle_packet(&handler_name, &data, &tun, &evaluator, &mode).await;
             }
             eprintln!("[{handler_name}] Handler task exiting (sender dropped)");
         });
@@ -156,7 +151,11 @@ async fn main() {
 
 /// Inspect a raw Ethernet frame, evaluate it against the firewall policy,
 /// and forward it through the TUN device or drop it based on the verdict.
-async fn handle_packet(iface: &str, data: &[u8], tun: &AsyncDevice, evaluator: &PolicyEvaluator) {
+async fn handle_packet(iface: &str, data: &[u8], tun: &AsyncDevice, evaluator: &PolicyEvaluator, mode: &FirewallModeState) {
+    if mode.get() == FirewallMode::SafeDeny {
+        return;
+    }
+
     let packet = match SlicedPacket::from_ethernet(data) {
         Ok(packet) => packet,
         Err(err) => {


### PR DESCRIPTION
Add support for three firewall startup modes when backend is unavailable:
- NORMAL: Configuration from backend + event streaming
- EMERGENCY: Load configuration from Redb snapshot, attempt periodic reconnection
- SAFE-DENY: Drop all traffic when no snapshot exists

Implement automatic reconnection task with exponential backoff to transition from EMERGENCY/SAFE-DENY back to NORMAL. Add ResyncRequestedEvent and ResyncConfirmedEvent handlers to gracefully re-establish synchronization with backend. Refactor BackendConnection::startup() to always succeed and manage firewall mode state internally.

Closes FW-176