### PR TITLE
refactor(firewall): split control plane and data plane modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ redb = "3.1.1"
 dotenvy = "0.15"
 serde_json = "1.0.149"
 arc-swap = "1.8.2"
+tokio-util = "0.7"
 redis = { version = "1.0.5", features = ["aio", "tokio-comp"] }
 paste = "1.0.15"
 tracing-subscriber = "0.3.23"

--- a/backend/src/infrastructure/grpc/raptorgate.controller.ts
+++ b/backend/src/infrastructure/grpc/raptorgate.controller.ts
@@ -24,13 +24,13 @@ export class RaptorGateController implements RaptorGateServiceController {
   ) {}
 
   async getActiveConfig(request: GetConfigRequest): Promise<ConfigResponse> {
+    this.logger.log(`[GetActiveConfig] correlationId=${request.correlationId} reason=${request.reason}`);
     const activeConfig = await this.getActiveConfigUseCase.execute(
       request.correlationId,
       request.knownVersions,
     );
 
-    // TODO: wczytać aktywną konfigurację z bazy, porównać z known_versions,
-    // odesłać pełny bundle lub delta
+    this.logger.log(`[GetActiveConfig] sending version=${activeConfig.configVersion}`);
 
     return {
       ...activeConfig,
@@ -39,10 +39,10 @@ export class RaptorGateController implements RaptorGateServiceController {
 
   eventStream(request: Observable<FirewallEvent>): Observable<BackendEvent> {
     return new Observable<BackendEvent>((subscriber) => {
-      this.logger.debug('[EventStream] New connection established');
+      this.logger.log('[EventStream] Firewall connected');
       const sub = request.subscribe({
         next: (envelope) => {
-          this.logger.debug(envelope, '[EventStream] Received event');
+          this.logger.debug(`[EventStream] Received event type=${envelope.type}`);
 
           switch (envelope.type) {
             case 'fw.heartbeat': {

--- a/build.rs
+++ b/build.rs
@@ -28,4 +28,3 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
-

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -1,5 +1,5 @@
-use std::net::Ipv4Addr;
 use anyhow::{Context, Result};
+use std::net::Ipv4Addr;
 
 pub struct AppConfig {
     // Packet capture
@@ -40,8 +40,7 @@ impl AppConfig {
                 .parse()
                 .context("PCAP_TIMEOUT_MS must be an integer")?,
 
-            tun_device_name: std::env::var("TUN_DEVICE_NAME")
-                .unwrap_or_else(|_| "tun0".into()),
+            tun_device_name: std::env::var("TUN_DEVICE_NAME").unwrap_or_else(|_| "tun0".into()),
 
             tun_address: std::env::var("TUN_ADDRESS")
                 .unwrap_or_else(|_| "10.254.254.1".into())
@@ -55,7 +54,8 @@ impl AppConfig {
 
             block_icmp: std::env::var("BLOCK_ICMP")
                 .unwrap_or_else(|_| "false".into())
-                .to_lowercase() == "true",
+                .to_lowercase()
+                == "true",
 
             grpc_socket_path: std::env::var("GRPC_SOCKET_PATH")
                 .unwrap_or_else(|_| "./sockets/firewall.sock".into()),

--- a/src/control_plane/api.rs
+++ b/src/control_plane/api.rs
@@ -1,0 +1,131 @@
+use std::sync::Arc;
+
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::app_config::AppConfig;
+use crate::control_plane::backend_api::proto::raptorgate::common::FirewallMode;
+use crate::control_plane::error::ControlPlaneError;
+use crate::control_plane::runtime::state::StatusPublisher;
+use crate::control_plane::service;
+use crate::policy::compiler;
+use crate::policy::runtime::CompiledPolicy;
+
+pub struct ControlPlaneConfig {
+    pub grpc_socket_path: String,
+    pub firewall_version: String,
+    pub heartbeat_interval_secs: u64,
+    pub event_buffer: usize,
+    pub snapshot_path: Option<String>,
+    pub reconnect_initial_backoff_ms: u64,
+    pub reconnect_max_backoff_ms: u64,
+    pub fallback_block_icmp: bool,
+}
+
+impl From<&AppConfig> for ControlPlaneConfig {
+    fn from(config: &AppConfig) -> Self {
+        Self {
+            grpc_socket_path: config.grpc_socket_path.clone(),
+            firewall_version: config.firewall_version.clone(),
+            heartbeat_interval_secs: config.heartbeat_interval_secs,
+            event_buffer: 10_000,
+            snapshot_path: Some(config.redb_snapshot_path.clone()),
+            reconnect_initial_backoff_ms: 500,
+            reconnect_max_backoff_ms: 5_000,
+            fallback_block_icmp: config.block_icmp,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ControlPlaneHandle {
+    status_rx: watch::Receiver<ControlPlaneStatus>,
+    policy_rx: watch::Receiver<Arc<CompiledPolicy>>,
+}
+
+impl ControlPlaneHandle {
+    pub fn status(&self) -> watch::Receiver<ControlPlaneStatus> {
+        self.status_rx.clone()
+    }
+
+    pub fn policy(&self) -> watch::Receiver<Arc<CompiledPolicy>> {
+        self.policy_rx.clone()
+    }
+}
+
+pub struct ControlPlane {
+    handle: ControlPlaneHandle,
+    shutdown: CancellationToken,
+    join: JoinHandle<Result<(), ControlPlaneError>>,
+}
+
+impl ControlPlane {
+    pub async fn start(config: ControlPlaneConfig) -> Result<Self, ControlPlaneError> {
+        let initial_policy = Arc::new(
+            compiler::compile_fallback(config.fallback_block_icmp)
+                .map_err(|err| ControlPlaneError::PolicyCompile(err.to_string()))?,
+        );
+
+        let (status_tx, status_rx) = watch::channel(ControlPlaneStatus {
+            phase: LifecyclePhase::Starting,
+            mode: FirewallMode::SafeDeny,
+            active_version: None,
+            backend_connected: false,
+            last_error: None,
+        });
+
+        let (policy_tx, policy_rx) = watch::channel(initial_policy);
+
+        let shutdown = CancellationToken::new();
+
+        let join = tokio::spawn(service::run(
+            config,
+            StatusPublisher::new(status_tx),
+            policy_tx,
+            shutdown.clone(),
+        ));
+
+        Ok(Self {
+            handle: ControlPlaneHandle {
+                status_rx,
+                policy_rx,
+            },
+            shutdown,
+            join,
+        })
+    }
+
+    pub fn handle(&self) -> ControlPlaneHandle {
+        self.handle.clone()
+    }
+
+    pub async fn shutdown(self) -> Result<(), ControlPlaneError> {
+        self.shutdown.cancel();
+        self.join
+            .await
+            .map_err(|err| ControlPlaneError::Join(err.to_string()))?
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum LifecyclePhase {
+    Starting,
+    LoadingSnapshot,
+    FetchingInitialConfig,
+    Normal,
+    Emergency,
+    SafeDeny,
+    Resyncing,
+    Reconnecting,
+    Stopped,
+}
+
+#[derive(Clone, Debug)]
+pub struct ControlPlaneStatus {
+    pub phase: LifecyclePhase,
+    pub mode: FirewallMode,
+    pub active_version: Option<u64>,
+    pub backend_connected: bool,
+    pub last_error: Option<String>,
+}

--- a/src/control_plane/backend_api/client.rs
+++ b/src/control_plane/backend_api/client.rs
@@ -1,0 +1,91 @@
+use tonic::transport::Channel;
+
+use crate::control_plane::backend_api::event_codec::receiver_stream;
+use crate::control_plane::backend_api::proto::raptorgate::config::{
+    ConfigResponse, GetConfigRequest,
+};
+use crate::control_plane::backend_api::proto::raptorgate::events::{BackendEvent, FirewallEvent};
+use crate::control_plane::backend_api::proto::raptorgate::raptor_gate_service_client::RaptorGateServiceClient;
+
+#[derive(Clone)]
+pub struct BackendApiClient {
+    inner: RaptorGateServiceClient<Channel>,
+}
+
+pub struct EventStreamChannels {
+    pub outbound: tokio::sync::mpsc::Sender<FirewallEvent>,
+    pub inbound: tokio::sync::mpsc::Receiver<BackendEvent>,
+    pub opened: tokio::sync::oneshot::Receiver<Result<(), tonic::Status>>,
+    pub join: tokio::task::JoinHandle<()>,
+}
+
+impl BackendApiClient {
+    pub async fn connect(socket_path: &str) -> Result<Self, tonic::transport::Error> {
+        let socket_path = socket_path.to_owned();
+
+        let channel = tonic::transport::Endpoint::try_from("http://[::]:50051")?
+            .connect_with_connector(tower::service_fn(move |_: tonic::transport::Uri| {
+                let path = socket_path.clone();
+
+                async move {
+                    let stream = tokio::net::UnixStream::connect(path).await?;
+                    Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(stream))
+                }
+            }))
+            .await?;
+
+        Ok(Self {
+            inner: RaptorGateServiceClient::new(channel),
+        })
+    }
+
+    pub async fn get_active_config(
+        &mut self,
+        request: GetConfigRequest,
+    ) -> Result<ConfigResponse, tonic::Status> {
+        let response = self.inner.get_active_config(request).await?;
+        Ok(response.into_inner())
+    }
+
+    pub fn open_event_stream(&mut self, buffer_size: usize) -> EventStreamChannels {
+        let (fw_tx, fw_rx) = tokio::sync::mpsc::channel::<FirewallEvent>(buffer_size);
+        let (be_tx, be_rx) = tokio::sync::mpsc::channel::<BackendEvent>(buffer_size);
+        let (opened_tx, opened_rx) = tokio::sync::oneshot::channel();
+        let mut inner = self.inner.clone();
+
+        let join = tokio::spawn(async move {
+            let response = match inner.event_stream(receiver_stream(fw_rx)).await {
+                Ok(response) => {
+                    let _ = opened_tx.send(Ok(()));
+                    response
+                }
+                Err(status) => {
+                    let _ = opened_tx.send(Err(status));
+                    return;
+                }
+            };
+
+            let mut inbound = response.into_inner();
+            while let Some(event) = inbound.message().await.transpose() {
+                match event {
+                    Ok(event) => {
+                        if be_tx.send(event).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(status) => {
+                        tracing::warn!(%status, "Event stream receive error");
+                        break;
+                    }
+                }
+            }
+        });
+
+        EventStreamChannels {
+            outbound: fw_tx,
+            inbound: be_rx,
+            opened: opened_rx,
+            join,
+        }
+    }
+}

--- a/src/control_plane/backend_api/event_codec.rs
+++ b/src/control_plane/backend_api/event_codec.rs
@@ -1,0 +1,58 @@
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::control_plane::backend_api::proto::raptorgate::events::{
+    BackendEvent, FirewallEvent, PolicyActivatedEvent, PolicyFailedEvent, ResyncConfirmedEvent,
+};
+
+pub const FW_HEARTBEAT: &str = "fw.heartbeat";
+pub const FW_METRICS: &str = "fw.metrics";
+pub const FW_POLICY_ACTIVATED: &str = "fw.policy_activated";
+pub const FW_POLICY_FAILED: &str = "fw.policy_failed";
+pub const FW_RESYNC_CONFIRMED: &str = "fw.resync_confirmed";
+pub const BE_HEARTBEAT_ACK: &str = "be.heartbeat_ack";
+pub const BE_CONFIG_CHANGED: &str = "be.config_changed";
+pub const BE_RESYNC_REQUESTED: &str = "be.resync_requested";
+
+pub fn receiver_stream(
+    rx: tokio::sync::mpsc::Receiver<FirewallEvent>,
+) -> ReceiverStream<FirewallEvent> {
+    ReceiverStream::new(rx)
+}
+
+pub fn encode_firewall_event(event_type: &str, payload: impl prost::Message) -> FirewallEvent {
+    FirewallEvent {
+        event_id: uuid::Uuid::now_v7().to_string(),
+        r#type: event_type.to_string(),
+        payload: prost::Message::encode_to_vec(&payload),
+        ts: Some(current_timestamp()),
+    }
+}
+
+pub fn encode_policy_activated(payload: PolicyActivatedEvent) -> FirewallEvent {
+    encode_firewall_event(FW_POLICY_ACTIVATED, payload)
+}
+
+pub fn encode_policy_failed(payload: PolicyFailedEvent) -> FirewallEvent {
+    encode_firewall_event(FW_POLICY_FAILED, payload)
+}
+
+pub fn encode_resync_confirmed(payload: ResyncConfirmedEvent) -> FirewallEvent {
+    encode_firewall_event(FW_RESYNC_CONFIRMED, payload)
+}
+
+pub fn decode_backend_payload<T: prost::Message + Default>(
+    event: &BackendEvent,
+) -> Result<T, prost::DecodeError> {
+    T::decode(event.payload.as_ref())
+}
+
+pub fn current_timestamp() -> prost_types::Timestamp {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+
+    prost_types::Timestamp {
+        seconds: now.as_secs() as i64,
+        nanos: now.subsec_nanos() as i32,
+    }
+}

--- a/src/control_plane/backend_api/mod.rs
+++ b/src/control_plane/backend_api/mod.rs
@@ -1,0 +1,3 @@
+pub mod client;
+pub mod event_codec;
+pub mod proto;

--- a/src/control_plane/backend_api/proto.rs
+++ b/src/control_plane/backend_api/proto.rs
@@ -1,0 +1,33 @@
+use std::convert::TryFrom;
+
+pub mod raptorgate {
+    pub mod common {
+        tonic::include_proto!("raptorgate.common");
+    }
+    pub mod config {
+        tonic::include_proto!("raptorgate.config");
+    }
+    pub mod events {
+        tonic::include_proto!("raptorgate.events");
+    }
+    pub mod telemetry {
+        tonic::include_proto!("raptorgate.telemetry");
+    }
+
+    tonic::include_proto!("raptorgate");
+}
+
+impl TryFrom<u8> for raptorgate::common::FirewallMode {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(raptorgate::common::FirewallMode::Unspecified),
+            1 => Ok(raptorgate::common::FirewallMode::Normal),
+            2 => Ok(raptorgate::common::FirewallMode::Emergency),
+            3 => Ok(raptorgate::common::FirewallMode::SafeDeny),
+            4 => Ok(raptorgate::common::FirewallMode::Resyncing),
+            _ => Err(()),
+        }
+    }
+}

--- a/src/control_plane/config/active_config.rs
+++ b/src/control_plane/config/active_config.rs
@@ -1,0 +1,231 @@
+use crate::control_plane::backend_api::proto::raptorgate::config::{
+    ConfigResponse, ConfigSectionVersions, DnsBlacklistEntry, FirewallCertificate, IdentityBundle,
+    IpsSignature, MlModel, NatRule, Rule, SslBypassEntry, Zone, ZoneInterface, ZonePair,
+};
+use crate::control_plane::config::delta::{ChangedSections, DeltaError};
+
+#[derive(Clone)]
+pub struct ActiveConfig {
+    pub version: u64,
+    pub bundle_checksum: String,
+    pub section_versions: ConfigSectionVersions,
+    pub rules: Vec<Rule>,
+    pub zones: Vec<Zone>,
+    pub zone_interfaces: Vec<ZoneInterface>,
+    pub zone_pairs: Vec<ZonePair>,
+    pub nat_rules: Vec<NatRule>,
+    pub dns_blacklist: Vec<DnsBlacklistEntry>,
+    pub ssl_bypass_list: Vec<SslBypassEntry>,
+    pub ips_signatures: Vec<IpsSignature>,
+    pub ml_model: Option<MlModel>,
+    pub firewall_certificates: Vec<FirewallCertificate>,
+    pub identity: Option<IdentityBundle>,
+}
+
+impl ActiveConfig {
+    pub fn from_response(resp: ConfigResponse) -> Self {
+        Self {
+            version: resp.config_version,
+            bundle_checksum: resp.bundle_checksum,
+            section_versions: resp.current_versions.unwrap_or_default(),
+            rules: resp.rules,
+            zones: resp.zones,
+            zone_interfaces: resp.zone_interfaces,
+            zone_pairs: resp.zone_pairs,
+            nat_rules: resp.nat_rules,
+            dns_blacklist: resp.dns_blacklist,
+            ssl_bypass_list: resp.ssl_bypass_list,
+            ips_signatures: resp.ips_signatures,
+            ml_model: resp.ml_model,
+            firewall_certificates: resp.firewall_certificates,
+            identity: resp.identity,
+        }
+    }
+
+    pub fn to_config_response(&self) -> ConfigResponse {
+        ConfigResponse {
+            config_version: self.version,
+            bundle_checksum: self.bundle_checksum.clone(),
+            correlation_id: String::new(),
+            configuration_changed: true,
+            current_versions: Some(self.section_versions.clone()),
+            rules: self.rules.clone(),
+            zones: self.zones.clone(),
+            zone_interfaces: self.zone_interfaces.clone(),
+            zone_pairs: self.zone_pairs.clone(),
+            nat_rules: self.nat_rules.clone(),
+            dns_blacklist: self.dns_blacklist.clone(),
+            ssl_bypass_list: self.ssl_bypass_list.clone(),
+            ips_signatures: self.ips_signatures.clone(),
+            ml_model: self.ml_model.clone(),
+            firewall_certificates: self.firewall_certificates.clone(),
+            identity: self.identity.clone(),
+        }
+    }
+
+    pub fn apply_delta(&self, resp: ConfigResponse) -> Result<Self, DeltaError> {
+        let current_versions = resp
+            .current_versions
+            .clone()
+            .ok_or(DeltaError::MissingCurrentVersions)?;
+        let changed = ChangedSections::from_versions(&self.section_versions, &current_versions);
+
+        Ok(Self {
+            version: resp.config_version,
+            bundle_checksum: resp.bundle_checksum,
+            section_versions: current_versions,
+            rules: if changed.rules {
+                resp.rules
+            } else {
+                self.rules.clone()
+            },
+            zones: if changed.zones {
+                resp.zones
+            } else {
+                self.zones.clone()
+            },
+            zone_interfaces: if changed.zone_interfaces {
+                resp.zone_interfaces
+            } else {
+                self.zone_interfaces.clone()
+            },
+            zone_pairs: if changed.zone_pairs {
+                resp.zone_pairs
+            } else {
+                self.zone_pairs.clone()
+            },
+            nat_rules: if changed.nat_rules {
+                resp.nat_rules
+            } else {
+                self.nat_rules.clone()
+            },
+            dns_blacklist: if changed.dns_blacklist {
+                resp.dns_blacklist
+            } else {
+                self.dns_blacklist.clone()
+            },
+            ssl_bypass_list: if changed.ssl_bypass_list {
+                resp.ssl_bypass_list
+            } else {
+                self.ssl_bypass_list.clone()
+            },
+            ips_signatures: if changed.ips_signatures {
+                resp.ips_signatures
+            } else {
+                self.ips_signatures.clone()
+            },
+            ml_model: if changed.ml_model {
+                resp.ml_model
+            } else {
+                self.ml_model.clone()
+            },
+            firewall_certificates: if changed.certificates {
+                resp.firewall_certificates
+            } else {
+                self.firewall_certificates.clone()
+            },
+            identity: if changed.identity {
+                resp.identity
+            } else {
+                self.identity.clone()
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_versions() -> ConfigSectionVersions {
+        ConfigSectionVersions {
+            rules: 1,
+            zones: 1,
+            zone_interfaces: 1,
+            zone_pairs: 1,
+            nat_rules: 1,
+            dns_blacklist: 1,
+            ssl_bypass_list: 1,
+            ips_signatures: 1,
+            ml_model: 1,
+            certificates: 1,
+            identity: 1,
+        }
+    }
+
+    fn sample_rule(name: &str) -> Rule {
+        Rule {
+            id: name.into(),
+            name: name.into(),
+            zone_pair_id: "zp-1".into(),
+            priority: 1,
+            content: "allow".into(),
+        }
+    }
+
+    fn base_config() -> ActiveConfig {
+        ActiveConfig {
+            version: 1,
+            bundle_checksum: "old".into(),
+            section_versions: base_versions(),
+            rules: vec![sample_rule("rule-1")],
+            zones: Vec::new(),
+            zone_interfaces: Vec::new(),
+            zone_pairs: Vec::new(),
+            nat_rules: vec![NatRule::default()],
+            dns_blacklist: Vec::new(),
+            ssl_bypass_list: Vec::new(),
+            ips_signatures: Vec::new(),
+            ml_model: Some(MlModel {
+                id: "model-1".into(),
+                name: "model".into(),
+                artifact_path: "/tmp/model.onnx".into(),
+                checksum: "abc".into(),
+            }),
+            firewall_certificates: Vec::new(),
+            identity: Some(IdentityBundle::default()),
+        }
+    }
+
+    #[test]
+    fn apply_delta_clears_repeated_section_when_version_changes_to_empty() {
+        let base = base_config();
+        let mut next_versions = base_versions();
+        next_versions.nat_rules = 2;
+
+        let next = base
+            .apply_delta(ConfigResponse {
+                config_version: 2,
+                bundle_checksum: "new".into(),
+                correlation_id: "corr".into(),
+                configuration_changed: true,
+                current_versions: Some(next_versions),
+                nat_rules: Vec::new(),
+                ..Default::default()
+            })
+            .expect("delta should apply");
+
+        assert!(next.nat_rules.is_empty());
+    }
+
+    #[test]
+    fn apply_delta_clears_optional_section_when_version_changes_to_none() {
+        let base = base_config();
+        let mut next_versions = base_versions();
+        next_versions.ml_model = 2;
+
+        let next = base
+            .apply_delta(ConfigResponse {
+                config_version: 2,
+                bundle_checksum: "new".into(),
+                correlation_id: "corr".into(),
+                configuration_changed: true,
+                current_versions: Some(next_versions),
+                ml_model: None,
+                ..Default::default()
+            })
+            .expect("delta should apply");
+
+        assert!(next.ml_model.is_none());
+    }
+}

--- a/src/control_plane/config/delta.rs
+++ b/src/control_plane/config/delta.rs
@@ -1,0 +1,42 @@
+use crate::control_plane::backend_api::proto::raptorgate::config::ConfigSectionVersions;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DeltaError {
+    #[error("config delta is missing current_versions")]
+    MissingCurrentVersions,
+}
+
+pub(crate) struct ChangedSections {
+    pub rules: bool,
+    pub zones: bool,
+    pub zone_interfaces: bool,
+    pub zone_pairs: bool,
+    pub nat_rules: bool,
+    pub dns_blacklist: bool,
+    pub ssl_bypass_list: bool,
+    pub ips_signatures: bool,
+    pub ml_model: bool,
+    pub certificates: bool,
+    pub identity: bool,
+}
+
+impl ChangedSections {
+    pub fn from_versions(
+        previous: &ConfigSectionVersions,
+        current: &ConfigSectionVersions,
+    ) -> Self {
+        Self {
+            rules: current.rules != previous.rules,
+            zones: current.zones != previous.zones,
+            zone_interfaces: current.zone_interfaces != previous.zone_interfaces,
+            zone_pairs: current.zone_pairs != previous.zone_pairs,
+            nat_rules: current.nat_rules != previous.nat_rules,
+            dns_blacklist: current.dns_blacklist != previous.dns_blacklist,
+            ssl_bypass_list: current.ssl_bypass_list != previous.ssl_bypass_list,
+            ips_signatures: current.ips_signatures != previous.ips_signatures,
+            ml_model: current.ml_model != previous.ml_model,
+            certificates: current.certificates != previous.certificates,
+            identity: current.identity != previous.identity,
+        }
+    }
+}

--- a/src/control_plane/config/mod.rs
+++ b/src/control_plane/config/mod.rs
@@ -1,0 +1,4 @@
+pub mod active_config;
+mod delta;
+
+pub use delta::DeltaError;

--- a/src/control_plane/error.rs
+++ b/src/control_plane/error.rs
@@ -1,0 +1,33 @@
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotError {
+    #[error("snapshot database error: {0}")]
+    Database(#[from] redb::DatabaseError),
+    #[error("snapshot transaction error: {0}")]
+    Transaction(#[from] redb::TransactionError),
+    #[error("snapshot table error: {0}")]
+    Table(#[from] redb::TableError),
+    #[error("snapshot storage error: {0}")]
+    Storage(#[from] redb::StorageError),
+    #[error("snapshot commit error: {0}")]
+    Commit(#[from] redb::CommitError),
+    #[error("snapshot decode error: {0}")]
+    Decode(#[from] prost::DecodeError),
+    #[error("snapshot task join error: {0}")]
+    Join(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ControlPlaneError {
+    #[error("transport connect failed: {0}")]
+    Connect(#[from] tonic::transport::Error),
+    #[error("config fetch failed: {0}")]
+    ConfigFetch(#[from] tonic::Status),
+    #[error("snapshot error: {0}")]
+    Snapshot(#[from] SnapshotError),
+    #[error("policy compile failed: {0}")]
+    PolicyCompile(String),
+    #[error("delta apply failed: {0}")]
+    Delta(String),
+    #[error("task join failed: {0}")]
+    Join(String),
+}

--- a/src/control_plane/mod.rs
+++ b/src/control_plane/mod.rs
@@ -1,0 +1,13 @@
+mod api;
+mod error;
+mod service;
+
+pub mod backend_api;
+pub mod config;
+pub mod runtime;
+pub mod snapshot;
+
+pub use api::{
+    ControlPlane, ControlPlaneConfig, ControlPlaneHandle, ControlPlaneStatus, LifecyclePhase,
+};
+pub use error::{ControlPlaneError, SnapshotError};

--- a/src/control_plane/runtime/mod.rs
+++ b/src/control_plane/runtime/mod.rs
@@ -1,0 +1,1 @@
+pub mod state;

--- a/src/control_plane/runtime/state.rs
+++ b/src/control_plane/runtime/state.rs
@@ -1,0 +1,46 @@
+use tokio::sync::watch;
+
+use crate::control_plane::backend_api::proto::raptorgate::common::FirewallMode;
+use crate::control_plane::{ControlPlaneStatus, LifecyclePhase};
+
+#[derive(Clone)]
+pub struct StatusPublisher {
+    tx: watch::Sender<ControlPlaneStatus>,
+}
+
+impl StatusPublisher {
+    pub fn new(tx: watch::Sender<ControlPlaneStatus>) -> Self {
+        Self { tx }
+    }
+
+    pub fn update(&self, update: impl FnOnce(&mut ControlPlaneStatus)) {
+        let mut next = self.tx.borrow().clone();
+        update(&mut next);
+        let _ = self.tx.send(next);
+    }
+
+    pub fn set_phase(&self, phase: LifecyclePhase) {
+        self.update(|status| status.phase = phase);
+    }
+
+    pub fn set_mode(&self, mode: FirewallMode) {
+        self.update(|status| status.mode = mode);
+    }
+
+    pub fn set_version(&self, version: Option<u64>) {
+        self.update(|status| status.active_version = version);
+    }
+
+    pub fn set_backend_connected(&self, backend_connected: bool) {
+        self.update(|status| status.backend_connected = backend_connected);
+    }
+
+    pub fn set_last_error(&self, error: impl Into<String>) {
+        let error = error.into();
+        self.update(|status| status.last_error = Some(error));
+    }
+
+    pub fn clear_last_error(&self) {
+        self.update(|status| status.last_error = None);
+    }
+}

--- a/src/control_plane/service.rs
+++ b/src/control_plane/service.rs
@@ -1,0 +1,452 @@
+use std::cmp::min;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
+
+use crate::control_plane::api::{ControlPlaneConfig, LifecyclePhase};
+use crate::control_plane::backend_api::client::BackendApiClient;
+use crate::control_plane::backend_api::event_codec::{
+    BE_CONFIG_CHANGED, BE_HEARTBEAT_ACK, BE_RESYNC_REQUESTED, FW_HEARTBEAT, FW_METRICS,
+    current_timestamp, decode_backend_payload, encode_firewall_event, encode_policy_activated,
+    encode_policy_failed, encode_resync_confirmed,
+};
+use crate::control_plane::backend_api::proto::raptorgate::common::{
+    FirewallMode, PolicyFailureCode,
+};
+use crate::control_plane::backend_api::proto::raptorgate::config::{
+    ConfigRequestReason, ConfigResponse, GetConfigRequest,
+};
+use crate::control_plane::backend_api::proto::raptorgate::events::{
+    ConfigChangedEvent, HeartbeatAck, HeartbeatEvent, PolicyActivatedEvent, PolicyFailedEvent,
+    ResyncConfirmedEvent, ResyncRequestedEvent,
+};
+use crate::control_plane::backend_api::proto::raptorgate::telemetry::MetricsBatch;
+use crate::control_plane::config::active_config::ActiveConfig;
+use crate::control_plane::error::ControlPlaneError;
+use crate::control_plane::runtime::state::StatusPublisher;
+use crate::control_plane::snapshot::redb::RedbSnapshotStore;
+use crate::control_plane::snapshot::store::SnapshotStore;
+use crate::policy::compiler;
+use crate::policy::runtime::{CompiledPolicy, PolicySource};
+
+pub async fn run(
+    config: ControlPlaneConfig,
+    status: StatusPublisher,
+    policy_tx: watch::Sender<Arc<CompiledPolicy>>,
+    shutdown: CancellationToken,
+) -> Result<(), ControlPlaneError> {
+    let snapshot_store = open_snapshot_store(&config)?;
+    let mut active_config = load_snapshot(snapshot_store.as_ref(), &config, &status, &policy_tx)?;
+    let mut reconnect_backoff_ms = config.reconnect_initial_backoff_ms;
+
+    loop {
+        if shutdown.is_cancelled() {
+            status.set_phase(LifecyclePhase::Stopped);
+            status.set_backend_connected(false);
+            return Ok(());
+        }
+
+        match connect_and_bootstrap(
+            &config,
+            &status,
+            &policy_tx,
+            snapshot_store.as_ref(),
+            active_config.clone(),
+        )
+        .await
+        {
+            Ok((client, next_active)) => {
+                reconnect_backoff_ms = config.reconnect_initial_backoff_ms;
+                active_config = Some(next_active);
+
+                if let Some(current) = active_config.clone() {
+                    let session_result = run_event_session(
+                        &config,
+                        &status,
+                        &policy_tx,
+                        snapshot_store.as_ref(),
+                        client,
+                        current,
+                        &shutdown,
+                    )
+                    .await?;
+
+                    active_config = Some(session_result);
+                    status.set_backend_connected(false);
+                    if !shutdown.is_cancelled() {
+                        status.set_phase(LifecyclePhase::Reconnecting);
+                    }
+                }
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "Bootstrap failed");
+                status.set_last_error(err.to_string());
+                status.set_backend_connected(false);
+
+                match active_config.as_ref() {
+                    Some(snapshot_active) => {
+                        tracing::warn!(version = snapshot_active.version, "Backend unavailable — entering EMERGENCY mode (snapshot from Redb)");
+                        status.set_phase(LifecyclePhase::Emergency);
+                        status.set_mode(FirewallMode::Emergency);
+                        status.set_version(Some(snapshot_active.version));
+                        publish_active_config(
+                            &policy_tx,
+                            snapshot_active,
+                            config.fallback_block_icmp,
+                            PolicySource::Snapshot,
+                        )?;
+                    }
+                    None => {
+                        tracing::warn!("No snapshot available — entering SAFE-DENY mode (drop all)");
+                        status.set_phase(LifecyclePhase::SafeDeny);
+                        status.set_mode(FirewallMode::SafeDeny);
+                        status.set_version(None);
+                        publish_safe_deny(&policy_tx)?;
+                    }
+                }
+            }
+        }
+
+        tracing::info!(backoff_ms = reconnect_backoff_ms, "Reconnecting after backoff...");
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                status.set_phase(LifecyclePhase::Stopped);
+                status.set_backend_connected(false);
+                return Ok(());
+            }
+            _ = tokio::time::sleep(Duration::from_millis(reconnect_backoff_ms)) => {}
+        }
+
+        reconnect_backoff_ms = min(
+            reconnect_backoff_ms.saturating_mul(2),
+            config.reconnect_max_backoff_ms,
+        );
+    }
+}
+
+fn open_snapshot_store(
+    config: &ControlPlaneConfig,
+) -> Result<Option<Arc<dyn SnapshotStore>>, ControlPlaneError> {
+    match config.snapshot_path.as_deref() {
+        Some(path) => {
+            let store: Arc<dyn SnapshotStore> = Arc::new(RedbSnapshotStore::open(path)?);
+            Ok(Some(store))
+        }
+        None => Ok(None),
+    }
+}
+
+fn load_snapshot(
+    snapshot_store: Option<&Arc<dyn SnapshotStore>>,
+    config: &ControlPlaneConfig,
+    status: &StatusPublisher,
+    policy_tx: &watch::Sender<Arc<CompiledPolicy>>,
+) -> Result<Option<ActiveConfig>, ControlPlaneError> {
+    let Some(snapshot_store) = snapshot_store else {
+        return Ok(None);
+    };
+
+    status.set_phase(LifecyclePhase::LoadingSnapshot);
+
+    let Some(response) = snapshot_store.load()? else {
+        return Ok(None);
+    };
+
+    let active_config = ActiveConfig::from_response(response);
+    publish_active_config(
+        policy_tx,
+        &active_config,
+        config.fallback_block_icmp,
+        PolicySource::Snapshot,
+    )?;
+    status.set_mode(FirewallMode::Emergency);
+    status.set_phase(LifecyclePhase::Emergency);
+    status.set_version(Some(active_config.version));
+    Ok(Some(active_config))
+}
+
+async fn connect_and_bootstrap(
+    config: &ControlPlaneConfig,
+    status: &StatusPublisher,
+    policy_tx: &watch::Sender<Arc<CompiledPolicy>>,
+    snapshot_store: Option<&Arc<dyn SnapshotStore>>,
+    existing: Option<ActiveConfig>,
+) -> Result<(BackendApiClient, ActiveConfig), ControlPlaneError> {
+    status.set_phase(LifecyclePhase::FetchingInitialConfig);
+
+    tracing::info!(socket = %config.grpc_socket_path, "Connecting to backend...");
+    let mut client = BackendApiClient::connect(&config.grpc_socket_path).await
+        .inspect_err(|e| tracing::warn!(error = %e, "Backend connection failed"))?;
+    tracing::info!("Connected to backend, fetching config...");
+
+    let request_reason = if existing.is_some() {
+        ConfigRequestReason::Emergency as i32
+    } else {
+        ConfigRequestReason::Startup as i32
+    };
+    let correlation_id = uuid::Uuid::now_v7().to_string();
+    let response = client
+        .get_active_config(GetConfigRequest {
+            correlation_id,
+            reason: request_reason,
+            known_versions: existing.as_ref().map(|cfg| cfg.section_versions.clone()),
+            known_version: existing.as_ref().map(|cfg| cfg.version as i32),
+        })
+        .await?;
+
+    let active_config = merge_response(existing, response)?;
+    persist_snapshot(snapshot_store, &active_config)?;
+    publish_active_config(
+        policy_tx,
+        &active_config,
+        config.fallback_block_icmp,
+        if active_config.version > 0 {
+            PolicySource::Backend
+        } else {
+            PolicySource::SnapshotThenBackend
+        },
+    )?;
+
+    status.clear_last_error();
+    status.set_phase(LifecyclePhase::Normal);
+    status.set_mode(FirewallMode::Normal);
+    status.set_version(Some(active_config.version));
+    status.set_backend_connected(true);
+
+    tracing::info!(version = active_config.version, "Config loaded, entering NORMAL mode");
+    Ok((client, active_config))
+}
+
+async fn run_event_session(
+    config: &ControlPlaneConfig,
+    status: &StatusPublisher,
+    policy_tx: &watch::Sender<Arc<CompiledPolicy>>,
+    snapshot_store: Option<&Arc<dyn SnapshotStore>>,
+    mut client: BackendApiClient,
+    mut active_config: ActiveConfig,
+    shutdown: &CancellationToken,
+) -> Result<ActiveConfig, ControlPlaneError> {
+    let mut stream_channels = client.open_event_stream(config.event_buffer);
+    let session_started = Instant::now();
+
+    send_heartbeat(
+        &stream_channels.outbound,
+        config,
+        FirewallMode::Normal,
+        active_config.version,
+        session_started.elapsed().as_secs(),
+    )
+    .await;
+
+    match stream_channels.opened.await {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => return Err(ControlPlaneError::ConfigFetch(err)),
+        Err(err) => return Err(ControlPlaneError::Join(err.to_string())),
+    }
+
+    let mut interval = tokio::time::interval(Duration::from_secs(config.heartbeat_interval_secs));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                status.set_phase(LifecyclePhase::Stopped);
+                status.set_backend_connected(false);
+                return Ok(active_config);
+            }
+            _ = interval.tick() => {
+                send_heartbeat(
+                    &stream_channels.outbound,
+                    config,
+                    FirewallMode::Normal,
+                    active_config.version,
+                    session_started.elapsed().as_secs(),
+                ).await;
+                let _ = stream_channels.outbound.send(encode_firewall_event(FW_METRICS, MetricsBatch::default())).await;
+            }
+            next_event = stream_channels.inbound.recv() => {
+                match next_event {
+                    Some(event) => {
+                        match event.r#type.as_str() {
+                            BE_HEARTBEAT_ACK => {
+                                let _ = decode_backend_payload::<HeartbeatAck>(&event);
+                            }
+                            BE_CONFIG_CHANGED => {
+                                let payload = decode_backend_payload::<ConfigChangedEvent>(&event)
+                                    .map_err(|err| ControlPlaneError::Delta(err.to_string()))?;
+                                let previous_version = active_config.version;
+                                match reconcile_config_change(
+                                    &mut client,
+                                    config,
+                                    snapshot_store,
+                                    policy_tx,
+                                    &mut active_config,
+                                    payload.correlation_id.clone(),
+                                    ConfigRequestReason::ConfigChanged,
+                                    PolicySource::Backend,
+                                ).await {
+                                    Ok(changed) => {
+                                        status.set_phase(LifecyclePhase::Normal);
+                                        status.set_mode(FirewallMode::Normal);
+                                        status.set_version(Some(active_config.version));
+                                        if changed {
+                                            let _ = stream_channels.outbound.send(encode_policy_activated(PolicyActivatedEvent {
+                                                config_id: payload.config_id,
+                                                config_version: active_config.version,
+                                                correlation_id: payload.correlation_id,
+                                                activated_at: Some(current_timestamp()),
+                                            })).await;
+                                        }
+                                        tracing::info!(from = previous_version, to = active_config.version, "Config change reconciled");
+                                    }
+                                    Err(err) => {
+                                        let _ = stream_channels.outbound.send(encode_policy_failed(PolicyFailedEvent {
+                                            config_id: payload.config_id,
+                                            config_version: active_config.version,
+                                            correlation_id: payload.correlation_id,
+                                            failure_code: PolicyFailureCode::Unspecified as i32,
+                                            failure_message: err.to_string(),
+                                            validation_errors: Vec::new(),
+                                            failed_at: Some(current_timestamp()),
+                                        })).await;
+                                        return Err(err);
+                                    }
+                                }
+                            }
+                            BE_RESYNC_REQUESTED => {
+                                let payload = decode_backend_payload::<ResyncRequestedEvent>(&event)
+                                    .map_err(|err| ControlPlaneError::Delta(err.to_string()))?;
+                                let previous_version = active_config.version;
+                                status.set_phase(LifecyclePhase::Resyncing);
+                                status.set_mode(FirewallMode::Resyncing);
+                                let changed = reconcile_config_change(
+                                    &mut client,
+                                    config,
+                                    snapshot_store,
+                                    policy_tx,
+                                    &mut active_config,
+                                    payload.correlation_id.clone(),
+                                    ConfigRequestReason::Resync,
+                                    PolicySource::Backend,
+                                ).await?;
+
+                                status.set_phase(LifecyclePhase::Normal);
+                                status.set_mode(FirewallMode::Normal);
+                                status.set_version(Some(active_config.version));
+
+                                let _ = stream_channels.outbound.send(encode_resync_confirmed(ResyncConfirmedEvent {
+                                    previous_version,
+                                    current_version: active_config.version,
+                                    correlation_id: payload.correlation_id,
+                                    no_change: !changed,
+                                    confirmed_at: Some(current_timestamp()),
+                                })).await;
+                            }
+                            other => {
+                                tracing::warn!(event_type = other, "Unknown backend event type");
+                            }
+                        }
+                    }
+                    None => return Ok(active_config),
+                }
+            }
+        }
+    }
+}
+
+async fn reconcile_config_change(
+    client: &mut BackendApiClient,
+    config: &ControlPlaneConfig,
+    snapshot_store: Option<&Arc<dyn SnapshotStore>>,
+    policy_tx: &watch::Sender<Arc<CompiledPolicy>>,
+    active_config: &mut ActiveConfig,
+    correlation_id: String,
+    reason: ConfigRequestReason,
+    source: PolicySource,
+) -> Result<bool, ControlPlaneError> {
+    let response = client
+        .get_active_config(GetConfigRequest {
+            correlation_id,
+            reason: reason as i32,
+            known_versions: Some(active_config.section_versions.clone()),
+            known_version: Some(active_config.version as i32),
+        })
+        .await?;
+
+    let changed = response.configuration_changed;
+    let next_config = merge_response(Some(active_config.clone()), response)?;
+    persist_snapshot(snapshot_store, &next_config)?;
+    publish_active_config(policy_tx, &next_config, config.fallback_block_icmp, source)?;
+    *active_config = next_config;
+    Ok(changed)
+}
+
+fn merge_response(
+    existing: Option<ActiveConfig>,
+    response: ConfigResponse,
+) -> Result<ActiveConfig, ControlPlaneError> {
+    match existing {
+        Some(current) if !response.configuration_changed => Ok(current),
+        Some(current) => current
+            .apply_delta(response)
+            .map_err(|err| ControlPlaneError::Delta(err.to_string())),
+        None => Ok(ActiveConfig::from_response(response)),
+    }
+}
+
+fn publish_active_config(
+    policy_tx: &watch::Sender<Arc<CompiledPolicy>>,
+    active_config: &ActiveConfig,
+    block_icmp: bool,
+    source: PolicySource,
+) -> Result<(), ControlPlaneError> {
+    let policy = compiler::compile_from_active_config(active_config, block_icmp, source)
+        .map_err(|err| ControlPlaneError::PolicyCompile(err.to_string()))?;
+    let _ = policy_tx.send(Arc::new(policy));
+    Ok(())
+}
+
+fn publish_safe_deny(
+    policy_tx: &watch::Sender<Arc<CompiledPolicy>>,
+) -> Result<(), ControlPlaneError> {
+    let policy = compiler::compile_safe_deny()
+        .map_err(|err| ControlPlaneError::PolicyCompile(err.to_string()))?;
+    let _ = policy_tx.send(Arc::new(policy));
+    Ok(())
+}
+
+fn persist_snapshot(
+    snapshot_store: Option<&Arc<dyn SnapshotStore>>,
+    active_config: &ActiveConfig,
+) -> Result<(), ControlPlaneError> {
+    if let Some(snapshot_store) = snapshot_store {
+        snapshot_store.save(&active_config.to_config_response())?;
+    }
+
+    Ok(())
+}
+
+async fn send_heartbeat(
+    fw_tx: &mpsc::Sender<
+        crate::control_plane::backend_api::proto::raptorgate::events::FirewallEvent,
+    >,
+    config: &ControlPlaneConfig,
+    mode: FirewallMode,
+    active_config_version: u64,
+    uptime_seconds: u64,
+) {
+    let _ = fw_tx
+        .send(encode_firewall_event(
+            FW_HEARTBEAT,
+            HeartbeatEvent {
+                firewall_version: config.firewall_version.clone(),
+                mode: mode as i32,
+                active_config_version,
+                uptime_seconds,
+            },
+        ))
+        .await;
+}

--- a/src/control_plane/snapshot/mod.rs
+++ b/src/control_plane/snapshot/mod.rs
@@ -1,0 +1,2 @@
+pub mod redb;
+pub mod store;

--- a/src/control_plane/snapshot/redb.rs
+++ b/src/control_plane/snapshot/redb.rs
@@ -1,0 +1,51 @@
+use prost::Message;
+use redb::{Database, ReadableDatabase, TableDefinition};
+
+use crate::control_plane::backend_api::proto::raptorgate::config::ConfigResponse;
+use crate::control_plane::error::SnapshotError;
+use crate::control_plane::snapshot::store::SnapshotStore;
+
+const KEY: u64 = 0;
+const TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("snapshots");
+
+pub struct RedbSnapshotStore {
+    db: Database,
+}
+
+impl RedbSnapshotStore {
+    pub fn open(path: &str) -> Result<Self, SnapshotError> {
+        Ok(Self {
+            db: Database::create(path)?,
+        })
+    }
+}
+
+impl SnapshotStore for RedbSnapshotStore {
+    fn load(&self) -> Result<Option<ConfigResponse>, SnapshotError> {
+        let tx = self.db.begin_read()?;
+        let table = match tx.open_table(TABLE) {
+            Ok(table) => table,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(err) => return Err(err.into()),
+        };
+
+        let bytes = match table.get(KEY)? {
+            Some(guard) => guard.value().to_vec(),
+            None => return Ok(None),
+        };
+
+        Ok(Some(ConfigResponse::decode(bytes.as_slice())?))
+    }
+
+    fn save(&self, response: &ConfigResponse) -> Result<(), SnapshotError> {
+        let tx = self.db.begin_write()?;
+
+        {
+            let mut table = tx.open_table(TABLE)?;
+            table.insert(KEY, response.encode_to_vec().as_slice())?;
+        }
+
+        tx.commit()?;
+        Ok(())
+    }
+}

--- a/src/control_plane/snapshot/store.rs
+++ b/src/control_plane/snapshot/store.rs
@@ -1,0 +1,7 @@
+use crate::control_plane::backend_api::proto::raptorgate::config::ConfigResponse;
+use crate::control_plane::error::SnapshotError;
+
+pub trait SnapshotStore: Send + Sync {
+    fn load(&self) -> Result<Option<ConfigResponse>, SnapshotError>;
+    fn save(&self, response: &ConfigResponse) -> Result<(), SnapshotError>;
+}

--- a/src/data_plane/mod.rs
+++ b/src/data_plane/mod.rs
@@ -1,0 +1,3 @@
+pub mod packet_handler;
+pub mod policy_store;
+pub mod runtime;

--- a/src/data_plane/packet_handler.rs
+++ b/src/data_plane/packet_handler.rs
@@ -1,0 +1,76 @@
+use tun::AsyncDevice;
+
+use etherparse::{NetSlice, SlicedPacket, TransportSlice};
+
+use crate::data_plane::policy_store::PolicyStore;
+use crate::frame::RealFrame;
+use crate::rule_tree::Verdict;
+
+pub async fn handle_packet(iface: &str, data: &[u8], tun: &AsyncDevice, policies: &PolicyStore) {
+    let packet = match SlicedPacket::from_ethernet(data) {
+        Ok(packet) => packet,
+        Err(err) => {
+            eprintln!("[{iface}] SlicedPacket parse error: {err:?}");
+            return;
+        }
+    };
+
+    if !matches!(&packet.net, Some(NetSlice::Ipv4(_))) {
+        return;
+    }
+
+    if let Err(reason) = crate::packet_validator::validate(&packet) {
+        println!("[{iface}] DROP (invalid packet: {reason})");
+        return;
+    }
+
+    let compiled_policy = policies.load();
+    let verdict = RealFrame::from_sliced(&packet)
+        .and_then(|frame| compiled_policy.evaluator().evaluate(&frame));
+
+    let allow = matches!(verdict, Some(Verdict::Allow | Verdict::AllowWarn(_)));
+
+    match &verdict {
+        Some(Verdict::AllowWarn(msg)) => eprintln!("[{iface}] WARN (allow): {msg}"),
+        Some(Verdict::DropWarn(msg)) => eprintln!("[{iface}] WARN (drop): {msg}"),
+        _ => {}
+    }
+
+    let ip_info = match &packet.net {
+        Some(NetSlice::Ipv4(ipv4)) => {
+            let header = ipv4.header();
+            let src = std::net::Ipv4Addr::from(header.source());
+            let dst = std::net::Ipv4Addr::from(header.destination());
+            let ttl = header.ttl();
+            let total_len = header.total_len();
+            let (proto, ports) = match &packet.transport {
+                Some(TransportSlice::Tcp(tcp)) => (
+                    "TCP",
+                    format!("{}:{}", tcp.source_port(), tcp.destination_port()),
+                ),
+                Some(TransportSlice::Udp(udp)) => (
+                    "UDP",
+                    format!("{}:{}", udp.source_port(), udp.destination_port()),
+                ),
+                Some(TransportSlice::Icmpv4(_)) => ("ICMP", "-".into()),
+                _ => ("OTHER", "-".into()),
+            };
+
+            format!("{src} -> {dst} proto={proto} ports={ports} ttl={ttl} len={total_len}")
+        }
+        _ => "N/A".into(),
+    };
+
+    if !allow {
+        println!("[{iface}] DROP {ip_info}");
+        return;
+    }
+
+    println!("[{iface}] PASS {ip_info}");
+
+    if let Some(ip_payload) = packet.ether_payload().map(|ether| ether.payload) {
+        if let Err(err) = tun.send(ip_payload).await {
+            eprintln!("[{iface}] Failed to send to tun0: {err}");
+        }
+    }
+}

--- a/src/data_plane/policy_store.rs
+++ b/src/data_plane/policy_store.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+use crate::policy::runtime::CompiledPolicy;
+
+pub struct PolicyStore {
+    current: ArcSwap<CompiledPolicy>,
+}
+
+impl PolicyStore {
+    pub fn new(initial: Arc<CompiledPolicy>) -> Arc<Self> {
+        Arc::new(Self {
+            current: ArcSwap::from(initial),
+        })
+    }
+
+    pub fn from_watch(
+        policy_rx: watch::Receiver<Arc<CompiledPolicy>>,
+    ) -> (Arc<Self>, JoinHandle<()>) {
+        let initial = policy_rx.borrow().clone();
+        let store = Self::new(initial);
+        let store_task = Arc::clone(&store);
+
+        let join = tokio::spawn(async move {
+            let mut policy_rx = policy_rx;
+
+            while policy_rx.changed().await.is_ok() {
+                let next_policy = policy_rx.borrow().clone();
+                store_task.current.store(next_policy);
+            }
+        });
+
+        (store, join)
+    }
+
+    pub fn load(&self) -> Arc<CompiledPolicy> {
+        self.current.load_full()
+    }
+}

--- a/src/data_plane/runtime.rs
+++ b/src/data_plane/runtime.rs
@@ -1,0 +1,126 @@
+use std::sync::Arc;
+
+use pcap::Direction;
+use tokio::sync::mpsc;
+use tokio::task;
+use tun::AsyncDevice;
+
+use crate::app_config::AppConfig;
+use crate::data_plane::packet_handler::handle_packet;
+use crate::data_plane::policy_store::PolicyStore;
+
+pub async fn run(config: &AppConfig, policies: Arc<PolicyStore>) -> anyhow::Result<()> {
+    let all_devices = pcap::Device::list()?;
+
+    let devices: Vec<pcap::Device> = all_devices
+        .into_iter()
+        .filter(|dev| config.capture_interfaces.contains(&dev.name))
+        .collect();
+
+    if devices.is_empty() {
+        tracing::warn!(
+            interfaces = %config.capture_interfaces.join(","),
+            "No matching capture devices found — data plane inactive, control plane running"
+        );
+        std::future::pending::<()>().await;
+        return Ok(());
+    }
+
+    println!(
+        "Using devices: {}",
+        devices
+            .iter()
+            .map(|d| d.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    let tun = Arc::new(setup_tun(
+        &config.tun_device_name,
+        config.tun_address,
+        config.tun_netmask,
+    )?);
+
+    let pcap_timeout_ms = config.pcap_timeout_ms;
+    let mut handles = Vec::new();
+
+    for device in devices {
+        let tun = Arc::clone(&tun);
+        let policies = Arc::clone(&policies);
+        let name = device.name.clone();
+        let (tx, rx) = mpsc::channel::<Vec<u8>>(256);
+
+        let capture_name = name.clone();
+        task::spawn_blocking(move || {
+            let mut cap = match pcap::Capture::from_device(device)
+                .map(|c| {
+                    c.immediate_mode(true)
+                        .promisc(true)
+                        .timeout(pcap_timeout_ms)
+                })
+                .and_then(pcap::Capture::open)
+            {
+                Ok(c) => c,
+                Err(err) => {
+                    eprintln!("[{capture_name}] Failed to open capture: {err:?}");
+                    return;
+                }
+            };
+
+            if let Err(err) = cap.direction(Direction::In) {
+                eprintln!("[{capture_name}] Warning: could not set direction: {err:?}");
+            }
+
+            loop {
+                match cap.next_packet() {
+                    Ok(packet) => {
+                        if tx.blocking_send(packet.data.to_vec()).is_err() {
+                            eprintln!("[{capture_name}] Receiver dropped, stopping capture");
+                            break;
+                        }
+                    }
+                    Err(pcap::Error::TimeoutExpired) => continue,
+                    Err(err) => {
+                        eprintln!("[{capture_name}] Capture error (fatal): {err:?}");
+                        break;
+                    }
+                }
+            }
+
+            eprintln!("[{capture_name}] Capture thread exiting");
+        });
+
+        let handler_name = name;
+        let handle = tokio::spawn(async move {
+            let mut rx = rx;
+            while let Some(data) = rx.recv().await {
+                handle_packet(&handler_name, &data, &tun, &policies).await;
+            }
+            eprintln!("[{handler_name}] Handler task exiting (sender dropped)");
+        });
+
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.await?;
+    }
+
+    Ok(())
+}
+
+fn setup_tun(
+    name: &str,
+    address: std::net::Ipv4Addr,
+    netmask: std::net::Ipv4Addr,
+) -> tun::Result<AsyncDevice> {
+    let mut config = tun::Configuration::default();
+    config.tun_name(name).address(address).netmask(netmask).up();
+
+    #[cfg(target_os = "linux")]
+    config.platform_config(|config| {
+        config.ensure_root_privileges(true);
+    });
+
+    tun::create_as_async(&config)
+}

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,6 +1,6 @@
-use std::time::{SystemTime, UNIX_EPOCH};
 use derive_more::{Display, Eq, From};
 use etherparse::{NetSlice, SlicedPacket, TransportSlice};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(crate) trait Frame {
     fn ip_ver(&self) -> IpVer;
@@ -32,10 +32,7 @@ impl std::fmt::Display for IP {
         write!(
             f,
             "{}.{}.{}.{}",
-            self.octets[0],
-            self.octets[1],
-            self.octets[2],
-            self.octets[3],
+            self.octets[0], self.octets[1], self.octets[2], self.octets[3],
         )
     }
 }
@@ -51,7 +48,6 @@ impl PartialEq for Octet {
         match (self, other) {
             (Octet::Value(a), Octet::Value(b)) => a == b,
             _ => true,
-            
         }
     }
 }
@@ -76,18 +72,29 @@ impl TryFrom<u8> for Hour {
     }
 }
 
-
 #[derive(Debug, Display, Clone, Copy, PartialEq, PartialOrd)]
-pub(crate) enum Protocol { Tcp, Udp, Icmp }
+pub(crate) enum Protocol {
+    Tcp,
+    Udp,
+    Icmp,
+}
 #[derive(Debug, Display, Clone, Copy, PartialEq, PartialOrd)]
-pub(crate) enum Weekday { Mon, Tue, Wed, Thu, Fri, Sat, Sun }
+pub(crate) enum Weekday {
+    Mon,
+    Tue,
+    Wed,
+    Thu,
+    Fri,
+    Sat,
+    Sun,
+}
 
 pub(crate) struct RealFrame {
     ip_ver: IpVer,
     src_ip: IP,
     dst_ip: IP,
     protocol: Protocol,
-    src_port: Option<Port>, 
+    src_port: Option<Port>,
     dst_port: Option<Port>,
     hour: Hour,
     day_of_week: Weekday,
@@ -102,8 +109,18 @@ impl RealFrame {
                 let d = h.destination();
                 (
                     IpVer::V4,
-                    IP::new([Octet::Value(s[0]), Octet::Value(s[1]), Octet::Value(s[2]), Octet::Value(s[3])]),
-                    IP::new([Octet::Value(d[0]), Octet::Value(d[1]), Octet::Value(d[2]), Octet::Value(d[3])]),
+                    IP::new([
+                        Octet::Value(s[0]),
+                        Octet::Value(s[1]),
+                        Octet::Value(s[2]),
+                        Octet::Value(s[3]),
+                    ]),
+                    IP::new([
+                        Octet::Value(d[0]),
+                        Octet::Value(d[1]),
+                        Octet::Value(d[2]),
+                        Octet::Value(d[3]),
+                    ]),
                 )
             }
             // No IPv6 for now
@@ -144,17 +161,42 @@ impl RealFrame {
             _ => Weekday::Wed,
         };
 
-        Some(Self { ip_ver, src_ip, dst_ip, protocol, src_port, dst_port, hour, day_of_week })
+        Some(Self {
+            ip_ver,
+            src_ip,
+            dst_ip,
+            protocol,
+            src_port,
+            dst_port,
+            hour,
+            day_of_week,
+        })
     }
 }
 
 impl Frame for RealFrame {
-    fn ip_ver(&self) -> IpVer { self.ip_ver }
-    fn src_ip(&self) -> IP { self.src_ip }
-    fn dst_ip(&self) -> IP { self.dst_ip }
-    fn protocol(&self) -> Protocol { self.protocol }
-    fn src_port(&self) -> Option<Port> { self.src_port }
-    fn dst_port(&self) -> Option<Port> { self.dst_port }
-    fn hour(&self) -> Hour { self.hour }
-    fn day_of_week(&self) -> Weekday { self.day_of_week }
+    fn ip_ver(&self) -> IpVer {
+        self.ip_ver
+    }
+    fn src_ip(&self) -> IP {
+        self.src_ip
+    }
+    fn dst_ip(&self) -> IP {
+        self.dst_ip
+    }
+    fn protocol(&self) -> Protocol {
+        self.protocol
+    }
+    fn src_port(&self) -> Option<Port> {
+        self.src_port
+    }
+    fn dst_port(&self) -> Option<Port> {
+        self.dst_port
+    }
+    fn hour(&self) -> Hour {
+        self.hour
+    }
+    fn day_of_week(&self) -> Weekday {
+        self.day_of_week
+    }
 }

--- a/src/grpc_client.rs
+++ b/src/grpc_client.rs
@@ -1,10 +1,10 @@
 pub mod client;
-pub mod proto_types;
 pub mod active_config;
 pub mod config_snapshot;
 pub mod backend_connection;
-pub mod firewall_mode_state;
 pub mod event_stream_manager;
 
+mod proto_types;
 mod event_type;
 mod event_dispatcher;
+mod firewall_mode_state;

--- a/src/grpc_client/backend_connection.rs
+++ b/src/grpc_client/backend_connection.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
-use std::time::Duration;
 
-use tokio::sync::mpsc::Sender;
 use tokio::sync::RwLock;
 
 use crate::app_config::AppConfig;
@@ -14,21 +12,31 @@ use crate::grpc_client::event_stream_manager::EventStreamManager;
 use crate::grpc_client::client::{current_timestamp, make_firewall_event, GrpcClient};
 use crate::grpc_client::proto_types::raptorgate::{
     common::{FirewallMode, PolicyFailureCode},
-    config::{ConfigRequestReason, ConfigResponse, GetConfigRequest},
-    events::{
-        ConfigChangedEvent, FirewallEvent, PolicyActivatedEvent, PolicyFailedEvent,
-        ResyncConfirmedEvent, ResyncRequestedEvent,
-    },
+    config::{ConfigRequestReason, GetConfigRequest},
+    events::{ConfigChangedEvent, PolicyActivatedEvent, PolicyFailedEvent},
 };
 
 pub struct BackendConnection {
     pub mode: FirewallModeState,
+    pub event_manager: EventStreamManager,
     pub active_config: Arc<RwLock<ActiveConfig>>,
     pub snapshot: Option<Arc<ConfigSnapshot>>,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum BackendConnectionError {
+    #[error("połączenie UDS: {0}")]
+    Connect(#[from] tonic::transport::Error),
+    #[error("pobieranie konfiguracji: {0}")]
+    ConfigFetch(tonic::Status),
+    #[error("otwarcie EventStream: {0}")]
+    EventStream(tonic::Status),
+}
+
 impl BackendConnection {
-    pub async fn startup(config: &AppConfig) -> Self {
+    pub async fn startup(config: &AppConfig) -> Result<Self, BackendConnectionError> {
+        let mode = FirewallModeState::new(FirewallMode::SafeDeny);
+
         let snapshot: Option<Arc<ConfigSnapshot>> = match ConfigSnapshot::open(&config.redb_snapshot_path) {
             Ok(s) => Some(Arc::new(s)),
             Err(e) => {
@@ -37,359 +45,135 @@ impl BackendConnection {
             }
         };
 
-        // --- próba normalnego startu ---
-        'normal: {
-            let mut client = match GrpcClient::connect(&config.grpc_socket_path).await {
-                Ok(c) => c,
-                Err(e) => {
-                    tracing::warn!(error = %e, "gRPC niedostępny przy starcie");
-                    break 'normal;
-                }
-            };
+        let mut client = GrpcClient::connect(&config.grpc_socket_path).await?;
 
-            let resp = match client.get_active_config(GetConfigRequest {
-                correlation_id: uuid::Uuid::now_v7().to_string(),
+        let correlation_id = uuid::Uuid::now_v7().to_string();
+
+        let resp = client
+            .get_active_config(GetConfigRequest {
+                correlation_id: correlation_id.clone(),
                 reason: ConfigRequestReason::Startup as i32,
                 known_versions: None,
                 known_version: None,
-            }).await {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::warn!(error = %e, "GetActiveConfig nieudany przy starcie");
-                    break 'normal;
-                }
-            };
+            }).await
+            .map_err(BackendConnectionError::ConfigFetch)?;
 
-            // --- NORMAL ---
-            let config_version = resp.config_version;
-            let active_config = Arc::new(RwLock::new(ActiveConfig::from_response(resp)));
-            let mode = FirewallModeState::new(FirewallMode::Normal);
-            mode.set_config_version(config_version);
+        let config_version = resp.config_version;
+        let active_config = Arc::new(RwLock::new(ActiveConfig::from_response(resp)));
 
-            if let Some(ref snap) = snapshot {
-                snap.clone().save_bg(active_config.read().await.to_config_response());
-            }
-
-            tracing::info!(version = config_version, "Konfiguracja pobrana, tryb NORMAL");
-
-            let (fw_tx, be_rx) = client.open_event_stream(10_000);
-            let dispatcher = build_dispatcher(
-                client,
-                Arc::clone(&active_config),
-                mode.clone(),
-                fw_tx.clone(),
-                config.firewall_version.clone(),
-                snapshot.clone(),
-            );
-
-            match EventStreamManager::start(
-                fw_tx,
-                be_rx,
-                mode.clone(),
-                config.firewall_version.clone(),
-                config.heartbeat_interval_secs,
-                dispatcher,
-            ).await {
-                Ok(_) => {}
-                Err(e) => tracing::warn!(error = %e, "EventStream nieudany"),
-            }
-
-            return Self { mode, active_config, snapshot };
+        if let Some(ref snap) = snapshot {
+            snap.clone().save_bg(active_config.read().await.to_config_response());
         }
 
-        // --- EMERGENCY lub SAFE-DENY ---
-        let (active_config, mode) = match snapshot.as_ref().and_then(|s| s.load()) {
-            Some(resp) => {
-                let version = resp.config_version;
-                let ac = Arc::new(RwLock::new(ActiveConfig::from_response(resp)));
-                let m = FirewallModeState::new(FirewallMode::Emergency);
-                m.set_config_version(version);
-                tracing::warn!(version, "Backend niedostępny — tryb EMERGENCY (snapshot z Redb)");
-                (ac, m)
-            }
-            None => {
-                let ac = Arc::new(RwLock::new(ActiveConfig::from_response(ConfigResponse::default())));
-                let m = FirewallModeState::new(FirewallMode::SafeDeny);
-                tracing::warn!("Brak snapshotu — tryb SAFE-DENY (DROP wszystkiego)");
-                (ac, m)
-            }
-        };
+        mode.set(FirewallMode::Normal);
+        mode.set_config_version(config_version);
 
-        spawn_reconnect_task(
-            config.grpc_socket_path.clone(),
+        tracing::info!(version = config_version, "Konfiguracja pobrana, tryb NORMAL");
+        
+        let (fw_tx, be_rx) = client.open_event_stream(10_000);
+        
+        let handler_client = client.clone();
+
+        let handler_config = Arc::clone(&active_config);
+
+        let handler_mode = mode.clone();
+
+        let handler_fw_tx = fw_tx.clone();
+
+        let fw_version = config.firewall_version.clone();
+
+        let handler_snapshot = snapshot.clone();
+
+        let dispatcher =
+            EventDispatcher::new().on::<ConfigChangedEvent, _, _>(move |event| {
+                let mut client = handler_client.clone();
+
+                let config = Arc::clone(&handler_config);
+
+                let mode = handler_mode.clone();
+
+                let fw_tx = handler_fw_tx.clone();
+
+                let fw_version = fw_version.clone();
+                let correlation = event.correlation_id.clone();
+
+                let snap = handler_snapshot.clone();
+
+                async move {
+                    tracing::info!(correlation_id = %correlation, "config_changed — re-fetch");
+
+                    let known_versions = {
+                        let guard = config.read().await;
+                        Some(guard.section_versions.clone())
+                    };
+
+                    match client
+                        .get_active_config(GetConfigRequest {
+                            correlation_id: correlation.clone(),
+                            reason: ConfigRequestReason::ConfigChanged as i32,
+                            known_versions,
+                            known_version: None,
+                        }).await
+                    {
+                        Ok(resp) => {
+                            let new_version = resp.config_version;
+
+                            config.write().await.merge_delta(resp);
+                            mode.set_config_version(new_version);
+
+                            if let Some(ref s) = snap {
+                                s.clone().save_bg(config.read().await.to_config_response());
+                            }
+
+                            tracing::info!(
+                                version = new_version,
+                                fw_version = %fw_version,
+                                "Polityka zaktualizowana po config_changed"
+                            );
+
+                            let _ = fw_tx.try_send(make_firewall_event(
+                                PolicyActivatedEvent::TYPE,
+                                PolicyActivatedEvent {
+                                    config_version: new_version,
+                                    correlation_id: correlation,
+                                    activated_at: Some(current_timestamp()),
+                                    ..Default::default()
+                                },
+                            ));
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, "re-fetch konfiguracji nieudany");
+
+                            let _ = fw_tx.try_send(make_firewall_event(
+                                PolicyFailedEvent::TYPE,
+                                PolicyFailedEvent {
+                                    correlation_id: correlation,
+                                    failure_message: e.message().to_string(),
+                                    failure_code: PolicyFailureCode::Unspecified as i32,
+                                    failed_at: Some(current_timestamp()),
+                                    ..Default::default()
+                                },
+                            ));
+                        }
+                    }
+                }
+            });
+        
+        let event_manager = EventStreamManager::start(
+            fw_tx,
+            be_rx,
+            mode.clone(),
             config.firewall_version.clone(),
             config.heartbeat_interval_secs,
-            Arc::clone(&active_config),
-            mode.clone(),
-            snapshot.clone(),
-        );
+            dispatcher,
+        ).await
+        .map_err(|s| BackendConnectionError::EventStream(s))?;
 
-        Self { mode, active_config, snapshot }
+        Ok(Self {
+            mode,
+            event_manager,
+            active_config,
+            snapshot,
+        })
     }
-}
-
-fn build_dispatcher(
-    client: GrpcClient,
-    active_config: Arc<RwLock<ActiveConfig>>,
-    mode: FirewallModeState,
-    fw_tx: Sender<FirewallEvent>,
-    fw_version: String,
-    snapshot: Option<Arc<ConfigSnapshot>>,
-) -> EventDispatcher {
-    // ConfigChangedEvent handler
-    let cc_client = client.clone();
-    let cc_config = Arc::clone(&active_config);
-    let cc_mode = mode.clone();
-    let cc_fw_tx = fw_tx.clone();
-    let cc_fw_version = fw_version.clone();
-    let cc_snapshot = snapshot.clone();
-
-    // ResyncRequestedEvent handler
-    let rr_client = client.clone();
-    let rr_config = Arc::clone(&active_config);
-    let rr_mode = mode.clone();
-    let rr_fw_tx = fw_tx.clone();
-    let rr_snapshot = snapshot.clone();
-
-    EventDispatcher::new()
-        .on::<ConfigChangedEvent, _, _>(move |event| {
-            let mut client = cc_client.clone();
-            let config = Arc::clone(&cc_config);
-            let mode = cc_mode.clone();
-            let fw_tx = cc_fw_tx.clone();
-            let fw_version = cc_fw_version.clone();
-            let correlation = event.correlation_id.clone();
-            let snap = cc_snapshot.clone();
-
-            async move {
-                tracing::info!(correlation_id = %correlation, "config_changed — re-fetch");
-
-                let known_versions = {
-                    let guard = config.read().await;
-                    Some(guard.section_versions.clone())
-                };
-
-                match client.get_active_config(GetConfigRequest {
-                    correlation_id: correlation.clone(),
-                    reason: ConfigRequestReason::ConfigChanged as i32,
-                    known_versions,
-                    known_version: None,
-                }).await {
-                    Ok(resp) => {
-                        let new_version = resp.config_version;
-                        config.write().await.merge_delta(resp);
-                        mode.set_config_version(new_version);
-
-                        if let Some(ref s) = snap {
-                            s.clone().save_bg(config.read().await.to_config_response());
-                        }
-
-                        tracing::info!(
-                            version = new_version,
-                            fw_version = %fw_version,
-                            "Polityka zaktualizowana po config_changed"
-                        );
-
-                        let _ = fw_tx.try_send(make_firewall_event(
-                            PolicyActivatedEvent::TYPE,
-                            PolicyActivatedEvent {
-                                config_version: new_version,
-                                correlation_id: correlation,
-                                activated_at: Some(current_timestamp()),
-                                ..Default::default()
-                            },
-                        ));
-                    }
-                    Err(e) => {
-                        tracing::error!(error = %e, "re-fetch konfiguracji nieudany");
-
-                        let _ = fw_tx.try_send(make_firewall_event(
-                            PolicyFailedEvent::TYPE,
-                            PolicyFailedEvent {
-                                correlation_id: correlation,
-                                failure_message: e.message().to_string(),
-                                failure_code: PolicyFailureCode::Unspecified as i32,
-                                failed_at: Some(current_timestamp()),
-                                ..Default::default()
-                            },
-                        ));
-                    }
-                }
-            }
-        })
-        .on::<ResyncRequestedEvent, _, _>(move |event| {
-            let mut client = rr_client.clone();
-            let config = Arc::clone(&rr_config);
-            let mode = rr_mode.clone();
-            let fw_tx = rr_fw_tx.clone();
-            let snap = rr_snapshot.clone();
-            let correlation = event.correlation_id.clone();
-
-            async move {
-                tracing::info!(correlation_id = %correlation, "resync_requested — re-fetch konfiguracji");
-
-                let (previous_version, known_versions) = {
-                    let guard = config.read().await;
-                    (mode.get_config_version(), Some(guard.section_versions.clone()))
-                };
-
-                mode.set(FirewallMode::Resyncing);
-
-                match client.get_active_config(GetConfigRequest {
-                    correlation_id: correlation.clone(),
-                    reason: ConfigRequestReason::Resync as i32,
-                    known_versions,
-                    known_version: None,
-                }).await {
-                    Ok(resp) => {
-                        let new_version = resp.config_version;
-                        config.write().await.merge_delta(resp);
-                        mode.set_config_version(new_version);
-
-                        if let Some(ref s) = snap {
-                            s.clone().save_bg(config.read().await.to_config_response());
-                        }
-
-                        let _ = fw_tx.try_send(make_firewall_event(
-                            ResyncConfirmedEvent::TYPE,
-                            ResyncConfirmedEvent {
-                                previous_version,
-                                current_version: new_version,
-                                correlation_id: correlation,
-                                no_change: previous_version == new_version,
-                                confirmed_at: Some(current_timestamp()),
-                            },
-                        ));
-
-                        mode.set(FirewallMode::Normal);
-                        tracing::info!(version = new_version, "Resync zakończony, tryb NORMAL");
-                    }
-                    Err(e) => {
-                        tracing::error!(error = %e, "GetActiveConfig podczas resync nieudany");
-                        mode.set(FirewallMode::Emergency);
-                    }
-                }
-            }
-        })
-}
-
-fn spawn_reconnect_task(
-    grpc_socket_path: String,
-    firewall_version: String,
-    heartbeat_interval_secs: u64,
-    active_config: Arc<RwLock<ActiveConfig>>,
-    mode: FirewallModeState,
-    snapshot: Option<Arc<ConfigSnapshot>>,
-) {
-    tokio::spawn(async move {
-        let mut delay_secs = 1u64;
-
-        loop {
-            tokio::time::sleep(Duration::from_secs(delay_secs)).await;
-            delay_secs = (delay_secs * 2).min(60);
-
-            tracing::info!(delay_secs, "Próba reconnect z backendem...");
-
-            let mut client = match GrpcClient::connect(&grpc_socket_path).await {
-                Ok(c) => {
-                    delay_secs = 1;
-                    c
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "Reconnect nieudany");
-                    continue;
-                }
-            };
-
-            let previous_version = mode.get_config_version();
-            let reason = if previous_version > 0 {
-                ConfigRequestReason::Emergency
-            } else {
-                ConfigRequestReason::Startup
-            };
-            let known_versions = if previous_version > 0 {
-                let guard = active_config.read().await;
-                Some(guard.section_versions.clone())
-            } else {
-                None
-            };
-
-            let correlation = uuid::Uuid::now_v7().to_string();
-            mode.set(FirewallMode::Resyncing);
-
-            let resp = match client.get_active_config(GetConfigRequest {
-                correlation_id: correlation.clone(),
-                reason: reason as i32,
-                known_versions,
-                known_version: None,
-            }).await {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::warn!(error = %e, "GetActiveConfig podczas reconnect nieudany");
-                    mode.set(if previous_version > 0 {
-                        FirewallMode::Emergency
-                    } else {
-                        FirewallMode::SafeDeny
-                    });
-                    continue;
-                }
-            };
-
-            let new_version = resp.config_version;
-            {
-                let mut guard = active_config.write().await;
-                if previous_version > 0 {
-                    guard.merge_delta(resp);
-                } else {
-                    *guard = ActiveConfig::from_response(resp);
-                }
-            }
-            mode.set_config_version(new_version);
-
-            if let Some(ref snap) = snapshot {
-                snap.clone().save_bg(active_config.read().await.to_config_response());
-            }
-
-            let (fw_tx, be_rx) = client.open_event_stream(10_000);
-            let dispatcher = build_dispatcher(
-                client,
-                Arc::clone(&active_config),
-                mode.clone(),
-                fw_tx.clone(),
-                firewall_version.clone(),
-                snapshot.clone(),
-            );
-
-            let _ = fw_tx.try_send(make_firewall_event(
-                ResyncConfirmedEvent::TYPE,
-                ResyncConfirmedEvent {
-                    previous_version,
-                    current_version: new_version,
-                    correlation_id: correlation,
-                    no_change: previous_version == new_version,
-                    confirmed_at: Some(current_timestamp()),
-                },
-            ));
-
-            match EventStreamManager::start(
-                fw_tx,
-                be_rx,
-                mode.clone(),
-                firewall_version.clone(),
-                heartbeat_interval_secs,
-                dispatcher,
-            ).await {
-                Ok(_) => {
-                    mode.set(FirewallMode::Normal);
-                    tracing::info!(version = new_version, "Resync zakończony, tryb NORMAL");
-                    break;
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "EventStream nieudany po reconnect");
-                    mode.set(FirewallMode::Emergency);
-                    // kontynuuj pętlę
-                }
-            }
-        }
-    });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,12 @@
+pub mod app_config;
+pub mod control_plane;
+pub mod data_plane;
+pub mod frame;
+pub mod packet_validator;
+pub mod policy;
+pub mod policy_evaluator;
+pub mod rule_tree;
+
+pub mod config {
+    pub use crate::app_config::AppConfig;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,7 @@
-use tokio::sync::mpsc;
-use tokio::task;
-
-use std::cmp::min;
-use std::sync::Arc;
-
-use etherparse::{NetSlice, SlicedPacket, TransportSlice};
-use pcap::Direction;
-use tun::AsyncDevice;
-
-use crate::{frame::RealFrame, policy_evaluator::PolicyEvaluator, rule_tree::{ArmEnd, FieldValue, MatchBuilder, MatchKind, Pattern, RuleTree, Verdict}};
-use crate::grpc_client::backend_connection::BackendConnection;
-use crate::grpc_client::firewall_mode_state::FirewallModeState;
-use crate::grpc_client::proto_types::raptorgate::common::FirewallMode;
-
-mod frame;
-mod rule_tree;
-mod app_config;
-mod grpc_client;
-mod policy_evaluator;
-mod packet_validator;
+use ngfw::config::AppConfig;
+use ngfw::control_plane::{ControlPlane, ControlPlaneConfig};
+use ngfw::data_plane::policy_store::PolicyStore;
+use ngfw::data_plane::runtime as data_plane_runtime;
 
 #[tokio::main]
 async fn main() {
@@ -29,246 +12,30 @@ async fn main() {
         .with_thread_names(false)
         .init();
 
-    let config = match app_config::AppConfig::from_env() {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("Configuration error: {e}");
-            return;
-        }
-    };
-
-    let backend = BackendConnection::startup(&config).await;
-    let mode = Arc::new(backend.mode.clone());
-
-    let all_devices = match pcap::Device::list() {
-        Ok(list) => list,
+    let config = match AppConfig::from_env() {
+        Ok(config) => config,
         Err(err) => {
-            eprintln!("Device lookup error: {err:?}");
+            eprintln!("Configuration error: {err}");
             return;
         }
     };
 
-    let devices: Vec<pcap::Device> = all_devices
-        .into_iter()
-        .filter(|dev| config.capture_interfaces.contains(&dev.name))
-        .collect();
-
-    if devices.is_empty() {
-        eprintln!("No matching devices found");
-        return;
-    }
-
-    println!(
-        "Using devices: {}",
-        devices
-            .iter()
-            .map(|d| d.name.as_str())
-            .collect::<Vec<_>>()
-            .join(", ")
-    );
-
-    let tun = match setup_tun(&config.tun_device_name, config.tun_address, config.tun_netmask) {
-        Ok(t) => Arc::new(t),
-        Err(e) => {
-            eprintln!("Can't set up tun: {e:?}");
-            return;
-        }
-    };
-
-    let evaluator = Arc::new(build_policy(config.block_icmp));
-
-    let pcap_timeout_ms = config.pcap_timeout_ms;
-    let mut handles = Vec::new();
-
-    for device in devices {
-        let tun = Arc::clone(&tun);
-        let evaluator = Arc::clone(&evaluator);
-        let mode = Arc::clone(&mode);
-        let name = device.name.clone();
-        let (tx, rx) = mpsc::channel::<Vec<u8>>(256);
-
-        let capture_name = name.clone();
-        task::spawn_blocking(move || {
-            let mut cap = match pcap::Capture::from_device(device)
-                .map(|c| c.immediate_mode(true).promisc(true).timeout(pcap_timeout_ms))
-                .and_then(pcap::Capture::open)
-            {
-                Ok(c) => c,
-                Err(err) => {
-                    eprintln!("[{capture_name}] Failed to open capture: {err:?}");
-                    return;
-                }
-            };
-
-            // FIX: Only capture INCOMING packets.
-            // Without this, packets that the kernel forwards out of tun0 back onto
-            // enp0s8/enp0s9 are re-captured by pcap, creating an infinite loop.
-            // Direction::In uses pcap_setdirection(PCAP_D_IN), which on Linux
-            // AF_PACKET sockets excludes packets with sll_pkttype == PACKET_OUTGOING.
-            if let Err(e) = cap.direction(Direction::In) {
-                eprintln!("[{capture_name}] Warning: could not set direction: {e:?}");
-            }
-
-            loop {
-                match cap.next_packet() {
-                    Ok(packet) => {
-                        if tx.blocking_send(packet.data.to_vec()).is_err() {
-                            eprintln!("[{capture_name}] Receiver dropped, stopping capture");
-                            break;
-                        }
-                    }
-                    Err(pcap::Error::TimeoutExpired) => {
-                        // No packet within timeout window — just keep waiting.
-                        continue;
-                    }
-                    Err(err) => {
-                        eprintln!("[{capture_name}] Capture error (fatal): {err:?}");
-                        break;
-                    }
-                }
-            }
-            eprintln!("[{capture_name}] Capture thread exiting");
-        });
-
-        let handler_name = name;
-        let handle = tokio::spawn(async move {
-            let mut rx = rx;
-            while let Some(data) = rx.recv().await {
-                handle_packet(&handler_name, &data, &tun, &evaluator, &mode).await;
-            }
-            eprintln!("[{handler_name}] Handler task exiting (sender dropped)");
-        });
-
-        handles.push(handle);
-    }
-
-    for handle in handles {
-        if let Err(e) = handle.await {
-            eprintln!("Task panicked: {e:?}");
-        }
-    }
-}
-
-/// Inspect a raw Ethernet frame, evaluate it against the firewall policy,
-/// and forward it through the TUN device or drop it based on the verdict.
-async fn handle_packet(iface: &str, data: &[u8], tun: &AsyncDevice, evaluator: &PolicyEvaluator, mode: &FirewallModeState) {
-    if mode.get() == FirewallMode::SafeDeny {
-        return;
-    }
-
-    let packet = match SlicedPacket::from_ethernet(data) {
-        Ok(packet) => packet,
+    let control_plane = match ControlPlane::start(ControlPlaneConfig::from(&config)).await {
+        Ok(control_plane) => control_plane,
         Err(err) => {
-            eprintln!("[{iface}] SlicedPacket parse error: {err:?}");
+            eprintln!("Failed to start control plane: {err}");
             return;
         }
     };
 
-    // Only forward IPv4 packets.
-    if !matches!(&packet.net, Some(NetSlice::Ipv4(_))) {
-        return;
+    let handle = control_plane.handle();
+    let (policy_store, _policy_sync_task) = PolicyStore::from_watch(handle.policy());
+
+    if let Err(err) = data_plane_runtime::run(&config, policy_store).await {
+        eprintln!("Data plane error: {err}");
     }
 
-    if let Err(reason) = packet_validator::validate(&packet) {
-        println!("[{iface}] DROP (invalid packet: {reason})");
-        return;
+    if let Err(err) = control_plane.shutdown().await {
+        eprintln!("Control plane shutdown error: {err}");
     }
-
-    let verdict = RealFrame::from_sliced(&packet).and_then(|frame| evaluator.evaluate(&frame));
-
-    let allow = matches!(verdict, Some(Verdict::Allow | Verdict::AllowWarn(_)));
-
-    // Log warnings attached to verdict
-    match &verdict {
-        Some(Verdict::AllowWarn(msg)) => eprintln!("[{iface}] WARN (allow): {msg}"),
-        Some(Verdict::DropWarn(msg)) => eprintln!("[{iface}] WARN (drop): {msg}"),
-        _ => {}
-    }
-
-    let ip_info = match &packet.net {
-        Some(NetSlice::Ipv4(ipv4)) => {
-            let header = ipv4.header();
-            let src = std::net::Ipv4Addr::from(header.source());
-            let dst = std::net::Ipv4Addr::from(header.destination());
-            let ttl = header.ttl();
-            let total_len = header.total_len();
-            let (proto, ports) = match &packet.transport {
-                Some(TransportSlice::Tcp(tcp)) => (
-                    "TCP",
-                    format!("{}:{}", tcp.source_port(), tcp.destination_port()),
-                ),
-                Some(TransportSlice::Udp(udp)) => (
-                    "UDP",
-                    format!("{}:{}", udp.source_port(), udp.destination_port()),
-                ),
-                Some(TransportSlice::Icmpv4(_)) => ("ICMP", "-".into()),
-                _ => ("OTHER", "-".into()),
-            };
-            format!("{src} -> {dst} proto={proto} ports={ports} ttl={ttl} len={total_len}")
-        }
-        _ => "N/A".into(),
-    };
-
-    if !allow {
-        println!("[{iface}] DROP {ip_info}");
-        return;
-    }
-
-    println!("[{iface}] PASS {ip_info}");
-
-    if let Some(ip_payload) = packet.ether_payload().map(|ether| ether.payload) {
-        match tun.send(ip_payload).await {
-            Ok(_) => {}
-            Err(e) => eprintln!("[{iface}] Failed to send to tun0: {e}"),
-        }
-    }
-}
-
-fn build_policy(block_icmp: bool) -> PolicyEvaluator {
-    use frame::Protocol;
-
-    let tree = if block_icmp {
-        RuleTree::new(
-            "default".into(),
-            "Block ICMP, allow everything else".into(),
-            MatchBuilder::with_arm(
-                MatchKind::Protocol,
-                Pattern::Equal(FieldValue::Protocol(Protocol::Icmp)),
-                ArmEnd::Verdict(Verdict::Drop),
-            )
-            .arm(Pattern::Wildcard, ArmEnd::Verdict(Verdict::Allow))
-            .build()
-            .expect("default policy is valid"),
-        )
-    } else {
-        RuleTree::new(
-            "default".into(),
-            "Allow everything".into(),
-            MatchBuilder::with_arm(
-                MatchKind::Protocol,
-                Pattern::Wildcard,
-                ArmEnd::Verdict(Verdict::Allow),
-            )
-            .build()
-            .expect("default policy is valid"),
-        )
-    };
-
-    PolicyEvaluator::new(tree, Verdict::Drop)
-}
-
-fn setup_tun(name: &str, address: std::net::Ipv4Addr, netmask: std::net::Ipv4Addr) -> tun::Result<AsyncDevice> {
-    let mut config = tun::Configuration::default();
-    config
-        .tun_name(name)
-        .address(address)
-        .netmask(netmask)
-        .up();
-
-    #[cfg(target_os = "linux")]
-    config.platform_config(|config| {
-        config.ensure_root_privileges(true);
-    });
-
-    tun::create_as_async(&config)
 }

--- a/src/packet_validator.rs
+++ b/src/packet_validator.rs
@@ -136,7 +136,10 @@ mod tests {
         let mut buf = build_tcp_packet([10, 0, 0, 1], [10, 0, 0, 2], 64);
         buf[24] ^= 0xFF;
         let packet = SlicedPacket::from_ethernet(&buf).unwrap();
-        assert!(matches!(validate(&packet), Err(InvalidReason::BadIpv4Checksum)));
+        assert!(matches!(
+            validate(&packet),
+            Err(InvalidReason::BadIpv4Checksum)
+        ));
     }
 
     // Sprawdza czy pakiet z zepsutą sumą kontrolną TCP jest odrzucony.
@@ -145,7 +148,10 @@ mod tests {
         let mut buf = build_tcp_packet([10, 0, 0, 1], [10, 0, 0, 2], 64);
         buf[50] ^= 0xFF;
         let packet = SlicedPacket::from_ethernet(&buf).unwrap();
-        assert!(matches!(validate(&packet), Err(InvalidReason::BadTcpChecksum)));
+        assert!(matches!(
+            validate(&packet),
+            Err(InvalidReason::BadTcpChecksum)
+        ));
     }
 
     // Sprawdza czy pakiet z zepsutą sumą kontrolną UDP jest odrzucony.
@@ -154,7 +160,10 @@ mod tests {
         let mut buf = build_udp_packet([10, 0, 0, 1], [10, 0, 0, 2], 64);
         buf[40] ^= 0xFF;
         let packet = SlicedPacket::from_ethernet(&buf).unwrap();
-        assert!(matches!(validate(&packet), Err(InvalidReason::BadUdpChecksum)));
+        assert!(matches!(
+            validate(&packet),
+            Err(InvalidReason::BadUdpChecksum)
+        ));
     }
 
     // Sprawdza czy pakiet UDP z sumą kontrolną = 0 przechodzi.

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -1,0 +1,97 @@
+use crate::control_plane::config::active_config::ActiveConfig;
+use crate::policy::runtime::{CompiledPolicy, PolicyMetadata, PolicySource};
+use crate::policy_evaluator::PolicyEvaluator;
+use crate::rule_tree::{ArmEnd, FieldValue, MatchBuilder, MatchKind, Pattern, RuleTree, Verdict};
+
+#[derive(Debug, thiserror::Error)]
+pub enum PolicyCompileError {
+    #[error("invalid fallback policy: {0}")]
+    Fallback(String),
+}
+
+pub fn compile_fallback(block_icmp: bool) -> Result<CompiledPolicy, PolicyCompileError> {
+    build_compiled_policy(None, None, 0, PolicySource::LocalFallback, block_icmp)
+}
+
+pub fn compile_safe_deny() -> Result<CompiledPolicy, PolicyCompileError> {
+    let tree = RuleTree::new(
+        "safe-deny".into(),
+        "Drop everything".into(),
+        MatchBuilder::with_arm(
+            MatchKind::Protocol,
+            Pattern::Wildcard,
+            ArmEnd::Verdict(Verdict::Drop),
+        )
+        .build()
+        .map_err(|err| PolicyCompileError::Fallback(err.to_string()))?,
+    );
+
+    Ok(CompiledPolicy::new(
+        PolicyMetadata {
+            config_version: None,
+            bundle_checksum: None,
+            source: PolicySource::LocalFallback,
+            rule_count: 0,
+        },
+        PolicyEvaluator::new(tree, Verdict::Drop),
+    ))
+}
+
+pub fn compile_from_active_config(
+    active_config: &ActiveConfig,
+    block_icmp: bool,
+    source: PolicySource,
+) -> Result<CompiledPolicy, PolicyCompileError> {
+    build_compiled_policy(
+        Some(active_config.version),
+        Some(active_config.bundle_checksum.clone()),
+        active_config.rules.len(),
+        source,
+        block_icmp,
+    )
+}
+
+fn build_compiled_policy(
+    config_version: Option<u64>,
+    bundle_checksum: Option<String>,
+    rule_count: usize,
+    source: PolicySource,
+    block_icmp: bool,
+) -> Result<CompiledPolicy, PolicyCompileError> {
+    let tree = if block_icmp {
+        RuleTree::new(
+            "default".into(),
+            "Block ICMP, allow everything else".into(),
+            MatchBuilder::with_arm(
+                MatchKind::Protocol,
+                Pattern::Equal(FieldValue::Protocol(crate::frame::Protocol::Icmp)),
+                ArmEnd::Verdict(Verdict::Drop),
+            )
+            .arm(Pattern::Wildcard, ArmEnd::Verdict(Verdict::Allow))
+            .build()
+            .map_err(|err| PolicyCompileError::Fallback(err.to_string()))?,
+        )
+    } else {
+        RuleTree::new(
+            "default".into(),
+            "Allow everything".into(),
+            MatchBuilder::with_arm(
+                MatchKind::Protocol,
+                Pattern::Wildcard,
+                ArmEnd::Verdict(Verdict::Allow),
+            )
+            .build()
+            .map_err(|err| PolicyCompileError::Fallback(err.to_string()))?,
+        )
+    };
+
+    Ok(CompiledPolicy::new(
+        PolicyMetadata {
+            config_version,
+            bundle_checksum,
+            source,
+            rule_count,
+        },
+        PolicyEvaluator::new(tree, Verdict::Drop),
+    ))
+}

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -1,0 +1,2 @@
+pub mod compiler;
+pub mod runtime;

--- a/src/policy/runtime.rs
+++ b/src/policy/runtime.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use crate::policy_evaluator::PolicyEvaluator;
+
+#[derive(Clone, Debug)]
+pub enum PolicySource {
+    LocalFallback,
+    Snapshot,
+    Backend,
+    SnapshotThenBackend,
+}
+
+#[derive(Clone, Debug)]
+pub struct PolicyMetadata {
+    pub config_version: Option<u64>,
+    pub bundle_checksum: Option<String>,
+    pub source: PolicySource,
+    pub rule_count: usize,
+}
+
+#[derive(Clone)]
+pub struct CompiledPolicy {
+    metadata: PolicyMetadata,
+    evaluator: Arc<PolicyEvaluator>,
+}
+
+impl CompiledPolicy {
+    pub(crate) fn new(metadata: PolicyMetadata, evaluator: PolicyEvaluator) -> Self {
+        Self {
+            metadata,
+            evaluator: Arc::new(evaluator),
+        }
+    }
+
+    pub fn metadata(&self) -> &PolicyMetadata {
+        &self.metadata
+    }
+
+    pub(crate) fn evaluator(&self) -> &PolicyEvaluator {
+        self.evaluator.as_ref()
+    }
+}

--- a/src/policy_evaluator.rs
+++ b/src/policy_evaluator.rs
@@ -1,4 +1,7 @@
-use crate::{frame::Frame, rule_tree::{FieldValue, MatchKind, Operation, Pattern, RuleTree, Step, TreeWalker, Verdict}};
+use crate::{
+    frame::Frame,
+    rule_tree::{FieldValue, MatchKind, Operation, Pattern, RuleTree, Step, TreeWalker, Verdict},
+};
 
 pub(crate) struct PolicyEvaluator {
     rules: RuleTree,
@@ -7,11 +10,18 @@ pub(crate) struct PolicyEvaluator {
 
 impl PolicyEvaluator {
     pub(crate) fn new(rules: RuleTree, orphaned_verdict: Verdict) -> Self {
-        Self { rules, orphaned_verdict }
+        Self {
+            rules,
+            orphaned_verdict,
+        }
     }
 
     pub(crate) fn evaluate<T: Frame>(&self, frame: &T) -> Option<Verdict> {
-        let context = PolicyContext { frame, allowed: false, warned: false };
+        let context = PolicyContext {
+            frame,
+            allowed: false,
+            warned: false,
+        };
         let mut walker = TreeWalker::new(&self.rules);
 
         loop {
@@ -19,7 +29,9 @@ impl PolicyEvaluator {
                 Step::NeedsMatch { kind, pattern } => {
                     let value = Self::extract(*kind, &context)?;
                     let matched = Self::pattern_matches(pattern, value);
-                    if let Step::Verdict(v) = walker.advance(matched) { return Some(v.clone()) }
+                    if let Step::Verdict(v) = walker.advance(matched) {
+                        return Some(v.clone());
+                    }
                 }
                 Step::Verdict(v) => return Some(v.clone()),
                 Step::NoMatch => return None,
@@ -45,7 +57,7 @@ impl PolicyEvaluator {
         match (pattern, value) {
             (Pattern::Wildcard, _) => true,
 
-            (Pattern::Equal(field_value), value) => { *field_value == value }
+            (Pattern::Equal(field_value), value) => *field_value == value,
 
             (Pattern::Glob(FieldValue::Ip(pat_ip)), FieldValue::Ip(ip)) => *pat_ip == ip,
             (Pattern::Glob(_), _) => false,
@@ -58,22 +70,18 @@ impl PolicyEvaluator {
             }
             (Pattern::Range(_, _), _) => false,
 
-            (Pattern::Comparison(op, FieldValue::Port(rhs)), FieldValue::Port(v)) => {
-                match op {
-                    Operation::Greater => v > *rhs,
-                    Operation::Lesser => v < *rhs,
-                    Operation::GreaterOrEqual => v >= *rhs,
-                    Operation::LesserOrEqual => v <= *rhs,
-                }
-            }
-            (Pattern::Comparison(op, FieldValue::Hour(rhs)), FieldValue::Hour(v)) => {
-                match op {
-                    Operation::Greater => v > *rhs,
-                    Operation::Lesser => v < *rhs,
-                    Operation::GreaterOrEqual => v >= *rhs,
-                    Operation::LesserOrEqual => v <= *rhs,
-                }
-            }
+            (Pattern::Comparison(op, FieldValue::Port(rhs)), FieldValue::Port(v)) => match op {
+                Operation::Greater => v > *rhs,
+                Operation::Lesser => v < *rhs,
+                Operation::GreaterOrEqual => v >= *rhs,
+                Operation::LesserOrEqual => v <= *rhs,
+            },
+            (Pattern::Comparison(op, FieldValue::Hour(rhs)), FieldValue::Hour(v)) => match op {
+                Operation::Greater => v > *rhs,
+                Operation::Lesser => v < *rhs,
+                Operation::GreaterOrEqual => v >= *rhs,
+                Operation::LesserOrEqual => v <= *rhs,
+            },
             (Pattern::Comparison(op, FieldValue::DayOfWeek(rhs)), FieldValue::DayOfWeek(v)) => {
                 match op {
                     Operation::Greater => v > *rhs,
@@ -89,7 +97,10 @@ impl PolicyEvaluator {
     }
 }
 
-struct PolicyContext<'a, T> where T: Frame {
+struct PolicyContext<'a, T>
+where
+    T: Frame,
+{
     frame: &'a T,
     allowed: bool,
     warned: bool,
@@ -98,7 +109,10 @@ struct PolicyContext<'a, T> where T: Frame {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{frame::{Hour, IP, IpVer, Octet, Port, Protocol, Weekday}, rule_tree::{ArmEnd, MatchBuilder}};
+    use crate::{
+        frame::{Hour, IP, IpVer, Octet, Port, Protocol, Weekday},
+        rule_tree::{ArmEnd, MatchBuilder},
+    };
 
     struct DummyFrame {
         src_ip: IP,
@@ -114,8 +128,18 @@ mod tests {
     impl DummyFrame {
         fn default_v4() -> Self {
             Self {
-                src_ip: IP::new([Octet::Value(192), Octet::Value(168), Octet::Value(1), Octet::Value(10)]),
-                dst_ip: IP::new([Octet::Value(10), Octet::Value(0), Octet::Value(0), Octet::Value(1)]),
+                src_ip: IP::new([
+                    Octet::Value(192),
+                    Octet::Value(168),
+                    Octet::Value(1),
+                    Octet::Value(10),
+                ]),
+                dst_ip: IP::new([
+                    Octet::Value(10),
+                    Octet::Value(0),
+                    Octet::Value(0),
+                    Octet::Value(1),
+                ]),
                 ip_ver: IpVer::V4,
                 protocol: Protocol::Tcp,
                 src_port: Some(Port::from(12345)),
@@ -127,14 +151,30 @@ mod tests {
     }
 
     impl Frame for DummyFrame {
-        fn ip_ver(&self) -> IpVer { self.ip_ver }
-        fn src_ip(&self) -> IP { self.src_ip }
-        fn dst_ip(&self) -> IP { self.dst_ip }
-        fn protocol(&self) -> Protocol { self.protocol }
-        fn src_port(&self) -> Option<Port> { self.src_port }
-        fn dst_port(&self) -> Option<Port> { self.dst_port }
-        fn hour(&self) -> Hour { self.hour }
-        fn day_of_week(&self) -> Weekday { self.day_of_week }
+        fn ip_ver(&self) -> IpVer {
+            self.ip_ver
+        }
+        fn src_ip(&self) -> IP {
+            self.src_ip
+        }
+        fn dst_ip(&self) -> IP {
+            self.dst_ip
+        }
+        fn protocol(&self) -> Protocol {
+            self.protocol
+        }
+        fn src_port(&self) -> Option<Port> {
+            self.src_port
+        }
+        fn dst_port(&self) -> Option<Port> {
+            self.dst_port
+        }
+        fn hour(&self) -> Hour {
+            self.hour
+        }
+        fn day_of_week(&self) -> Weekday {
+            self.day_of_week
+        }
     }
 
     fn eval(tree: RuleTree, frame: &DummyFrame) -> Option<Verdict> {
@@ -145,9 +185,15 @@ mod tests {
     #[test]
     fn wildcard_always_matches() {
         let tree = RuleTree::new(
-            "wildcard".into(), "".into(),
-            MatchBuilder::with_arm(MatchKind::SrcIp, Pattern::Wildcard, ArmEnd::Verdict(Verdict::Allow))
-                .build().unwrap(),
+            "wildcard".into(),
+            "".into(),
+            MatchBuilder::with_arm(
+                MatchKind::SrcIp,
+                Pattern::Wildcard,
+                ArmEnd::Verdict(Verdict::Allow),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
     }
@@ -157,12 +203,15 @@ mod tests {
     #[test]
     fn equal_ip_ver_match() {
         let tree = RuleTree::new(
-            "ipver_eq".into(), "".into(),
+            "ipver_eq".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::IpVer,
                 Pattern::Equal(FieldValue::IpVer(IpVer::V4)),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
     }
@@ -170,12 +219,15 @@ mod tests {
     #[test]
     fn equal_ip_ver_no_match() {
         let tree = RuleTree::new(
-            "ipver_eq_miss".into(), "".into(),
+            "ipver_eq_miss".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::IpVer,
                 Pattern::Equal(FieldValue::IpVer(IpVer::V6)),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert!(eval(tree, &DummyFrame::default_v4()).is_none());
     }
@@ -185,12 +237,15 @@ mod tests {
     #[test]
     fn equal_protocol_match() {
         let tree = RuleTree::new(
-            "proto_eq".into(), "".into(),
+            "proto_eq".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::Protocol,
                 Pattern::Equal(FieldValue::Protocol(Protocol::Tcp)),
                 ArmEnd::Verdict(Verdict::Drop),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Drop));
     }
@@ -198,12 +253,15 @@ mod tests {
     #[test]
     fn equal_protocol_no_match() {
         let tree = RuleTree::new(
-            "proto_eq_miss".into(), "".into(),
+            "proto_eq_miss".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::Protocol,
                 Pattern::Equal(FieldValue::Protocol(Protocol::Udp)),
                 ArmEnd::Verdict(Verdict::Drop),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert!(eval(tree, &DummyFrame::default_v4()).is_none());
     }
@@ -212,28 +270,44 @@ mod tests {
 
     #[test]
     fn equal_src_ip_match() {
-        let ip = IP::new([Octet::Value(192), Octet::Value(168), Octet::Value(1), Octet::Value(10)]);
+        let ip = IP::new([
+            Octet::Value(192),
+            Octet::Value(168),
+            Octet::Value(1),
+            Octet::Value(10),
+        ]);
         let tree = RuleTree::new(
-            "srcip_eq".into(), "".into(),
+            "srcip_eq".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::SrcIp,
                 Pattern::Equal(FieldValue::Ip(ip)),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
     }
 
     #[test]
     fn equal_src_ip_no_match() {
-        let ip = IP::new([Octet::Value(10), Octet::Value(10), Octet::Value(10), Octet::Value(10)]);
+        let ip = IP::new([
+            Octet::Value(10),
+            Octet::Value(10),
+            Octet::Value(10),
+            Octet::Value(10),
+        ]);
         let tree = RuleTree::new(
-            "srcip_eq_miss".into(), "".into(),
+            "srcip_eq_miss".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::SrcIp,
                 Pattern::Equal(FieldValue::Ip(ip)),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert!(eval(tree, &DummyFrame::default_v4()).is_none());
     }
@@ -242,14 +316,22 @@ mod tests {
 
     #[test]
     fn equal_dst_ip_match() {
-        let ip = IP::new([Octet::Value(10), Octet::Value(0), Octet::Value(0), Octet::Value(1)]);
+        let ip = IP::new([
+            Octet::Value(10),
+            Octet::Value(0),
+            Octet::Value(0),
+            Octet::Value(1),
+        ]);
         let tree = RuleTree::new(
-            "dstip_eq".into(), "".into(),
+            "dstip_eq".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DstIp,
                 Pattern::Equal(FieldValue::Ip(ip)),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
     }
@@ -259,12 +341,15 @@ mod tests {
     #[test]
     fn equal_src_port_match() {
         let tree = RuleTree::new(
-            "srcport_eq".into(), "".into(),
+            "srcport_eq".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::SrcPort,
                 Pattern::Equal(FieldValue::Port(Port::from(12345))),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
     }
@@ -272,12 +357,15 @@ mod tests {
     #[test]
     fn equal_src_port_no_match() {
         let tree = RuleTree::new(
-            "srcport_eq_miss".into(), "".into(),
+            "srcport_eq_miss".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::SrcPort,
                 Pattern::Equal(FieldValue::Port(Port::from(9999))),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert!(eval(tree, &DummyFrame::default_v4()).is_none());
     }
@@ -287,14 +375,20 @@ mod tests {
     #[test]
     fn equal_dst_port_match() {
         let tree = RuleTree::new(
-            "dstport_eq".into(), "".into(),
+            "dstport_eq".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DstPort,
                 Pattern::Equal(FieldValue::Port(Port::from(80))),
                 ArmEnd::Verdict(Verdict::AllowWarn("dst port is 80".into())),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
-        assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::AllowWarn("dst port is 80".into())));
+        assert_eq!(
+            eval(tree, &DummyFrame::default_v4()),
+            Some(Verdict::AllowWarn("dst port is 80".into()))
+        );
     }
 
     // ── Equal: Hour ───────────────────────────────────────────
@@ -302,12 +396,15 @@ mod tests {
     #[test]
     fn equal_hour_match() {
         let tree = RuleTree::new(
-            "hour_eq".into(), "".into(),
+            "hour_eq".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::Hour,
                 Pattern::Equal(FieldValue::Hour(Hour::try_from(14).unwrap())),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
     }
@@ -315,12 +412,15 @@ mod tests {
     #[test]
     fn equal_hour_no_match() {
         let tree = RuleTree::new(
-            "hour_eq_miss".into(), "".into(),
+            "hour_eq_miss".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::Hour,
                 Pattern::Equal(FieldValue::Hour(Hour::try_from(3).unwrap())),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert!(eval(tree, &DummyFrame::default_v4()).is_none());
     }
@@ -330,12 +430,15 @@ mod tests {
     #[test]
     fn equal_day_of_week_match() {
         let tree = RuleTree::new(
-            "dow_eq".into(), "".into(),
+            "dow_eq".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DayOfWeek,
                 Pattern::Equal(FieldValue::DayOfWeek(Weekday::Wed)),
                 ArmEnd::Verdict(Verdict::Drop),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Drop));
     }
@@ -343,12 +446,15 @@ mod tests {
     #[test]
     fn equal_day_of_week_no_match() {
         let tree = RuleTree::new(
-            "dow_eq_miss".into(), "".into(),
+            "dow_eq_miss".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DayOfWeek,
                 Pattern::Equal(FieldValue::DayOfWeek(Weekday::Mon)),
                 ArmEnd::Verdict(Verdict::Drop),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert!(eval(tree, &DummyFrame::default_v4()).is_none());
     }
@@ -359,12 +465,15 @@ mod tests {
     fn glob_src_ip_wildcard_octets() {
         let pat_ip = IP::new([Octet::Value(192), Octet::Value(168), Octet::Any, Octet::Any]);
         let tree = RuleTree::new(
-            "glob_src".into(), "".into(),
+            "glob_src".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::SrcIp,
                 Pattern::Glob(FieldValue::Ip(pat_ip)),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
     }
@@ -373,12 +482,15 @@ mod tests {
     fn glob_src_ip_mismatch() {
         let pat_ip = IP::new([Octet::Value(10), Octet::Value(10), Octet::Any, Octet::Any]);
         let tree = RuleTree::new(
-            "glob_src_miss".into(), "".into(),
+            "glob_src_miss".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::SrcIp,
                 Pattern::Glob(FieldValue::Ip(pat_ip)),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert!(eval(tree, &DummyFrame::default_v4()).is_none());
     }
@@ -387,12 +499,15 @@ mod tests {
     fn glob_dst_ip_wildcard_octets() {
         let pat_ip = IP::new([Octet::Value(10), Octet::Any, Octet::Any, Octet::Any]);
         let tree = RuleTree::new(
-            "glob_dst".into(), "".into(),
+            "glob_dst".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DstIp,
                 Pattern::Glob(FieldValue::Ip(pat_ip)),
                 ArmEnd::Verdict(Verdict::Drop),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Drop));
     }
@@ -402,12 +517,18 @@ mod tests {
     #[test]
     fn range_dst_port_inclusive_match() {
         let tree = RuleTree::new(
-            "range_port".into(), "".into(),
+            "range_port".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DstPort,
-                Pattern::Range(FieldValue::Port(Port::from(70)), FieldValue::Port(Port::from(90))),
+                Pattern::Range(
+                    FieldValue::Port(Port::from(70)),
+                    FieldValue::Port(Port::from(90)),
+                ),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // dst_port = 80, in [70, 90]
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
@@ -416,12 +537,18 @@ mod tests {
     #[test]
     fn range_dst_port_below() {
         let tree = RuleTree::new(
-            "range_port_miss".into(), "".into(),
+            "range_port_miss".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DstPort,
-                Pattern::Range(FieldValue::Port(Port::from(81)), FieldValue::Port(Port::from(443))),
+                Pattern::Range(
+                    FieldValue::Port(Port::from(81)),
+                    FieldValue::Port(Port::from(443)),
+                ),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // dst_port = 80, not in [81, 443]
         assert!(eval(tree, &DummyFrame::default_v4()).is_none());
@@ -430,12 +557,18 @@ mod tests {
     #[test]
     fn range_dst_port_exact_boundary() {
         let tree = RuleTree::new(
-            "range_port_boundary".into(), "".into(),
+            "range_port_boundary".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DstPort,
-                Pattern::Range(FieldValue::Port(Port::from(80)), FieldValue::Port(Port::from(80))),
+                Pattern::Range(
+                    FieldValue::Port(Port::from(80)),
+                    FieldValue::Port(Port::from(80)),
+                ),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
     }
@@ -443,12 +576,18 @@ mod tests {
     #[test]
     fn range_src_port_match() {
         let tree = RuleTree::new(
-            "range_srcport".into(), "".into(),
+            "range_srcport".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::SrcPort,
-                Pattern::Range(FieldValue::Port(Port::from(10000)), FieldValue::Port(Port::from(20000))),
+                Pattern::Range(
+                    FieldValue::Port(Port::from(10000)),
+                    FieldValue::Port(Port::from(20000)),
+                ),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // src_port = 12345
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
@@ -459,7 +598,8 @@ mod tests {
     #[test]
     fn range_hour_match() {
         let tree = RuleTree::new(
-            "range_hour".into(), "".into(),
+            "range_hour".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::Hour,
                 Pattern::Range(
@@ -467,7 +607,9 @@ mod tests {
                     FieldValue::Hour(Hour::try_from(17).unwrap()),
                 ),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // hour = 14, in [9, 17]
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
@@ -476,7 +618,8 @@ mod tests {
     #[test]
     fn range_hour_outside() {
         let tree = RuleTree::new(
-            "range_hour_miss".into(), "".into(),
+            "range_hour_miss".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::Hour,
                 Pattern::Range(
@@ -484,7 +627,9 @@ mod tests {
                     FieldValue::Hour(Hour::try_from(23).unwrap()),
                 ),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // hour = 14, not in [15, 23]
         assert!(eval(tree, &DummyFrame::default_v4()).is_none());
@@ -495,12 +640,15 @@ mod tests {
     #[test]
     fn comparison_dst_port_greater() {
         let tree = RuleTree::new(
-            "cmp_port_gt".into(), "".into(),
+            "cmp_port_gt".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DstPort,
                 Pattern::Comparison(Operation::Greater, FieldValue::Port(Port::from(79))),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // dst_port = 80 > 79
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
@@ -509,12 +657,15 @@ mod tests {
     #[test]
     fn comparison_dst_port_greater_fail() {
         let tree = RuleTree::new(
-            "cmp_port_gt_fail".into(), "".into(),
+            "cmp_port_gt_fail".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DstPort,
                 Pattern::Comparison(Operation::Greater, FieldValue::Port(Port::from(80))),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // dst_port = 80, not > 80
         assert!(eval(tree, &DummyFrame::default_v4()).is_none());
@@ -523,12 +674,15 @@ mod tests {
     #[test]
     fn comparison_dst_port_greater_or_equal() {
         let tree = RuleTree::new(
-            "cmp_port_ge".into(), "".into(),
+            "cmp_port_ge".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DstPort,
                 Pattern::Comparison(Operation::GreaterOrEqual, FieldValue::Port(Port::from(80))),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
     }
@@ -536,12 +690,15 @@ mod tests {
     #[test]
     fn comparison_dst_port_lesser() {
         let tree = RuleTree::new(
-            "cmp_port_lt".into(), "".into(),
+            "cmp_port_lt".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DstPort,
                 Pattern::Comparison(Operation::Lesser, FieldValue::Port(Port::from(81))),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // dst_port = 80 < 81
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
@@ -550,12 +707,15 @@ mod tests {
     #[test]
     fn comparison_dst_port_lesser_or_equal() {
         let tree = RuleTree::new(
-            "cmp_port_le".into(), "".into(),
+            "cmp_port_le".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DstPort,
                 Pattern::Comparison(Operation::LesserOrEqual, FieldValue::Port(Port::from(80))),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
     }
@@ -565,12 +725,18 @@ mod tests {
     #[test]
     fn comparison_hour_greater() {
         let tree = RuleTree::new(
-            "cmp_hour_gt".into(), "".into(),
+            "cmp_hour_gt".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::Hour,
-                Pattern::Comparison(Operation::Greater, FieldValue::Hour(Hour::try_from(10).unwrap())),
+                Pattern::Comparison(
+                    Operation::Greater,
+                    FieldValue::Hour(Hour::try_from(10).unwrap()),
+                ),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // hour = 14 > 10
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
@@ -579,12 +745,18 @@ mod tests {
     #[test]
     fn comparison_hour_lesser_fail() {
         let tree = RuleTree::new(
-            "cmp_hour_lt_fail".into(), "".into(),
+            "cmp_hour_lt_fail".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::Hour,
-                Pattern::Comparison(Operation::Lesser, FieldValue::Hour(Hour::try_from(10).unwrap())),
+                Pattern::Comparison(
+                    Operation::Lesser,
+                    FieldValue::Hour(Hour::try_from(10).unwrap()),
+                ),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // hour = 14, not < 10
         assert!(eval(tree, &DummyFrame::default_v4()).is_none());
@@ -595,12 +767,18 @@ mod tests {
     #[test]
     fn comparison_day_of_week_greater_or_equal() {
         let tree = RuleTree::new(
-            "cmp_dow_ge".into(), "".into(),
+            "cmp_dow_ge".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DayOfWeek,
-                Pattern::Comparison(Operation::GreaterOrEqual, FieldValue::DayOfWeek(Weekday::Mon)),
+                Pattern::Comparison(
+                    Operation::GreaterOrEqual,
+                    FieldValue::DayOfWeek(Weekday::Mon),
+                ),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // Wed >= Mon
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
@@ -609,12 +787,15 @@ mod tests {
     #[test]
     fn comparison_day_of_week_lesser() {
         let tree = RuleTree::new(
-            "cmp_dow_lt".into(), "".into(),
+            "cmp_dow_lt".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DayOfWeek,
                 Pattern::Comparison(Operation::Lesser, FieldValue::DayOfWeek(Weekday::Fri)),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // Wed < Fri
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
@@ -623,12 +804,15 @@ mod tests {
     #[test]
     fn comparison_day_of_week_lesser_fail() {
         let tree = RuleTree::new(
-            "cmp_dow_lt_fail".into(), "".into(),
+            "cmp_dow_lt_fail".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DayOfWeek,
                 Pattern::Comparison(Operation::Lesser, FieldValue::DayOfWeek(Weekday::Mon)),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // Wed not < Mon
         assert!(eval(tree, &DummyFrame::default_v4()).is_none());
@@ -639,7 +823,8 @@ mod tests {
     #[test]
     fn or_protocol_matches_first() {
         let tree = RuleTree::new(
-            "or_proto".into(), "".into(),
+            "or_proto".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::Protocol,
                 Pattern::Or(vec![
@@ -647,7 +832,9 @@ mod tests {
                     Pattern::Equal(FieldValue::Protocol(Protocol::Udp)),
                 ]),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
     }
@@ -657,7 +844,8 @@ mod tests {
         let mut frame = DummyFrame::default_v4();
         frame.protocol = Protocol::Udp;
         let tree = RuleTree::new(
-            "or_proto_2nd".into(), "".into(),
+            "or_proto_2nd".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::Protocol,
                 Pattern::Or(vec![
@@ -665,7 +853,9 @@ mod tests {
                     Pattern::Equal(FieldValue::Protocol(Protocol::Udp)),
                 ]),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &frame), Some(Verdict::Allow));
     }
@@ -673,7 +863,8 @@ mod tests {
     #[test]
     fn or_protocol_no_match() {
         let tree = RuleTree::new(
-            "or_proto_miss".into(), "".into(),
+            "or_proto_miss".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::Protocol,
                 Pattern::Or(vec![
@@ -681,7 +872,9 @@ mod tests {
                     Pattern::Equal(FieldValue::Protocol(Protocol::Icmp)),
                 ]),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // frame is Tcp
         assert!(eval(tree, &DummyFrame::default_v4()).is_none());
@@ -690,7 +883,8 @@ mod tests {
     #[test]
     fn or_day_of_week() {
         let tree = RuleTree::new(
-            "or_dow".into(), "".into(),
+            "or_dow".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::DayOfWeek,
                 Pattern::Or(vec![
@@ -699,7 +893,9 @@ mod tests {
                     Pattern::Equal(FieldValue::DayOfWeek(Weekday::Fri)),
                 ]),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
     }
@@ -709,7 +905,8 @@ mod tests {
     #[test]
     fn multiple_arms_first_matches() {
         let tree = RuleTree::new(
-            "multi_arms_1st".into(), "".into(),
+            "multi_arms_1st".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::Protocol,
                 Pattern::Equal(FieldValue::Protocol(Protocol::Tcp)),
@@ -719,7 +916,8 @@ mod tests {
                 Pattern::Equal(FieldValue::Protocol(Protocol::Udp)),
                 ArmEnd::Verdict(Verdict::Drop),
             )
-            .build().unwrap(),
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
     }
@@ -729,7 +927,8 @@ mod tests {
         let mut frame = DummyFrame::default_v4();
         frame.protocol = Protocol::Udp;
         let tree = RuleTree::new(
-            "multi_arms_2nd".into(), "".into(),
+            "multi_arms_2nd".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::Protocol,
                 Pattern::Equal(FieldValue::Protocol(Protocol::Tcp)),
@@ -739,7 +938,8 @@ mod tests {
                 Pattern::Equal(FieldValue::Protocol(Protocol::Udp)),
                 ArmEnd::Verdict(Verdict::Drop),
             )
-            .build().unwrap(),
+            .build()
+            .unwrap(),
         );
         assert_eq!(eval(tree, &frame), Some(Verdict::Drop));
     }
@@ -747,7 +947,8 @@ mod tests {
     #[test]
     fn multiple_arms_none_match() {
         let tree = RuleTree::new(
-            "multi_arms_none".into(), "".into(),
+            "multi_arms_none".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::Protocol,
                 Pattern::Equal(FieldValue::Protocol(Protocol::Udp)),
@@ -757,7 +958,8 @@ mod tests {
                 Pattern::Equal(FieldValue::Protocol(Protocol::Icmp)),
                 ArmEnd::Verdict(Verdict::Drop),
             )
-            .build().unwrap(),
+            .build()
+            .unwrap(),
         );
         // frame is Tcp
         assert!(eval(tree, &DummyFrame::default_v4()).is_none());
@@ -773,12 +975,15 @@ mod tests {
         frame.dst_port = None;
 
         let tree = RuleTree::new(
-            "port_none".into(), "".into(),
+            "port_none".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::SrcPort,
                 Pattern::Equal(FieldValue::Port(Port::from(80))),
                 ArmEnd::Verdict(Verdict::Allow),
-            ).build().unwrap(),
+            )
+            .build()
+            .unwrap(),
         );
         // extract returns None → evaluate returns None
         assert!(eval(tree, &frame).is_none());
@@ -793,7 +998,8 @@ mod tests {
         //           → match Udp → Wildcard               → Drop
         // Match V6 → Drop
         let tree = RuleTree::new(
-            "nested".into(), "complex nested rule".into(),
+            "nested".into(),
+            "complex nested rule".into(),
             MatchBuilder::with_arm(
                 MatchKind::IpVer,
                 Pattern::Equal(FieldValue::IpVer(IpVer::V4)),
@@ -811,24 +1017,30 @@ mod tests {
                                 ArmEnd::Verdict(Verdict::Allow),
                             )
                             .arm(
-                                Pattern::Comparison(Operation::Greater, FieldValue::Port(Port::from(1024))),
+                                Pattern::Comparison(
+                                    Operation::Greater,
+                                    FieldValue::Port(Port::from(1024)),
+                                ),
                                 ArmEnd::Verdict(Verdict::AllowWarn("high dst port".into())),
                             )
-                            .build().unwrap(),
+                            .build()
+                            .unwrap(),
                         ),
                     )
                     .arm(
                         Pattern::Equal(FieldValue::Protocol(Protocol::Udp)),
                         ArmEnd::Verdict(Verdict::Drop),
                     )
-                    .build().unwrap(),
+                    .build()
+                    .unwrap(),
                 ),
             )
             .arm(
                 Pattern::Equal(FieldValue::IpVer(IpVer::V6)),
                 ArmEnd::Verdict(Verdict::Drop),
             )
-            .build().unwrap(),
+            .build()
+            .unwrap(),
         );
 
         assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::Allow));
@@ -837,7 +1049,8 @@ mod tests {
     #[test]
     fn nested_v4_tcp_high_port_allow_warn() {
         let tree = RuleTree::new(
-            "nested_high".into(), "".into(),
+            "nested_high".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::IpVer,
                 Pattern::Equal(FieldValue::IpVer(IpVer::V4)),
@@ -855,27 +1068,37 @@ mod tests {
                                 ArmEnd::Verdict(Verdict::Allow),
                             )
                             .arm(
-                                Pattern::Comparison(Operation::Greater, FieldValue::Port(Port::from(1024))),
+                                Pattern::Comparison(
+                                    Operation::Greater,
+                                    FieldValue::Port(Port::from(1024)),
+                                ),
                                 ArmEnd::Verdict(Verdict::AllowWarn("high dst port".into())),
                             )
-                            .build().unwrap(),
+                            .build()
+                            .unwrap(),
                         ),
                     )
-                    .build().unwrap(),
+                    .build()
+                    .unwrap(),
                 ),
             )
-            .build().unwrap(),
+            .build()
+            .unwrap(),
         );
 
         let mut frame = DummyFrame::default_v4();
         frame.dst_port = Some(Port::from(8080));
-        assert_eq!(eval(tree, &frame), Some(Verdict::AllowWarn("high dst port".into())));
+        assert_eq!(
+            eval(tree, &frame),
+            Some(Verdict::AllowWarn("high dst port".into()))
+        );
     }
 
     #[test]
     fn nested_v4_udp_drop() {
         let tree = RuleTree::new(
-            "nested_udp".into(), "".into(),
+            "nested_udp".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::IpVer,
                 Pattern::Equal(FieldValue::IpVer(IpVer::V4)),
@@ -889,10 +1112,12 @@ mod tests {
                         Pattern::Equal(FieldValue::Protocol(Protocol::Udp)),
                         ArmEnd::Verdict(Verdict::Drop),
                     )
-                    .build().unwrap(),
+                    .build()
+                    .unwrap(),
                 ),
             )
-            .build().unwrap(),
+            .build()
+            .unwrap(),
         );
 
         let mut frame = DummyFrame::default_v4();
@@ -903,7 +1128,8 @@ mod tests {
     #[test]
     fn nested_v6_drop() {
         let tree = RuleTree::new(
-            "nested_v6".into(), "".into(),
+            "nested_v6".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::IpVer,
                 Pattern::Equal(FieldValue::IpVer(IpVer::V4)),
@@ -913,7 +1139,8 @@ mod tests {
                 Pattern::Equal(FieldValue::IpVer(IpVer::V6)),
                 ArmEnd::Verdict(Verdict::Drop),
             )
-            .build().unwrap(),
+            .build()
+            .unwrap(),
         );
 
         let mut frame = DummyFrame::default_v4();
@@ -929,11 +1156,15 @@ mod tests {
         //                                          → otherwise       → Drop
         //                         → Hour outside   → AllowWarn
         let tree = RuleTree::new(
-            "nested_complex".into(), "glob+hour+day".into(),
+            "nested_complex".into(),
+            "glob+hour+day".into(),
             MatchBuilder::with_arm(
                 MatchKind::SrcIp,
                 Pattern::Glob(FieldValue::Ip(IP::new([
-                    Octet::Value(192), Octet::Value(168), Octet::Any, Octet::Any,
+                    Octet::Value(192),
+                    Octet::Value(168),
+                    Octet::Any,
+                    Octet::Any,
                 ]))),
                 ArmEnd::Match(
                     MatchBuilder::with_arm(
@@ -948,21 +1179,21 @@ mod tests {
                                 Pattern::Equal(FieldValue::DayOfWeek(Weekday::Wed)),
                                 ArmEnd::Verdict(Verdict::Allow),
                             )
-                            .arm(
-                                Pattern::Wildcard,
-                                ArmEnd::Verdict(Verdict::Drop),
-                            )
-                            .build().unwrap(),
+                            .arm(Pattern::Wildcard, ArmEnd::Verdict(Verdict::Drop))
+                            .build()
+                            .unwrap(),
                         ),
                     )
                     .arm(
                         Pattern::Wildcard,
                         ArmEnd::Verdict(Verdict::AllowWarn("hour outside range".into())),
                     )
-                    .build().unwrap(),
+                    .build()
+                    .unwrap(),
                 ),
             )
-            .build().unwrap(),
+            .build()
+            .unwrap(),
         );
 
         // Default: src=192.168.1.10, hour=14 (in [8,18]), day=Wed → Allow
@@ -972,11 +1203,15 @@ mod tests {
     #[test]
     fn nested_glob_ip_hour_in_range_wrong_day_drops() {
         let tree = RuleTree::new(
-            "nested_wrong_day".into(), "".into(),
+            "nested_wrong_day".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::SrcIp,
                 Pattern::Glob(FieldValue::Ip(IP::new([
-                    Octet::Value(192), Octet::Value(168), Octet::Any, Octet::Any,
+                    Octet::Value(192),
+                    Octet::Value(168),
+                    Octet::Any,
+                    Octet::Any,
                 ]))),
                 ArmEnd::Match(
                     MatchBuilder::with_arm(
@@ -991,17 +1226,17 @@ mod tests {
                                 Pattern::Equal(FieldValue::DayOfWeek(Weekday::Mon)),
                                 ArmEnd::Verdict(Verdict::Allow),
                             )
-                            .arm(
-                                Pattern::Wildcard,
-                                ArmEnd::Verdict(Verdict::Drop),
-                            )
-                            .build().unwrap(),
+                            .arm(Pattern::Wildcard, ArmEnd::Verdict(Verdict::Drop))
+                            .build()
+                            .unwrap(),
                         ),
                     )
-                    .build().unwrap(),
+                    .build()
+                    .unwrap(),
                 ),
             )
-            .build().unwrap(),
+            .build()
+            .unwrap(),
         );
 
         // day=Wed, but arm only allows Mon → falls to wildcard → Drop
@@ -1011,11 +1246,15 @@ mod tests {
     #[test]
     fn nested_glob_ip_hour_outside_range_drop_warn() {
         let tree = RuleTree::new(
-            "nested_late_hour".into(), "".into(),
+            "nested_late_hour".into(),
+            "".into(),
             MatchBuilder::with_arm(
                 MatchKind::SrcIp,
                 Pattern::Glob(FieldValue::Ip(IP::new([
-                    Octet::Value(192), Octet::Value(168), Octet::Any, Octet::Any,
+                    Octet::Value(192),
+                    Octet::Value(168),
+                    Octet::Any,
+                    Octet::Any,
                 ]))),
                 ArmEnd::Match(
                     MatchBuilder::with_arm(
@@ -1030,13 +1269,18 @@ mod tests {
                         Pattern::Wildcard,
                         ArmEnd::Verdict(Verdict::DropWarn("hour outside range".into())),
                     )
-                    .build().unwrap(),
+                    .build()
+                    .unwrap(),
                 ),
             )
-            .build().unwrap(),
+            .build()
+            .unwrap(),
         );
 
         // hour=14, not in [8,12] → falls to wildcard → AllowWarn
-        assert_eq!(eval(tree, &DummyFrame::default_v4()), Some(Verdict::DropWarn("hour outside range".into())));
+        assert_eq!(
+            eval(tree, &DummyFrame::default_v4()),
+            Some(Verdict::DropWarn("hour outside range".into()))
+        );
     }
 }

--- a/src/rule_tree.rs
+++ b/src/rule_tree.rs
@@ -1,22 +1,28 @@
-mod matcher;
 mod lexer;
+mod matcher;
 
 use derive_more::{Display, Error, PartialEq};
 
-use crate::{frame::{Hour, IP, IpVer, Port, Protocol, Weekday}, rule_tree::matcher::Match};
+use crate::{
+    frame::{Hour, IP, IpVer, Port, Protocol, Weekday},
+    rule_tree::matcher::Match,
+};
 pub(crate) use matcher::MatchBuilder;
 
 pub(crate) struct RuleTree {
     name: String,
     description: String,
-    pub(crate) head: Match
+    pub(crate) head: Match,
 }
 
 impl RuleTree {
     pub fn new(name: String, description: String, head: Match) -> Self {
-        Self { name, description, head }
+        Self {
+            name,
+            description,
+            head,
+        }
     }
-    
 }
 
 struct Arm {
@@ -93,20 +99,36 @@ impl Pattern {
             (Pattern::Glob(_), MatchKind::SrcIp | MatchKind::DstIp) => Ok(()),
             (Pattern::Glob(_), _) => Err(RuleError::InvalidPattern(self.clone())),
 
-            (Pattern::Range(..), MatchKind::SrcPort | MatchKind::DstPort | MatchKind::Hour) => Ok(()),
+            (Pattern::Range(..), MatchKind::SrcPort | MatchKind::DstPort | MatchKind::Hour) => {
+                Ok(())
+            }
             (Pattern::Range(..), _) => Err(RuleError::InvalidPattern(self.clone())),
 
-            (Pattern::Comparison(..), MatchKind::SrcPort | MatchKind::DstPort | MatchKind::Hour | MatchKind::DayOfWeek) => Ok(()),
+            (
+                Pattern::Comparison(..),
+                MatchKind::SrcPort | MatchKind::DstPort | MatchKind::Hour | MatchKind::DayOfWeek,
+            ) => Ok(()),
             (Pattern::Comparison(..), _) => Err(RuleError::InvalidPattern(self.clone())),
 
-            (Pattern::Or(_), MatchKind::Protocol | MatchKind::DayOfWeek | MatchKind::IpVer | MatchKind::Hour | MatchKind::SrcIp | MatchKind::DstIp) => Ok(()),
+            (
+                Pattern::Or(_),
+                MatchKind::Protocol
+                | MatchKind::DayOfWeek
+                | MatchKind::IpVer
+                | MatchKind::Hour
+                | MatchKind::SrcIp
+                | MatchKind::DstIp,
+            ) => Ok(()),
             (Pattern::Or(_), _) => Err(RuleError::InvalidPattern(self.clone())),
         }
     }
 }
 
 pub(crate) enum Step<'a> {
-    NeedsMatch { kind: &'a MatchKind, pattern: &'a Pattern },
+    NeedsMatch {
+        kind: &'a MatchKind,
+        pattern: &'a Pattern,
+    },
     Verdict(&'a Verdict),
     NoMatch,
 }
@@ -118,7 +140,10 @@ pub(crate) struct TreeWalker<'a> {
 
 impl<'a> TreeWalker<'a> {
     pub fn new(tree: &'a RuleTree) -> Self {
-        Self { current: &tree.head, arm_index: 0 }
+        Self {
+            current: &tree.head,
+            arm_index: 0,
+        }
     }
 
     pub fn current_step(&self) -> Step<'a> {
@@ -162,7 +187,12 @@ mod tests {
     use super::*;
 
     fn dummy_ip() -> IP {
-        IP::new([Octet::Value(10), Octet::Value(0), Octet::Value(0), Octet::Value(1)])
+        IP::new([
+            Octet::Value(10),
+            Octet::Value(0),
+            Octet::Value(0),
+            Octet::Value(1),
+        ])
     }
 
     #[test]
@@ -231,4 +261,3 @@ mod tests {
         }
     }
 }
-

--- a/src/rule_tree/lexer.rs
+++ b/src/rule_tree/lexer.rs
@@ -1,5 +1,5 @@
-use std::{char, fmt::Display, thread::current};
 use paste::paste;
+use std::{char, fmt::Display, thread::current};
 
 use derive_more::{Add, AddAssign, Debug, Display, From, derive};
 use thiserror::Error;
@@ -12,7 +12,7 @@ macro_rules! separating_chars {
 
 #[derive(Error, Debug, Display)]
 pub(crate) enum LexerError {
-    UnclosedStringLiteral(Position)
+    UnclosedStringLiteral(Position),
 }
 
 enum LexerMode {
@@ -27,7 +27,7 @@ struct StringLiteralBuilder {
 
 impl StringLiteralBuilder {
     fn push(&mut self, word: char) {
-        self.contents.push(word); 
+        self.contents.push(word);
     }
 }
 
@@ -70,7 +70,7 @@ enum TokenType {
 #[derive(Debug, Clone, PartialEq)]
 enum KeywordType {
     Match,
-    Verdict
+    Verdict,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -93,11 +93,20 @@ struct Word {
 
 impl Word {
     fn new(contents: String, pos: Position) -> Self {
-        Self { contents, start_pos: pos }
+        Self {
+            contents,
+            start_pos: pos,
+        }
     }
 
     fn default() -> Self {
-        Self { contents: "".into(), start_pos: Position { row: 0.into(), col: 0.into() } }
+        Self {
+            contents: "".into(),
+            start_pos: Position {
+                row: 0.into(),
+                col: 0.into(),
+            },
+        }
     }
 
     fn push(&mut self, c: char) {
@@ -105,7 +114,10 @@ impl Word {
     }
 
     fn into_token(&self, kind: TokenType) -> Token {
-        Token { pos: self.start_pos, kind }
+        Token {
+            pos: self.start_pos,
+            kind,
+        }
     }
 }
 
@@ -114,48 +126,57 @@ struct WordBuilder {
     start_pos: Position,
 }
 
-
 impl WordBuilder {
     fn new() -> Self {
-        Self { current_word: String::new(), start_pos: Position { row: 0.into(), col: 0.into() } }
+        Self {
+            current_word: String::new(),
+            start_pos: Position {
+                row: 0.into(),
+                col: 0.into(),
+            },
+        }
     }
 
     fn add_to(&mut self, c: char, pos: Position) -> Option<Word> {
-        if self.current_word.is_empty()  {
+        if self.current_word.is_empty() {
             if c.is_whitespace() {
-                return None
+                return None;
             }
 
             self.start_pos = pos;
             self.current_word.push(c);
         } else {
             if c.is_whitespace() {
-                return Some(self.exchange(c, pos))
+                return Some(self.exchange(c, pos));
             }
 
             if matches!(self.current_word.as_str(), "<=" | ">=" | "<>") {
-                return Some(self.exchange(c, pos))
+                return Some(self.exchange(c, pos));
             }
 
             if self.current_word.starts_with('<') || self.current_word.starts_with('>') {
-                let expected = if self.current_word.starts_with('>') { '<' } else { '>' };
+                let expected = if self.current_word.starts_with('>') {
+                    '<'
+                } else {
+                    '>'
+                };
 
                 if c == '=' || c == expected {
                     self.current_word.push(c);
-                    return Some(self.exchange(' ', pos))
+                    return Some(self.exchange(' ', pos));
                 }
 
-                return Some(self.exchange(c, pos))
+                return Some(self.exchange(c, pos));
             }
 
             if self.current_word.len() == 1
                 && matches!(self.current_word.chars().next(), Some(separating_chars!()))
             {
-                return Some(self.exchange(c, pos))
+                return Some(self.exchange(c, pos));
             }
 
             if matches!(c, separating_chars!()) {
-                return Some(self.exchange(c, pos))
+                return Some(self.exchange(c, pos));
             }
 
             self.current_word.push(c);
@@ -165,7 +186,9 @@ impl WordBuilder {
     }
 
     fn flush(&mut self) -> Option<Word> {
-        if self.current_word.is_empty() { return None }
+        if self.current_word.is_empty() {
+            return None;
+        }
         Some(self.exchange(' ', self.start_pos))
     }
 
@@ -188,7 +211,14 @@ pub(crate) struct Lexer {
 
 impl Lexer {
     pub fn new() -> Self {
-        Self { mode: LexerMode::Normal, curret_pos: Position { row: 1.into(), col: 0.into() }, word_builder: WordBuilder::new() }
+        Self {
+            mode: LexerMode::Normal,
+            curret_pos: Position {
+                row: 1.into(),
+                col: 0.into(),
+            },
+            word_builder: WordBuilder::new(),
+        }
     }
 
     fn update_pos(&mut self, current_char: char) {
@@ -232,33 +262,45 @@ impl Lexer {
             match &mut self.mode {
                 LexerMode::Normal => {
                     if c == '\"' {
-                        if let Some(word) = self.word_builder.flush() { tokens.push(Self::classify(word)) }
-                        self.mode = LexerMode::StringLiteral(StringLiteralBuilder { start_pos: self.curret_pos, contents: String::new() });
+                        if let Some(word) = self.word_builder.flush() {
+                            tokens.push(Self::classify(word))
+                        }
+                        self.mode = LexerMode::StringLiteral(StringLiteralBuilder {
+                            start_pos: self.curret_pos,
+                            contents: String::new(),
+                        });
                         continue;
                     }
 
-                    let Some(word) = self.word_builder.add_to(c, self.curret_pos) else { continue };
+                    let Some(word) = self.word_builder.add_to(c, self.curret_pos) else {
+                        continue;
+                    };
 
-                    tokens.push(
-                        Self::classify(word)
-                    );
-                },
+                    tokens.push(Self::classify(word));
+                }
                 LexerMode::StringLiteral(sb) => {
                     if c == '\"' {
-                        tokens.push(Token { pos: sb.start_pos, kind: TokenType::StringLiteral(sb.contents.clone()) });
+                        tokens.push(Token {
+                            pos: sb.start_pos,
+                            kind: TokenType::StringLiteral(sb.contents.clone()),
+                        });
                         self.mode = LexerMode::Normal;
                         continue;
                     }
 
                     sb.push(c);
-                },
+                }
             }
         }
 
         match &self.mode {
-            LexerMode::StringLiteral(sb) => return Err(LexerError::UnclosedStringLiteral(sb.start_pos)),
+            LexerMode::StringLiteral(sb) => {
+                return Err(LexerError::UnclosedStringLiteral(sb.start_pos));
+            }
             LexerMode::Normal => {
-                if let Some(word) = self.word_builder.flush() { tokens.push(Self::classify(word)) }
+                if let Some(word) = self.word_builder.flush() {
+                    tokens.push(Self::classify(word))
+                }
             }
         }
         Ok(tokens)
@@ -269,7 +311,9 @@ impl Lexer {
 mod tests {
     use std::vec;
 
-    use crate::rule_tree::lexer::{KeywordType, Lexer, LexerError, PatternType, Position, Token, TokenType};
+    use crate::rule_tree::lexer::{
+        KeywordType, Lexer, LexerError, PatternType, Position, Token, TokenType,
+    };
 
     #[test]
     fn empty_ruleset_passes() {
@@ -400,7 +444,7 @@ mod tests {
             TokenType::Identifier("abc".into()),
         ]
     );
-    
+
     gen_space_tests!(
         rng_operator,
         "5 <> abc",
@@ -473,11 +517,7 @@ mod tests {
     gen_space_tests!(
         colon_separator_braces_full,
         "} : {",
-        vec![
-            TokenType::RBrace,
-            TokenType::Semicolon,
-            TokenType::LBrace,
-        ]
+        vec![TokenType::RBrace, TokenType::Semicolon, TokenType::LBrace,]
     );
 
     gen_space_tests!(
@@ -547,26 +587,48 @@ mod tests {
     }
 
     #[test]
-    fn special_chars_dont_break_string_literals_no_space(){
+    fn special_chars_dont_break_string_literals_no_space() {
         let mut lexer = Lexer::new();
         let mut s = String::from("\"abc { dfg } xd {} dx <\"");
         s.retain(|c| !c.is_whitespace());
-        let got:Vec<TokenType>  = lexer.tokenize(&s).unwrap().into_iter().map(|t|t.kind).collect();
-        assert_eq!(got,(vec![TokenType::StringLiteral("abc{dfg}xd{}dx<".into())]));
+        let got: Vec<TokenType> = lexer
+            .tokenize(&s)
+            .unwrap()
+            .into_iter()
+            .map(|t| t.kind)
+            .collect();
+        assert_eq!(
+            got,
+            (vec![TokenType::StringLiteral("abc{dfg}xd{}dx<".into())])
+        );
     }
 
     #[test]
-    fn special_chars_dont_break_string_literals_space(){
+    fn special_chars_dont_break_string_literals_space() {
         let mut lexer = Lexer::new();
-        let got:Vec<TokenType>  = lexer.tokenize("\"abc { dfg } xd {} dx <\"").unwrap().into_iter().map(|t|t.kind).collect();
-        assert_eq!(got,(vec![TokenType::StringLiteral("abc { dfg } xd {} dx <".into())]));
+        let got: Vec<TokenType> = lexer
+            .tokenize("\"abc { dfg } xd {} dx <\"")
+            .unwrap()
+            .into_iter()
+            .map(|t| t.kind)
+            .collect();
+        assert_eq!(
+            got,
+            (vec![TokenType::StringLiteral("abc { dfg } xd {} dx <".into())])
+        );
     }
     gen_position_tests!(
         single_line_simple,
         "abc def",
         vec![
-            Position { row: 1.into(), col: 1.into() },
-            Position { row: 1.into(), col: 5.into() },
+            Position {
+                row: 1.into(),
+                col: 1.into()
+            },
+            Position {
+                row: 1.into(),
+                col: 5.into()
+            },
         ]
     );
 
@@ -574,8 +636,14 @@ mod tests {
         multiple_spaces_and_tab,
         "abc\t  def",
         vec![
-            Position { row: 1.into(), col: 1.into() },
-            Position { row: 1.into(), col: 7.into() },
+            Position {
+                row: 1.into(),
+                col: 1.into()
+            },
+            Position {
+                row: 1.into(),
+                col: 7.into()
+            },
         ]
     );
 
@@ -583,66 +651,123 @@ mod tests {
         linebreak_lf,
         "abc\ndef",
         vec![
-            Position { row: 1.into(), col: 1.into() },
-            Position { row: 2.into(), col: 1.into() },
+            Position {
+                row: 1.into(),
+                col: 1.into()
+            },
+            Position {
+                row: 2.into(),
+                col: 1.into()
+            },
         ]
     );
 
     gen_position_tests!(
         leading_whitespace_newline_tab,
         " \t\n\tabc",
-        vec![
-            Position { row: 2.into(), col: 2.into() },
-        ]
+        vec![Position {
+            row: 2.into(),
+            col: 2.into()
+        },]
     );
 
     gen_position_tests!(
         braces_and_colon_across_lines,
         "a:{\n\tb:1\n}",
         vec![
-            Position { row: 1.into(), col: 1.into() },
-            Position { row: 1.into(), col: 2.into() },
-            Position { row: 1.into(), col: 3.into() },
-            Position { row: 2.into(), col: 2.into() },
-            Position { row: 2.into(), col: 3.into() },
-            Position { row: 2.into(), col: 4.into() },
-            Position { row: 3.into(), col: 1.into() },
+            Position {
+                row: 1.into(),
+                col: 1.into()
+            },
+            Position {
+                row: 1.into(),
+                col: 2.into()
+            },
+            Position {
+                row: 1.into(),
+                col: 3.into()
+            },
+            Position {
+                row: 2.into(),
+                col: 2.into()
+            },
+            Position {
+                row: 2.into(),
+                col: 3.into()
+            },
+            Position {
+                row: 2.into(),
+                col: 4.into()
+            },
+            Position {
+                row: 3.into(),
+                col: 1.into()
+            },
         ]
     );
 
     #[test]
-    fn string_literal_position_after_newline_positions_space(){
+    fn string_literal_position_after_newline_positions_space() {
         let mut lexer = Lexer::new();
-        let got:Vec<Position>  = lexer.tokenize("abc\n\"x y\" z").unwrap().into_iter().map(|t|t.pos).collect();
-        assert_eq!(got,(vec![Position {
-            row:1.into(),col:1.into()
-        },Position {
-            row:2.into(),col:1.into()
-        },Position {
-            row:2.into(),col:7.into()
-        },]));
+        let got: Vec<Position> = lexer
+            .tokenize("abc\n\"x y\" z")
+            .unwrap()
+            .into_iter()
+            .map(|t| t.pos)
+            .collect();
+        assert_eq!(
+            got,
+            (vec![
+                Position {
+                    row: 1.into(),
+                    col: 1.into()
+                },
+                Position {
+                    row: 2.into(),
+                    col: 1.into()
+                },
+                Position {
+                    row: 2.into(),
+                    col: 7.into()
+                },
+            ])
+        );
     }
 
     #[test]
-    fn string_literal_position_after_newline_positions_no_space(){
+    fn string_literal_position_after_newline_positions_no_space() {
         let mut lexer = Lexer::new();
         let mut s = String::from("abc\n\"x y\" z");
         s.retain(|c| !c.is_whitespace());
-        let got:Vec<Position>  = lexer.tokenize(&s).unwrap().into_iter().map(|t|t.pos).collect();
-        let expected:Vec<Position> = vec![
-            Position { row: 1.into(), col: 1.into() },
-            Position { row: 1.into(), col: 4.into() },
-            Position { row: 1.into(), col: 8.into() },
+        let got: Vec<Position> = lexer
+            .tokenize(&s)
+            .unwrap()
+            .into_iter()
+            .map(|t| t.pos)
+            .collect();
+        let expected: Vec<Position> = vec![
+            Position {
+                row: 1.into(),
+                col: 1.into(),
+            },
+            Position {
+                row: 1.into(),
+                col: 4.into(),
+            },
+            Position {
+                row: 1.into(),
+                col: 8.into(),
+            },
         ];
-        assert_eq!(got,expected);
+        assert_eq!(got, expected);
     }
 
     #[test]
     fn unclosed_string_literal_returns_error() {
         let mut lexer = Lexer::new();
         assert!(matches!(
-                lexer.tokenize("abc \"unclosed"),
-                Err(LexerError::UnclosedStringLiteral(_))
+            lexer.tokenize("abc \"unclosed"),
+            Err(LexerError::UnclosedStringLiteral(_))
         ));
     }
 }

--- a/src/rule_tree/matcher.rs
+++ b/src/rule_tree/matcher.rs
@@ -1,7 +1,10 @@
 use nonempty::NonEmpty;
 use thiserror::Error;
 
-use crate::{frame::Octet, rule_tree::{Arm, ArmEnd, FieldValue, IpVer, MatchKind, Pattern, RuleError, RuleTree, Verdict}};
+use crate::{
+    frame::Octet,
+    rule_tree::{Arm, ArmEnd, FieldValue, IpVer, MatchKind, Pattern, RuleError, RuleTree, Verdict},
+};
 
 pub(crate) struct Match {
     kind: MatchKind,
@@ -33,14 +36,17 @@ pub(crate) struct MatchBuilder {
 
 impl MatchBuilder {
     pub(crate) fn with_arm(kind: MatchKind, pattern: Pattern, into: ArmEnd) -> Self {
-        Self { kind, arms: NonEmpty::new(Box::new(Arm { pattern, into })) }
-    }  
-       
+        Self {
+            kind,
+            arms: NonEmpty::new(Box::new(Arm { pattern, into })),
+        }
+    }
+
     pub(crate) fn arm(mut self, pattern: Pattern, into: ArmEnd) -> Self {
         self.arms.push(Box::new(Arm { pattern, into }));
         self
-    }  
-       
+    }
+
     pub(crate) fn build(self) -> Result<Match, RuleError> {
         let m = Match::new(self.kind, self.arms)?;
         Ok(m)
@@ -48,16 +54,30 @@ impl MatchBuilder {
 }
 
 fn test() -> Result<RuleTree, RuleError> {
-    Ok(RuleTree::new("test".into(), "testdesc".into(),
+    Ok(RuleTree::new(
+        "test".into(),
+        "testdesc".into(),
         MatchBuilder::with_arm(
             MatchKind::IpVer,
             Pattern::Equal(FieldValue::IpVer(super::IpVer::V4)),
             ArmEnd::Match(
                 MatchBuilder::with_arm(
                     MatchKind::SrcIp,
-                    Pattern::Glob(FieldValue::Ip(super::IP::new([Octet::Value(192), Octet::Value(168), Octet::Any, Octet::Any]))), ArmEnd::Verdict(Verdict::Allow)
-                ).build()?
-            )
-        ).arm(Pattern::Equal(FieldValue::IpVer(IpVer::V6)), ArmEnd::Verdict(Verdict::Drop)).build()?)
-    )
+                    Pattern::Glob(FieldValue::Ip(super::IP::new([
+                        Octet::Value(192),
+                        Octet::Value(168),
+                        Octet::Any,
+                        Octet::Any,
+                    ]))),
+                    ArmEnd::Verdict(Verdict::Allow),
+                )
+                .build()?,
+            ),
+        )
+        .arm(
+            Pattern::Equal(FieldValue::IpVer(IpVer::V6)),
+            ArmEnd::Verdict(Verdict::Drop),
+        )
+        .build()?,
+    ))
 }


### PR DESCRIPTION
Separate configuration management from packet handling with new ControlPlane, BackendApiClient, and PolicyStore abstractions. Add RedbSnapshotStore for persistence and emergency mode fallback.

Closes FW-177