### PR TITLE
test(core): fix backend auth controller tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -85,11 +85,6 @@
     "typescript-eslint": "^8.20.0"
   },
   "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
@@ -99,6 +94,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/backend/src/presentation/controllers/auth.controller.spec.ts
+++ b/backend/src/presentation/controllers/auth.controller.spec.ts
@@ -1,16 +1,14 @@
 import { RefreshTokenUseCase } from 'src/application/use-cases/refresh-token.use-case';
+import { LogoutUserUseCase } from 'src/application/use-cases/logout-user.use-case';
 import { LoginUserUseCase } from 'src/application/use-cases/login-user.use-case';
-import { Test, TestingModule } from '@nestjs/testing';
+import { TestingModule, Test } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
 import { ConfigService } from '@nestjs/config';
-import type { Response } from 'express';
-
 describe('AuthController', () => {
   let controller: AuthController;
   let loginUserUseCase: jest.Mocked<LoginUserUseCase>;
   let refreshTokenUseCase: jest.Mocked<RefreshTokenUseCase>;
   let configService: jest.Mocked<ConfigService>;
-
   // Mock obiektu odpowiedzi Express do testowania ciasteczek
   let mockResponse: jest.Mocked<Partial<Response>>;
   beforeEach(async () => {
@@ -26,7 +24,6 @@ describe('AuthController', () => {
     configService = {
       get: jest.fn(),
     } as any;
-
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
       providers: [
@@ -42,19 +39,20 @@ describe('AuthController', () => {
           provide: ConfigService,
           useValue: configService,
         },
+        {
+          provide: LogoutUserUseCase,
+          useValue: { execute: jest.fn() },
+        },
       ],
     }).compile();
     controller = module.get<AuthController>(AuthController);
   });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
-
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
-
   describe('login', () => {
     it('should authenticate user, set cookie and return access token', async () => {
       // Przygotowanie danych testowych
@@ -64,23 +62,19 @@ describe('AuthController', () => {
         refreshToken: 'mock-refresh-token',
         // Inne potencjalne dane z login response
       };
-
       // Zachowanie mocków
       loginUserUseCase.execute.mockResolvedValue(expectedResponse);
       configService.get.mockImplementation((key) => {
         if (key === 'NODE_ENV') return 'development';
         return undefined;
       });
-
       // Wykonanie testowanej metody
       const result = await controller.login(loginDto, mockResponse as Response);
-
       // Asercje (sprawdzenia)
       expect(loginUserUseCase.execute).toHaveBeenCalledWith({
         username: 'testuser',
         password: 'password123',
       });
-
       expect(mockResponse.cookie).toHaveBeenCalledWith(
         'refresh_token',
         'mock-refresh-token',
@@ -92,62 +86,50 @@ describe('AuthController', () => {
           path: '/auth/refresh',
         },
       );
-
       // Wynik nie powinien zawierać refreshTokena, bo ten ląduje tylko w ciastku
       expect(result).toEqual({ accessToken: 'mock-access-token' });
     });
   });
-
   describe('refresh', () => {
     it('should refresh access token WITHOUT rotating refresh token (cookie not set)', async () => {
       const accessToken = 'old-access-token';
       const refreshToken = 'valid-refresh-token';
-
       const expectedResponse = {
         accessToken: 'new-access-token',
         // Brak refreshToken w odpowiedzi z UseCase
       };
-
       refreshTokenUseCase.execute.mockResolvedValue(expectedResponse);
       const result = await controller.refresh(
         accessToken,
         refreshToken,
         mockResponse as Response,
       );
-
       expect(refreshTokenUseCase.execute).toHaveBeenCalledWith({
         accessToken,
         refreshToken,
       });
-
       // Sprawdzamy czy metoda cookie NIE została wywołana, bo nie dostaliśmy nowego od UseCase
       expect(mockResponse.cookie).not.toHaveBeenCalled();
       expect(result).toEqual({ accessToken: 'new-access-token' });
     });
-
     it('should refresh access token AND set new cookie when refresh token is rotated', async () => {
       const accessToken = 'old-access-token';
       const refreshToken = 'valid-refresh-token';
-
       const expectedResponse = {
         accessToken: 'new-access-token',
         refreshToken: 'rotated-refresh-token', // Use case zwrócił nowy RT
       };
-
       refreshTokenUseCase.execute.mockResolvedValue(expectedResponse);
       configService.get.mockReturnValue('development');
-
       const result = await controller.refresh(
         accessToken,
         refreshToken,
         mockResponse as Response,
       );
-
       expect(refreshTokenUseCase.execute).toHaveBeenCalledWith({
         accessToken,
         refreshToken,
       });
-
       // Tutaj oczekujemy, że zostanie zapisane ciastko z NOWYM 'rotated-refresh-token'
       // UWAGA: Test ten nie przejdzie na obecnym kodzie AuthController. W linii 122 jest błąd:
       // res.cookie('refresh_token', refreshToken, {...}) (przekazujesz stary zamiast useCase.refreshToken)


### PR DESCRIPTION
Update test cases and dependencies to fix failing auth controller tests.

Closes BE-98
