### PR TITLE
feat(core): implement rate limiting on auth login endpoint

### DIFF
--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -15,6 +15,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.2.6",
+        "@nestjs/throttler": "^6.5.0",
         "@scalar/nestjs-api-reference": "^1.1.2",
         "@types/passport-jwt": "^4.0.1",
         "bcrypt": "^6.0.0",
@@ -400,6 +401,8 @@
     "@nestjs/swagger": ["@nestjs/swagger@11.2.6", "", { "dependencies": { "@microsoft/tsdoc": "0.16.0", "@nestjs/mapped-types": "2.1.0", "js-yaml": "4.1.1", "lodash": "4.17.23", "path-to-regexp": "8.3.0", "swagger-ui-dist": "5.31.0" }, "peerDependencies": { "@fastify/static": "^8.0.0 || ^9.0.0", "@nestjs/common": "^11.0.1", "@nestjs/core": "^11.0.1", "class-transformer": "*", "class-validator": "*", "reflect-metadata": "^0.1.12 || ^0.2.0" }, "optionalPeers": ["@fastify/static", "class-transformer", "class-validator"] }, "sha512-oiXOxMQqDFyv1AKAqFzSo6JPvMEs4uA36Eyz/s2aloZLxUjcLfUMELSLSNQunr61xCPTpwEOShfmO7NIufKXdA=="],
 
     "@nestjs/testing": ["@nestjs/testing@11.1.16", "", { "dependencies": { "tslib": "2.8.1" }, "peerDependencies": { "@nestjs/common": "^11.0.0", "@nestjs/core": "^11.0.0", "@nestjs/microservices": "^11.0.0", "@nestjs/platform-express": "^11.0.0" }, "optionalPeers": ["@nestjs/microservices", "@nestjs/platform-express"] }, "sha512-E7/aUCxzeMSJV80L5GWGIuiMyR/1ncS7uOIetAImfbS4ATE1/h2GBafk0qpk+vjFtPIbtoh9BWDGICzUEU5jDA=="],
+
+    "@nestjs/throttler": ["@nestjs/throttler@6.5.0", "", { "peerDependencies": { "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0", "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0", "reflect-metadata": "^0.1.13 || ^0.2.0" } }, "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.2.6",
+    "@nestjs/throttler": "^6.5.0",
     "@scalar/nestjs-api-reference": "^1.1.2",
     "@types/passport-jwt": "^4.0.1",
     "bcrypt": "^6.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { JwtAuthGuard } from './infrastructure/adapters/jwt-auth.guard';
 import { JwtStrategy } from './infrastructure/adapters/jwt.strategy';
 import { GrpcModule } from './infrastructure/grpc/grpc.module';
 import { validate } from './shared/config/env.validation';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { AuthModule } from './modules/auth.module';
 import { PassportModule } from '@nestjs/passport';
 import { AppController } from './app.controller';
@@ -16,6 +17,12 @@ import { Module } from '@nestjs/common';
       isGlobal: true,
       validate,
     }),
+    ThrottlerModule.forRoot([
+      {
+        ttl: 60000, // 1 minuta
+        limit: 100, // 100 requestów globalnie
+      },
+    ]),
     DatabaseModule,
     PassportModule,
     AuthModule,

--- a/backend/src/presentation/controllers/auth.controller.ts
+++ b/backend/src/presentation/controllers/auth.controller.ts
@@ -27,6 +27,7 @@ import { Env } from 'src/shared/config/env.validation';
 import type { Request, Response } from 'express';
 import { ConfigService } from '@nestjs/config';
 import { LoginDto } from '../dtos/login.dto';
+import { Throttle } from '@nestjs/throttler';
 
 @UseFilters(DomainExceptionFilter)
 @ApiTags('Authentication')
@@ -68,6 +69,7 @@ export class AuthController {
     status: 500,
     description: 'Internal server error',
   })
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   async login(
     @Body() loginDto: LoginDto,
     @Res({ passthrough: true }) res: Response,


### PR DESCRIPTION
Add rate limiting protection to POST /auth/login with max 5 attempts per minute. Uses @nestjs/throttler to prevent brute force attacks.

Closes BE-68