### PR TITLE
feat(core): implement logout endpoint with session invalidation

### DIFF
--- a/backend/src/application/dtos/logout-user.dto.ts
+++ b/backend/src/application/dtos/logout-user.dto.ts
@@ -1,0 +1,3 @@
+export class LogoutUserDto {
+  accessToken: string;
+}

--- a/backend/src/application/use-cases/logout-user.use-case.ts
+++ b/backend/src/application/use-cases/logout-user.use-case.ts
@@ -1,0 +1,42 @@
+import { AccessTokenIsInvalidException } from 'src/domain/exceptions/acces-token-is-invalid.exception';
+import { UserNotFoundException } from 'src/domain/exceptions/user-not-found.exception';
+import { USER_REPOSITORY_TOKEN } from 'src/domain/repositories/user.repository';
+import type { IUserRepository } from 'src/domain/repositories/user.repository';
+import { TOKEN_SERVICE_TOKEN } from '../ports/token-service.interface';
+import type { ITokenService } from '../ports/token-service.interface';
+import { LogoutUserDto } from '../dtos/logout-user.dto';
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class LogoutUserUseCase {
+  constructor(
+    @Inject(USER_REPOSITORY_TOKEN)
+    private readonly userRepository: IUserRepository,
+    @Inject(TOKEN_SERVICE_TOKEN) private readonly tokenService: ITokenService,
+  ) {}
+
+  async execute(dto: LogoutUserDto): Promise<void> {
+    const verifiedToken = await this.tokenService.verifyAccessToken(
+      dto.accessToken,
+    );
+
+    if (!verifiedToken) throw new AccessTokenIsInvalidException();
+
+    const payload = this.tokenService.decodeAccessToken(dto.accessToken);
+
+    if (!payload) throw new AccessTokenIsInvalidException();
+
+    const user = await this.userRepository.findById(payload.sub);
+
+    if (!user) throw new UserNotFoundException(payload.sub);
+
+    user.setRefreshToken(null);
+    user.setRefreshTokenExpiry(null);
+
+    await this.userRepository.setRefreshToken(
+      user.getId(),
+      user.getRefreshToken(),
+      user.getRefreshTokenExpiry(),
+    );
+  }
+}

--- a/backend/src/domain/entities/user.entity.ts
+++ b/backend/src/domain/entities/user.entity.ts
@@ -78,7 +78,7 @@ export class User {
     this.refreshToken = refreshToken;
   }
 
-  public setRefreshTokenExpiry(refreshTokenExpiry: Date): void {
+  public setRefreshTokenExpiry(refreshTokenExpiry: Date | null): void {
     this.refreshTokenExpiry = refreshTokenExpiry;
   }
 }

--- a/backend/src/modules/auth.module.ts
+++ b/backend/src/modules/auth.module.ts
@@ -3,6 +3,7 @@ import { BcryptPasswordHasher } from 'src/infrastructure/adapters/bcrypt-passwor
 import { PASSWORD_HASHER_TOKEN } from 'src/application/ports/passowrd-hasher.interface';
 import { RefreshTokenUseCase } from 'src/application/use-cases/refresh-token.use-case';
 import { TOKEN_SERVICE_TOKEN } from 'src/application/ports/token-service.interface';
+import { LogoutUserUseCase } from 'src/application/use-cases/logout-user.use-case';
 import { LoginUserUseCase } from 'src/application/use-cases/login-user.use-case';
 import { USER_REPOSITORY_TOKEN } from 'src/domain/repositories/user.repository';
 import { AuthController } from 'src/presentation/controllers/auth.controller';
@@ -16,6 +17,7 @@ import { Module } from '@nestjs/common';
   providers: [
     LoginUserUseCase,
     RefreshTokenUseCase,
+    LogoutUserUseCase,
     {
       provide: PASSWORD_HASHER_TOKEN,
       useClass: BcryptPasswordHasher,

--- a/backend/src/presentation/controllers/auth.controller.ts
+++ b/backend/src/presentation/controllers/auth.controller.ts
@@ -15,6 +15,7 @@ import {
 } from '../dtos/error-response.dto';
 import { RefreshTokenUseCase } from 'src/application/use-cases/refresh-token.use-case';
 import { ExtractToken } from 'src/infrastructure/decorators/extract-token.decorator';
+import { LogoutUserUseCase } from 'src/application/use-cases/logout-user.use-case';
 import { LoginUserUseCase } from 'src/application/use-cases/login-user.use-case';
 import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
 import { RefreshTokenResponseDto } from '../dtos/refresh-token-response.dto';
@@ -33,9 +34,10 @@ import { LoginDto } from '../dtos/login.dto';
 export class AuthController {
   private readonly logger = new Logger(AuthController.name);
   constructor(
-    @Inject() private readonly loginUserUseCase: LoginUserUseCase,
     @Inject() private readonly refreshTokenUseCase: RefreshTokenUseCase,
     @Inject() private readonly configService: ConfigService<Env, true>,
+    @Inject() private readonly logoutUserUseCase: LogoutUserUseCase,
+    @Inject() private readonly loginUserUseCase: LoginUserUseCase,
   ) {}
 
   @IsPublic()
@@ -131,5 +133,38 @@ export class AuthController {
     return {
       accessToken: useCase.accessToken,
     };
+  }
+
+  @ApiOperation({
+    summary: 'User logout',
+    description:
+      'Logs out the user by invalidating the current access token and clearing the refresh token cookie. The access token should be sent in the Authorization header as a Bearer token. Upon successful logout, the refresh token cookie will be cleared.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'User logged out',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid access token format',
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Internal server error',
+  })
+  @Post('logout')
+  async logout(
+    @ExtractToken() accessToken: string,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<void> {
+    await this.logoutUserUseCase.execute({ accessToken });
+
+    res.clearCookie('refresh_token', {
+      httpOnly: true,
+      secure: this.configService.get('NODE_ENV') === 'development',
+      sameSite: 'strict',
+      maxAge: 60 * 60 * 1000,
+      path: '/auth/refresh',
+    });
   }
 }


### PR DESCRIPTION
Add POST /auth/logout endpoint that invalidates user session by clearing refresh token. Includes logout use case and user entity update.

Closes BE-66
