### PR TITLE
feat(firewall): add zero-copy RGPF/1 policy parser and validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,7 @@ dependencies = [
  "tun",
  "uuid",
  "visibility",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1699,6 +1700,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.9.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c9c378180b968f2e98efa0c4bba8c49fd4cd247dc82a7f01e72dc137d447d8c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.9.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36811c5ea90dd441f941919fc99163e702f150a8e1495d72a268106a0100df09"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ rcgen = { version = "0.13", features = ["pem"] }
 ring = "0.17"
 bytes = "1.11.1"
 nix = { version = "0.31.2", features = ["net"] }
+zerocopy = { version = "0.9.0-alpha.0", features = ["derive"] }

--- a/docs/rgipc-rgpf-spec.md
+++ b/docs/rgipc-rgpf-spec.md
@@ -2,19 +2,23 @@
 
 ## Status dokumentu
 
-Ten dokument opisuje **docelowy** protokół IPC i **docelowy** binarny format polityki dla RaptorGate.
+Ten dokument opisuje **aktualnie zaimplementowany** protokół IPC i **aktualnie zaimplementowany** binarny format polityki dla RaptorGate.
 
-Nie jest to opis aktualnej implementacji repozytorium. Obecny kod nadal używa:
+Dokument został dopasowany do bieżącego stanu repozytorium. Na dziś w kodzie znajdują się:
 
-- `gRPC over Unix Domain Socket` po stronie komunikacji z backendem,
-- protobuf `ConfigResponse` jako formatu lokalnej migawki,
-- pojedynczego `RuleTree` w evaluatorze polityki.
+- działające `RGIPC/1` nad `AF_UNIX/SOCK_STREAM`,
+- typowane wiadomości IPC oparte o `IpcMessage`, `IpcRequestMessage`, `IpcResponseMessage` i `IpcEventMessage`,
+- endpoint synchroniczny `SyncIpcEndpoint` i endpoint asynchroniczny `AsyncIpcEndpoint`,
+- runtime po stronie firewalla używający lokalnych gniazd synchronicznego i asynchronicznego IPC,
+- parser `RGPF/1` typu zero-copy oparty o `zerocopy`,
+- loader `RGPF/1 -> CompiledPolicy`, który obecnie obsługuje dokładnie jedno drzewo reguł filtrowania,
+- parser i walidator sekcji `NAT_RULE_TABLE`, ale bez pełnego załadowania NAT do aktywnego runtime.
 
-Dokument należy traktować jako specyfikację przebudowy, na podstawie której można wdrożyć nową warstwę IPC oraz `policy.bin`.
+Dokument należy traktować jako opis obowiązującego kontraktu oraz jego bieżących ograniczeń implementacyjnych.
 
 ## 1. Cel
 
-Docelowa architektura rozdziela odpowiedzialności w prosty sposób:
+Kontrakt systemowy rozdziela odpowiedzialności w prosty sposób:
 
 - backend waliduje konfigurację źródłową i publikuje rewizję,
 - firewall ładuje lokalną migawkę `active/policy.bin`,
@@ -33,7 +37,8 @@ Poza zakresem dokumentu pozostają:
 
 - transport inny niż UDS,
 - serializacja pełnego backendowego modelu konfiguracji,
-- NAT, QoS, DPI, identity, VLAN, app-id i inne funkcje spoza obecnego evaluatora polityki.
+- aktywny runtime NAT po stronie loadera `RGPF/1`,
+- QoS, DPI, identity, VLAN, app-id i inne funkcje spoza obecnego evaluatora polityki.
 
 ## 3. Architektura IPC
 
@@ -73,7 +78,7 @@ Protokół wspiera dwa modele wymiany:
 - żądanie-odpowiedź: `REQUEST -> RESPONSE | ERROR`
 - komunikacja zdarzeniowa: `EVENT` bez wymaganej odpowiedzi
 
-W MVP jedynym zdarzeniem jest `HEARTBEAT`.
+W aktualnej implementacji jedynym zdefiniowanym zdarzeniem jest `HEARTBEAT`.
 
 ### 4.1. Typy pól
 
@@ -155,7 +160,7 @@ payload      : [payload_len bytes]
 - `0x00 = NONE`
 - `0x01 = ACK_REQUIRED`
 - `0x02 = CRITICAL`
-- `0x04 = NOREPLY`
+- `0x04 = NO_REPLY`
 
 `opcode`
 
@@ -362,18 +367,32 @@ Rekomendowany interwał:
 
 ### 8.1. Kanał synchroniczny
 
-Klient:
+Kanał synchroniczny w aktualnej implementacji jest modelowany jako **dwukierunkowy endpoint** request-response. Oznacza to, że każda strona połączenia może:
 
 1. otwiera połączenie,
-2. wysyła `REQUEST`,
-3. odbiera `RESPONSE` albo `ERROR`,
-4. może utrzymać połączenie dla kolejnych żądań albo je zamknąć.
+2. wysyłać `REQUEST`,
+3. odbierać `REQUEST`,
+4. odsyłać `RESPONSE` albo `ERROR`,
+5. utrzymywać połączenie dla kolejnych wiadomości albo je zamknąć.
+
+W repo odpowiada za to typ `SyncIpcEndpoint`, który:
+
+- buduje `REQUEST` z typowanego requestu,
+- waliduje `magic`, `version`, `kind`, `opcode`, `request_id` i `status`,
+- potrafi odbierać typowane requesty od drugiej strony,
+- potrafi odsyłać typowane `RESPONSE` i surowe `ERROR`.
 
 W `RGIPC/1` nie ma osobnego komunikatu `HELLO`.
 
 ### 8.2. Kanał asynchroniczny
 
-Firewall:
+Kanał asynchroniczny w aktualnej implementacji jest modelowany jako endpoint zdarzeń. Po stronie repo odpowiada za to `AsyncIpcEndpoint`, który:
+
+- wysyła typowane `EVENT`,
+- automatycznie ustawia `kind = EVENT`, `request_id = 0` i kolejny `sequence_no`,
+- potrafi odbierać typowane eventy i walidować `magic`, `version`, `opcode`, `request_id` i `status`.
+
+W aktualnym runtime firewalla:
 
 1. otwiera połączenie,
 2. utrzymuje je przez cały czas działania sesji,
@@ -407,6 +426,18 @@ Wszystkie wartości wielobajtowe są zapisane jako:
 Struktury pokazane w dokumencie opisują układ bajtów w pliku, a nie układ pamięci kompilatora. Serializacja odbywa się pole po polu, bez ukrytego paddingu.
 
 Wszystkie offsety zapisane wewnątrz sekcji są liczone od początku danej sekcji, chyba że przy polu zapisano inaczej.
+
+### 9.2.1. Stan implementacji parsera
+
+Aktualna implementacja repozytorium używa parsera typu zero-copy.
+
+Oznacza to, że:
+
+- plik `policy.bin` jest parsowany na widoki oparte o `&[u8]`,
+- rekordy stałej szerokości są mapowane bezpośrednio z bufora wejściowego,
+- rekordy zmiennej długości i wszystkie offsety są sprawdzane jawnie pod kątem granic bufora,
+- parser korzysta z biblioteki `zerocopy` do bezpiecznego mapowania struktur fixed-size,
+- alokacje są dopuszczalne dopiero na etapie loadera do aktualnego runtime.
 
 ### 9.3. Zakres `v1`
 
@@ -455,6 +486,14 @@ pub struct NatRule {
 ```
 
 W obecnym kodzie repozytorium pełna wersja tego modelu nie jest jeszcze zaimplementowana. Istnieje jedynie uproszczona reprezentacja runtime `NatRuleDummy`, która zawiera podzbiór pól potrzebnych do obecnego silnika NAT.
+
+Aktualny parser `RGPF/1` potrafi już:
+
+- parsować sekcję `NAT_RULE_TABLE`,
+- walidować jej nagłówek, rekordy i referencje,
+- udostępniać widoki zero-copy na dane NAT.
+
+Aktualny loader runtime **nie** materializuje jeszcze tej sekcji do aktywnego runtime NAT.
 
 Poza zakresem `v1`:
 
@@ -880,7 +919,7 @@ Jest to domyślny werdykt używany wtedy, gdy żadna reguła nie zakończy ewalu
 
 ## 18.1. Sekcja `NAT_RULE_TABLE`
 
-Format `RGPF/1` przewiduje możliwość przechowywania również reguł NAT. Sekcja ta jest opcjonalna i może nie występować w pierwszej iteracji wdrożenia.
+Format `RGPF/1` przewiduje możliwość przechowywania również reguł NAT. Sekcja ta jest opcjonalna na poziomie pliku, ale jest już obsługiwana przez aktualny parser i walidator repozytorium.
 
 Celem tej sekcji jest zapis reguł NAT w formie skompilowanej, ale nadal bliskiej modelowi domenowemu:
 
@@ -903,6 +942,12 @@ Stan obecny repozytorium:
 - aktualny silnik NAT używa uproszczonej struktury `NatRuleDummy`,
 - uproszczona wersja zawiera obecnie pola: `id`, `priority`, `match_criteria`, `kind`, `timeouts`,
 - `NatStage` istnieje już w kodzie i wspiera wartości `Prerouting` oraz `Postrouting`.
+
+Stan implementacji `RGPF/1`:
+
+- sekcja `NAT_RULE_TABLE` jest parsowana,
+- sekcja `NAT_RULE_TABLE` jest walidowana,
+- brak jeszcze adaptera, który ładuje te dane do aktywnego runtime NAT.
 
 Wymagania dla formatu binarnego:
 
@@ -1219,7 +1264,7 @@ Zasada ogólna:
 - `0x00 = NONE`
 - `0x01 = ACK_REQUIRED`
 - `0x02 = CRITICAL`
-- `0x04 = NOREPLY`
+- `0x04 = NO_REPLY`
 
 Flagi mogą być łączone bitowo.
 
@@ -1457,7 +1502,16 @@ Przykłady błędów walidacji:
 - offset wychodzący poza granice sekcji,
 - `root_node_index >= node_count`.
 
+W aktualnej implementacji walidacja obejmuje również:
+
+- CRC32C całego pliku przy wyzerowanym polu `file_crc32c`,
+- brak duplikatów wymaganych sekcji,
+- pełną walidację `RULE_TREE_TABLE`,
+- walidację `NAT_RULE_TABLE`, jeśli sekcja występuje.
+
 ## 21. Publikacja rewizji
+
+Ta sekcja opisuje docelowy kontrakt współpracy backendu i firewalla wokół `policy.bin`. Na bieżącej gałęzi zaimplementowane są przede wszystkim firewall-side IPC oraz parser, walidator i loader `RGPF/1`.
 
 ### 21.1. Backend
 
@@ -1481,6 +1535,8 @@ Firewall:
 
 ## 22. MVP
 
+Ta sekcja opisuje stan zaimplementowany na dziś, a nie planowaną pierwszą iterację.
+
 ### 22.1. IPC
 
 Gniazda:
@@ -1494,6 +1550,15 @@ Wiadomości:
 - `GET_STATUS`
 - `GET_NETWORK_INTERFACES`
 - `HEARTBEAT`
+
+Aktualna implementacja IPC zawiera dodatkowo:
+
+- typowane requesty: `PingRequest`, `GetStatusRequest`, `GetNetworkInterfacesRequest`,
+- typowane response: `PingResponse`, `GetStatusResponse`, `GetNetworkInterfacesResponse`,
+- typowany event: `HeartbeatEvent`,
+- wspólne trait-y wiadomości: `IpcMessage`, `IpcRequestMessage`, `IpcResponseMessage`, `IpcEventMessage`,
+- `SyncIpcEndpoint` jako dwukierunkowy endpoint request-response,
+- `AsyncIpcEndpoint` jako endpoint eventów.
 
 ### 22.2. `policy.bin`
 
@@ -1509,7 +1574,9 @@ Obsługiwany model wykonywania:
 - obecny `MatchKind`,
 - obecny `Pattern`,
 - obecny `Verdict`,
-- oraz docelowo reguły NAT, przy czym na dziś implementacja runtime odpowiada tylko zakresowi `NatRuleDummy`.
+- parser i walidator `NAT_RULE_TABLE`,
+- loader do obecnego `CompiledPolicy`, który obsługuje dokładnie jedno drzewo reguł filtrowania,
+- brak aktywnego załadowania NAT do runtime, mimo że sekcja NAT jest już parsowana i walidowana.
 
 ## 23. Najważniejsze decyzje projektowe
 
@@ -1530,9 +1597,16 @@ IPC:
 
 ## 24. Podsumowanie
 
-Docelowa architektura opiera się na dwóch spójnych elementach:
+Aktualna implementacja repozytorium opiera się na dwóch spójnych elementach:
 
 - `RGIPC/1` jako lekkim lokalnym protokole komunikacji sterującej,
 - `RGPF/1` jako binarnej migawce polityki wykonywanej przez firewall.
 
-Backend pozostaje odpowiedzialny za walidację i publikację rewizji. Firewall ładuje lokalne `policy.bin`, działa niezależnie od bazy danych i traktuje aktywną rewizję jako źródło prawdy po stronie wykonawczej.
+Po stronie IPC w repo istnieją już działające typowane endpointy synchroniczne i asynchroniczne oraz runtime firewalla korzystający z tych kanałów.
+
+Po stronie `RGPF/1` istnieje już parser zero-copy z walidacją sekcji, loader do aktualnego `CompiledPolicy` oraz obsługa opcjonalnej sekcji `NAT_RULE_TABLE`.
+
+Najważniejsze bieżące ograniczenia implementacyjne są dwa:
+
+- loader filtrowania obsługuje obecnie dokładnie jedno drzewo reguł,
+- sekcja NAT jest parsowana i walidowana, ale nie jest jeszcze ładowana do aktywnego runtime NAT.

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -1,2 +1,3 @@
-pub mod compiler;
+pub mod rgpf;
 pub mod runtime;
+pub mod compiler;

--- a/src/policy/rgpf/constants.rs
+++ b/src/policy/rgpf/constants.rs
@@ -1,0 +1,73 @@
+pub const RGPF_MAGIC: u32 = u32::from_le_bytes(*b"RGPF");
+pub const RGPF_MAJOR: u16 = 1;
+pub const RGPF_MINOR: u16 = 0;
+pub const NO_INDEX: u32 = u32::MAX;
+
+pub const SECTION_STRING_TABLE: u16 = 1;
+pub const SECTION_RULE_TREE_TABLE: u16 = 2;
+pub const SECTION_DEFAULT_VERDICT: u16 = 3;
+pub const SECTION_NAT_RULE_TABLE: u16 = 4;
+
+pub const NODE_KIND_MATCH: u8 = 1;
+pub const NODE_KIND_VERDICT: u8 = 2;
+
+pub const PATTERN_KIND_WILDCARD: u8 = 1;
+pub const PATTERN_KIND_EQUAL: u8 = 2;
+pub const PATTERN_KIND_GLOB: u8 = 3;
+pub const PATTERN_KIND_RANGE: u8 = 4;
+pub const PATTERN_KIND_COMPARISON: u8 = 5;
+pub const PATTERN_KIND_OR: u8 = 6;
+
+pub const FIELD_VALUE_IP: u8 = 1;
+pub const FIELD_VALUE_IP_VER: u8 = 2;
+pub const FIELD_VALUE_DAY_OF_WEEK: u8 = 3;
+pub const FIELD_VALUE_HOUR: u8 = 4;
+pub const FIELD_VALUE_PROTOCOL: u8 = 5;
+pub const FIELD_VALUE_PORT: u8 = 6;
+
+pub const MATCH_KIND_SRC_IP: u8 = 1;
+pub const MATCH_KIND_DST_IP: u8 = 2;
+pub const MATCH_KIND_IP_VER: u8 = 3;
+pub const MATCH_KIND_DAY_OF_WEEK: u8 = 4;
+pub const MATCH_KIND_HOUR: u8 = 5;
+pub const MATCH_KIND_PROTOCOL: u8 = 6;
+pub const MATCH_KIND_SRC_PORT: u8 = 7;
+pub const MATCH_KIND_DST_PORT: u8 = 8;
+
+pub const COMPARISON_GREATER: u8 = 1;
+pub const COMPARISON_LESSER: u8 = 2;
+pub const COMPARISON_GREATER_OR_EQUAL: u8 = 3;
+pub const COMPARISON_LESSER_OR_EQUAL: u8 = 4;
+
+pub const VERDICT_ALLOW: u8 = 1;
+pub const VERDICT_DROP: u8 = 2;
+pub const VERDICT_ALLOW_WARN: u8 = 3;
+pub const VERDICT_DROP_WARN: u8 = 4;
+
+pub const IP_VER_V4: u8 = 1;
+pub const IP_VER_V6: u8 = 2;
+
+pub const PROTOCOL_TCP: u8 = 1;
+pub const PROTOCOL_UDP: u8 = 2;
+pub const PROTOCOL_ICMP: u8 = 3;
+
+pub const WEEKDAY_MON: u8 = 1;
+pub const WEEKDAY_TUE: u8 = 2;
+pub const WEEKDAY_WED: u8 = 3;
+pub const WEEKDAY_THU: u8 = 4;
+pub const WEEKDAY_FRI: u8 = 5;
+pub const WEEKDAY_SAT: u8 = 6;
+pub const WEEKDAY_SUN: u8 = 7;
+
+pub const NAT_STAGE_PREROUTING: u8 = 1;
+pub const NAT_STAGE_POSTROUTING: u8 = 2;
+
+pub const NAT_PROTO_ANY: u8 = 1;
+pub const NAT_PROTO_TCP: u8 = 2;
+pub const NAT_PROTO_UDP: u8 = 3;
+pub const NAT_PROTO_ICMP: u8 = 4;
+
+pub const NAT_KIND_SNAT: u8 = 1;
+pub const NAT_KIND_MASQUERADE: u8 = 2;
+pub const NAT_KIND_DNAT: u8 = 3;
+pub const NAT_KIND_PAT: u8 = 4;

--- a/src/policy/rgpf/endian.rs
+++ b/src/policy/rgpf/endian.rs
@@ -1,0 +1,1 @@
+pub use zerocopy::byteorder::little_endian::{U16 as LeU16, U32 as LeU32, U64 as LeU64};

--- a/src/policy/rgpf/errors/mod.rs
+++ b/src/policy/rgpf/errors/mod.rs
@@ -1,0 +1,1 @@
+pub mod rgpf_error;

--- a/src/policy/rgpf/errors/rgpf_error.rs
+++ b/src/policy/rgpf/errors/rgpf_error.rs
@@ -1,0 +1,50 @@
+#[derive(Debug, thiserror::Error)]
+pub enum RgpfError {
+    #[error("invalid rgpf magic: {0:#010x}")]
+    InvalidMagic(u32),
+
+    #[error("unsupported rgpf version: {major}.{minor}")]
+    UnsupportedVersion { major: u16, minor: u16 },
+
+    #[error("invalid header length: {0}")]
+    InvalidHeaderLength(u16),
+
+    #[error("invalid file length: declared {declared}, actual {actual}")]
+    InvalidFileLength { declared: u64, actual: usize },
+
+    #[error("invalid crc32c")]
+    InvalidCrc32c,
+
+    #[error("missing required section: {0}")]
+    MissingSection(&'static str),
+
+    #[error("duplicate section kind: {0}")]
+    DuplicateSection(u16),
+
+    #[error("invalid section: {0}")]
+    InvalidSection(&'static str),
+
+    #[error("section is out of bounds")]
+    SectionOutOfBounds,
+
+    #[error("offset is out of bounds")]
+    OffsetOutOfBounds,
+
+    #[error("integer overflow while validating layout")]
+    IntegerOverflow,
+
+    #[error("invalid utf-8 in string table")]
+    InvalidUtf8,
+
+    #[error("invalid enum value for {field}: {value}")]
+    InvalidEnum { field: &'static str, value: u64 },
+
+    #[error("invalid boolean value: {0}")]
+    InvalidBool(u8),
+
+    #[error("invalid layout: {0}")]
+    InvalidLayout(&'static str),
+
+    #[error("unsupported layout: {0}")]
+    UnsupportedLayout(&'static str),
+}

--- a/src/policy/rgpf/load/compiled_policy.rs
+++ b/src/policy/rgpf/load/compiled_policy.rs
@@ -1,0 +1,284 @@
+use crate::frame::{Hour, IP, IpVer, Octet, Port, Protocol, Weekday};
+
+use crate::policy_evaluator::PolicyEvaluator;
+use crate::policy::rgpf::errors::rgpf_error::RgpfError;
+use crate::policy::rgpf::sections::rgpf_file::RgpfFile;
+use crate::policy::runtime::{CompiledPolicy, PolicyMetadata, PolicySource};
+use crate::rule_tree::{ArmEnd, FieldValue, MatchBuilder, MatchKind, Operation, Pattern, RuleTree, Verdict};
+use crate::policy::rgpf::sections::rule_tree::sections::{FieldValueSection, PatternSection, RuleTreeSection};
+
+use crate::policy::rgpf::constants::{
+    NO_INDEX,
+    IP_VER_V4,
+    IP_VER_V6,
+    WEEKDAY_FRI,
+    WEEKDAY_MON,
+    WEEKDAY_SAT,
+    WEEKDAY_SUN,
+    WEEKDAY_THU,
+    WEEKDAY_TUE,
+    WEEKDAY_WED,
+    PROTOCOL_UDP,
+    PROTOCOL_TCP,
+    VERDICT_DROP,
+    PROTOCOL_ICMP,
+    VERDICT_ALLOW,
+    MATCH_KIND_HOUR,
+    NODE_KIND_MATCH,
+    NODE_KIND_VERDICT,
+    MATCH_KIND_SRC_IP,
+    MATCH_KIND_DST_IP,
+    COMPARISON_LESSER,
+    VERDICT_DROP_WARN,
+    MATCH_KIND_IP_VER,
+    VERDICT_ALLOW_WARN,
+    COMPARISON_GREATER,
+    MATCH_KIND_PROTOCOL,
+    MATCH_KIND_DST_PORT,
+    MATCH_KIND_SRC_PORT,
+    MATCH_KIND_DAY_OF_WEEK,
+    COMPARISON_LESSER_OR_EQUAL,
+    COMPARISON_GREATER_OR_EQUAL,
+};
+
+pub fn load_compiled_policy(file: &RgpfFile<'_>) -> Result<CompiledPolicy, RgpfError> {
+    let strings = file.string_table()?;
+    
+    let rule_tree = file.rule_tree()?;
+    
+    let default_verdict = file.default_verdict()?;
+
+    if rule_tree.rules().len() != 1 {
+        return Err(RgpfError::UnsupportedLayout("current runtime supports exactly one filter rule"));
+    }
+
+    let rule = &rule_tree.rules()[0];
+    
+    let name = strings.get(rule.name_str_off.get())?.to_owned();
+    
+    let description = if rule.desc_str_off.get() == 0 {
+        String::new()
+    } else {
+        strings.get(rule.desc_str_off.get())?.to_owned()
+    };
+    
+    let head = build_match(file, &rule_tree, rule.root_node_index.get(), &mut Vec::new())?;
+    
+    let default_verdict = build_verdict(file, default_verdict.verdict())?;
+
+    Ok(CompiledPolicy::new(
+        PolicyMetadata {
+            config_version: Some(file.header().revision_id.get()),
+            bundle_checksum: Some(format!("{:016x}", file.header().policy_hash.get())),
+            source: PolicySource::Snapshot,
+            rule_count: rule_tree.rules().len(),
+        },
+        PolicyEvaluator::new(RuleTree::new(name, description, head), default_verdict),
+    ))
+}
+
+fn build_match(file: &RgpfFile<'_>, section: &RuleTreeSection<'_>, root_index: u32, stack: &mut Vec<u32>) -> Result<crate::rule_tree::matcher::Match, RgpfError> {
+    if stack.contains(&root_index) {
+        return Err(RgpfError::InvalidLayout("cycle detected in rule graph"));
+    }
+
+    stack.push(root_index);
+
+    let root = section.node(root_index)?;
+    
+    if root.node_kind != NODE_KIND_MATCH {
+        stack.pop();
+        return Err(RgpfError::InvalidLayout("rule root must point to match node"));
+    }
+
+    let kind = build_match_kind(root.match_kind)?;
+    
+    let mut current_index = root_index;
+    
+    let mut builder: Option<MatchBuilder> = None;
+
+    loop {
+        let node = section.node(current_index)?;
+        
+        if node.node_kind != NODE_KIND_MATCH {
+            stack.pop();
+            return Err(RgpfError::InvalidLayout("arm chain contains non-match node"));
+        }
+        
+        if node.match_kind != root.match_kind {
+            stack.pop();
+            return Err(RgpfError::UnsupportedLayout("no_index chain changed match kind"));
+        }
+
+        let pattern = build_pattern(section, node.pattern_off.get())?;
+        
+        let arm_end = build_arm_end(file, section, node.yes_index.get(), stack)?;
+        
+        builder = Some(match builder {
+            Some(existing) => existing.arm(pattern, arm_end),
+            None => MatchBuilder::with_arm(kind, pattern, arm_end),
+        });
+
+        if node.no_index.get() == NO_INDEX {
+            break;
+        }
+
+        current_index = node.no_index.get();
+    }
+
+    stack.pop();
+    
+    builder.expect("at least one arm").build().map_err(|_| RgpfError::InvalidLayout("failed to build runtime match"))
+}
+
+fn build_arm_end(file: &RgpfFile<'_>, section: &RuleTreeSection<'_>, next_index: u32, stack: &mut Vec<u32>) -> Result<ArmEnd, RgpfError> {
+    if next_index == NO_INDEX {
+        return Err(RgpfError::InvalidLayout("yes edge must not be terminal"));
+    }
+
+    let node = section.node(next_index)?;
+    
+    match node.node_kind {
+        NODE_KIND_MATCH => Ok(ArmEnd::Match(build_match(file, section, next_index, stack)?)),
+        NODE_KIND_VERDICT => Ok(ArmEnd::Verdict(build_verdict_from_section(file, section, node.verdict_off.get())?)),
+        _ => Err(RgpfError::InvalidLayout("invalid arm target node kind")),
+    }
+}
+
+fn build_pattern(section: &RuleTreeSection<'_>, offset: u32) -> Result<Pattern, RgpfError> {
+    match section.pattern(offset)? {
+        PatternSection::Wildcard => Ok(Pattern::Wildcard),
+        PatternSection::Equal(value) => Ok(Pattern::Equal(build_field_value(value)?)),
+        PatternSection::Glob(value) => Ok(Pattern::Glob(build_field_value(value)?)),
+        PatternSection::Range { lo, hi } => Ok(Pattern::Range(build_field_value(lo)?, build_field_value(hi)?)),
+        PatternSection::Comparison { op, rhs } => Ok(Pattern::Comparison(build_operation(op)?, build_field_value(rhs)?)),
+        PatternSection::Or(or_pattern) => {
+            let mut patterns = Vec::new();
+            
+            for nested_offset in or_pattern.pattern_offsets() {
+                patterns.push(build_pattern(section, nested_offset.get())?);
+            }
+            
+            Ok(Pattern::Or(patterns))
+        }
+    }
+}
+
+fn build_field_value(value: FieldValueSection<'_>) -> Result<FieldValue, RgpfError> {
+    match value {
+        FieldValueSection::Ip(ip) => Ok(FieldValue::Ip(IP::new([
+            octet(ip.octet0, ip.mask0)?,
+            octet(ip.octet1, ip.mask1)?,
+            octet(ip.octet2, ip.mask2)?,
+            octet(ip.octet3, ip.mask3)?,
+        ]))),
+        FieldValueSection::IpVer(value) => Ok(FieldValue::IpVer(build_ip_ver(value.value)?)),
+        FieldValueSection::DayOfWeek(value) => Ok(FieldValue::DayOfWeek(build_weekday(value.value)?)),
+        FieldValueSection::Hour(value) => Ok(FieldValue::Hour(Hour::try_from(value.value).map_err(|_| RgpfError::InvalidEnum {
+            field: "hour.value",
+            value: u64::from(value.value),
+        })?)),
+        FieldValueSection::Protocol(value) => Ok(FieldValue::Protocol(build_protocol(value.value)?)),
+        FieldValueSection::Port(value) => Ok(FieldValue::Port(Port::from(value.value.get()))),
+    }
+}
+
+fn build_match_kind(kind: u8) -> Result<MatchKind, RgpfError> {
+    match kind {
+        MATCH_KIND_SRC_IP => Ok(MatchKind::SrcIp),
+        MATCH_KIND_DST_IP => Ok(MatchKind::DstIp),
+        MATCH_KIND_IP_VER => Ok(MatchKind::IpVer),
+        MATCH_KIND_DAY_OF_WEEK => Ok(MatchKind::DayOfWeek),
+        MATCH_KIND_HOUR => Ok(MatchKind::Hour),
+        MATCH_KIND_PROTOCOL => Ok(MatchKind::Protocol),
+        MATCH_KIND_SRC_PORT => Ok(MatchKind::SrcPort),
+        MATCH_KIND_DST_PORT => Ok(MatchKind::DstPort),
+        value => Err(RgpfError::InvalidEnum {
+            field: "rule_node.match_kind",
+            value: u64::from(value),
+        }),
+    }
+}
+
+fn build_operation(op: u8) -> Result<Operation, RgpfError> {
+    match op {
+        COMPARISON_GREATER => Ok(Operation::Greater),
+        COMPARISON_LESSER => Ok(Operation::Lesser),
+        COMPARISON_GREATER_OR_EQUAL => Ok(Operation::GreaterOrEqual),
+        COMPARISON_LESSER_OR_EQUAL => Ok(Operation::LesserOrEqual),
+        value => Err(RgpfError::InvalidEnum {
+            field: "comparison.op",
+            value: u64::from(value),
+        }),
+    }
+}
+
+fn build_ip_ver(value: u8) -> Result<IpVer, RgpfError> {
+    match value {
+        IP_VER_V4 => Ok(IpVer::V4),
+        IP_VER_V6 => Ok(IpVer::V6),
+        other => Err(RgpfError::InvalidEnum {
+            field: "ip_ver.value",
+            value: u64::from(other),
+        }),
+    }
+}
+
+fn build_protocol(value: u8) -> Result<Protocol, RgpfError> {
+    match value {
+        PROTOCOL_TCP => Ok(Protocol::Tcp),
+        PROTOCOL_UDP => Ok(Protocol::Udp),
+        PROTOCOL_ICMP => Ok(Protocol::Icmp),
+        other => Err(RgpfError::InvalidEnum {
+            field: "protocol.value",
+            value: u64::from(other),
+        }),
+    }
+}
+
+fn build_weekday(value: u8) -> Result<Weekday, RgpfError> {
+    match value {
+        WEEKDAY_MON => Ok(Weekday::Mon),
+        WEEKDAY_TUE => Ok(Weekday::Tue),
+        WEEKDAY_WED => Ok(Weekday::Wed),
+        WEEKDAY_THU => Ok(Weekday::Thu),
+        WEEKDAY_FRI => Ok(Weekday::Fri),
+        WEEKDAY_SAT => Ok(Weekday::Sat),
+        WEEKDAY_SUN => Ok(Weekday::Sun),
+        other => Err(RgpfError::InvalidEnum {
+            field: "day_of_week.value",
+            value: u64::from(other),
+        }),
+    }
+}
+
+fn build_verdict(file: &RgpfFile<'_>, verdict: &crate::policy::rgpf::sections::rule_tree::entries::VerdictEntry) -> Result<Verdict, RgpfError> {
+    let message = if verdict.message_str_off.get() == 0 {
+        None
+    } else {
+        Some(file.string_table()?.get(verdict.message_str_off.get())?.to_owned())
+    };
+
+    match verdict.verdict_kind {
+        VERDICT_ALLOW => Ok(Verdict::Allow),
+        VERDICT_DROP => Ok(Verdict::Drop),
+        VERDICT_ALLOW_WARN => Ok(Verdict::AllowWarn(message.unwrap_or_default())),
+        VERDICT_DROP_WARN => Ok(Verdict::DropWarn(message.unwrap_or_default())),
+        value => Err(RgpfError::InvalidEnum {
+            field: "verdict.kind",
+            value: u64::from(value),
+        }),
+    }
+}
+
+fn build_verdict_from_section(file: &RgpfFile<'_>, section: &RuleTreeSection<'_>, offset: u32) -> Result<Verdict, RgpfError> {
+    build_verdict(file, section.verdict(offset)?)
+}
+
+fn octet(value: u8, mask: u8) -> Result<Octet, RgpfError> {
+    match mask {
+        0 => Ok(Octet::Value(value)),
+        1 => Ok(Octet::Any),
+        other => Err(RgpfError::InvalidBool(other)),
+    }
+}

--- a/src/policy/rgpf/load/mod.rs
+++ b/src/policy/rgpf/load/mod.rs
@@ -1,0 +1,1 @@
+pub mod compiled_policy;

--- a/src/policy/rgpf/mod.rs
+++ b/src/policy/rgpf/mod.rs
@@ -1,0 +1,385 @@
+pub mod load;
+pub mod errors;
+pub mod endian;
+pub mod sections;
+pub mod constants;
+pub mod validators;
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+
+    use crate::rule_tree::Verdict;
+    use crate::policy::rgpf::sections::rgpf_file::RgpfFile;
+    use crate::policy::rgpf::sections::rgpf_header::RgpfHeader;
+    use crate::policy::rgpf::load::compiled_policy::load_compiled_policy;
+    use crate::policy::rgpf::sections::nat::entries::NatRuleSectionHeader;
+    use crate::frame::{Frame, Hour, IpVer, Octet, Port, Protocol, Weekday, IP};
+    use crate::policy::rgpf::sections::rule_tree::entries::{RuleEntry, RuleNode, RuleTreeSectionHeader};
+
+    use crate::policy::rgpf::constants::{
+        NO_INDEX,
+        VERDICT_DROP,
+        NODE_KIND_MATCH,
+        NODE_KIND_VERDICT,
+        VERDICT_ALLOW_WARN,
+        SECTION_STRING_TABLE,
+        PATTERN_KIND_WILDCARD,
+        SECTION_NAT_RULE_TABLE,
+        SECTION_DEFAULT_VERDICT,
+        SECTION_RULE_TREE_TABLE,
+    };
+
+    struct DummyFrame {
+        src_ip: IP,
+        dst_ip: IP,
+        ip_ver: IpVer,
+        protocol: Protocol,
+        src_port: Option<Port>,
+        dst_port: Option<Port>,
+        hour: Hour,
+        day_of_week: Weekday,
+    }
+
+    impl DummyFrame {
+        fn tcp() -> Self {
+            Self {
+                src_ip: IP::new([Octet::Value(10), Octet::Value(0), Octet::Value(0), Octet::Value(1)]),
+                dst_ip: IP::new([Octet::Value(10), Octet::Value(0), Octet::Value(0), Octet::Value(2)]),
+                ip_ver: IpVer::V4,
+                protocol: Protocol::Tcp,
+                src_port: Some(Port::from(1234)),
+                dst_port: Some(Port::from(80)),
+                hour: Hour::try_from(12).unwrap(),
+                day_of_week: Weekday::Mon,
+            }
+        }
+    }
+
+    impl Frame for DummyFrame {
+        fn ip_ver(&self) -> IpVer { self.ip_ver }
+        fn src_ip(&self) -> IP { self.src_ip }
+        fn dst_ip(&self) -> IP { self.dst_ip }
+        fn protocol(&self) -> Protocol { self.protocol }
+        fn src_port(&self) -> Option<Port> { self.src_port }
+        fn dst_port(&self) -> Option<Port> { self.dst_port }
+        fn hour(&self) -> Hour { self.hour }
+        fn day_of_week(&self) -> Weekday { self.day_of_week }
+    }
+
+    #[test]
+    fn parses_minimal_rgpf_file() {
+        let bytes = build_policy_bin(false);
+
+        let file = RgpfFile::parse(&bytes).unwrap();
+
+        assert_eq!(file.header().revision_id.get(), 7);
+        assert_eq!(file.string_table().unwrap().get(0).unwrap(), "default");
+        assert_eq!(file.rule_tree().unwrap().rules().len(), 1);
+        assert!(file.nat_rules().unwrap().is_none());
+    }
+
+    #[test]
+    fn loads_compiled_policy_from_rgpf() {
+        let bytes = build_policy_bin(false);
+
+        let file = RgpfFile::parse(&bytes).unwrap();
+
+        let compiled = load_compiled_policy(&file).unwrap();
+
+        assert_eq!(compiled.metadata().config_version, Some(7));
+        assert_eq!(compiled.metadata().rule_count, 1);
+
+        let verdict = compiled.evaluator().evaluate(&DummyFrame::tcp());
+
+        assert_eq!(verdict, Some(Verdict::AllowWarn("allow-from-rgpf".into())));
+    }
+
+    #[test]
+    fn parses_optional_nat_section() {
+        let bytes = build_policy_bin(true);
+
+        let file = RgpfFile::parse(&bytes).unwrap();
+
+        assert!(file.nat_rules().unwrap().is_some());
+        assert_eq!(file.nat_rules().unwrap().unwrap().rules().len(), 0);
+    }
+
+    fn build_policy_bin(include_nat: bool) -> Vec<u8> {
+        let strings = build_string_table(&["default", "Loaded from RGPF", "allow-from-rgpf"]);
+
+        let name_off = 0u32;
+
+        let desc_off = string_entry_offset("default");
+
+        let msg_off = desc_off + string_entry_len("Loaded from RGPF") as u32;
+
+        let rule_tree = build_rule_tree_section(name_off, desc_off, msg_off);
+
+        let default_verdict = build_default_verdict_section();
+
+        let nat = if include_nat {
+            Some(build_empty_nat_section())
+        } else {
+            None
+        };
+
+        let header_len = size_of::<RgpfHeader>();
+
+        let section_count = if include_nat { 4u16 } else { 3u16 };
+
+        let section_table_len = size_of::<crate::policy::rgpf::sections::section_table::SectionEntry>() * usize::from(section_count);
+
+        let mut cursor = header_len + section_table_len;
+
+        let string_offset = cursor;
+        cursor += strings.len();
+
+        let rule_tree_offset = cursor;
+        cursor += rule_tree.len();
+
+        let default_offset = cursor;
+        cursor += default_verdict.len();
+
+        let nat_offset = cursor;
+
+        if let Some(ref nat_bytes) = nat {
+            cursor += nat_bytes.len();
+        }
+
+        let mut bytes = Vec::with_capacity(cursor);
+
+        bytes.resize(header_len, 0);
+
+        let mut sections = Vec::new();
+
+        sections.push(section_entry(SECTION_STRING_TABLE, string_offset, strings.len(), 3));
+        sections.push(section_entry(SECTION_RULE_TREE_TABLE, rule_tree_offset, rule_tree.len(), 1));
+        sections.push(section_entry(SECTION_DEFAULT_VERDICT, default_offset, default_verdict.len(), 1));
+
+        if let Some(ref nat_bytes) = nat {
+            sections.push(section_entry(SECTION_NAT_RULE_TABLE, nat_offset, nat_bytes.len(), 0));
+        }
+
+        for section in sections {
+            bytes.extend_from_slice(&section);
+        }
+
+        bytes.extend_from_slice(&strings);
+        bytes.extend_from_slice(&rule_tree);
+        bytes.extend_from_slice(&default_verdict);
+
+        if let Some(nat_bytes) = nat {
+            bytes.extend_from_slice(&nat_bytes);
+        }
+
+        let total_len = bytes.len() as u64;
+
+        write_header(
+            &mut bytes[..header_len],
+            section_count,
+            header_len as u16,
+            header_len as u64,
+            total_len,
+        );
+
+        let crc = crc32c_with_zeroed_field(&bytes, file_crc32c_offset());
+
+        let crc_offset = file_crc32c_offset();
+
+        bytes[crc_offset..crc_offset + 4].copy_from_slice(&crc.to_le_bytes());
+
+        bytes
+    }
+
+    fn build_string_table(values: &[&str]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        for value in values {
+            bytes.extend_from_slice(&(value.len() as u32).to_le_bytes());
+            bytes.extend_from_slice(value.as_bytes());
+        }
+
+        bytes
+    }
+
+    fn build_rule_tree_section(name_off: u32, desc_off: u32, msg_off: u32) -> Vec<u8> {
+        let header_len = size_of::<RuleTreeSectionHeader>();
+
+        let rules_offset = header_len as u64;
+
+        let nodes_offset = rules_offset + size_of::<RuleEntry>() as u64;
+
+        let object_arena_offset = nodes_offset + (2 * size_of::<RuleNode>()) as u64;
+
+        let mut arena = Vec::new();
+        arena.extend_from_slice(&0u32.to_le_bytes());
+
+        let wildcard_off = arena.len() as u32;
+
+        arena.push(PATTERN_KIND_WILDCARD);
+        arena.push(0);
+        arena.extend_from_slice(&0u16.to_le_bytes());
+
+        let allow_verdict_off = arena.len() as u32;
+
+        arena.push(VERDICT_ALLOW_WARN);
+        arena.push(0);
+        arena.extend_from_slice(&0u16.to_le_bytes());
+        arena.extend_from_slice(&msg_off.to_le_bytes());
+
+        let mut bytes = Vec::new();
+
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.extend_from_slice(&2u32.to_le_bytes());
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&rules_offset.to_le_bytes());
+        bytes.extend_from_slice(&nodes_offset.to_le_bytes());
+        bytes.extend_from_slice(&object_arena_offset.to_le_bytes());
+        bytes.extend_from_slice(&(arena.len() as u64).to_le_bytes());
+
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.extend_from_slice(&name_off.to_le_bytes());
+        bytes.extend_from_slice(&desc_off.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+
+        bytes.push(NODE_KIND_MATCH);
+        bytes.push(crate::policy::rgpf::constants::MATCH_KIND_PROTOCOL);
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        bytes.extend_from_slice(&wildcard_off.to_le_bytes());
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.extend_from_slice(&NO_INDEX.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+
+        bytes.push(NODE_KIND_VERDICT);
+        bytes.push(0);
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&NO_INDEX.to_le_bytes());
+        bytes.extend_from_slice(&NO_INDEX.to_le_bytes());
+        bytes.extend_from_slice(&allow_verdict_off.to_le_bytes());
+
+        bytes.extend_from_slice(&arena);
+
+        bytes
+    }
+
+    fn build_default_verdict_section() -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        bytes.push(VERDICT_DROP);
+        bytes.push(0);
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+
+        bytes
+    }
+
+    fn build_empty_nat_section() -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        let header_len = size_of::<NatRuleSectionHeader>() as u64;
+
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&header_len.to_le_bytes());
+        bytes.extend_from_slice(&header_len.to_le_bytes());
+        bytes.extend_from_slice(&header_len.to_le_bytes());
+        bytes.extend_from_slice(&header_len.to_le_bytes());
+        bytes.extend_from_slice(&header_len.to_le_bytes());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+
+        bytes
+    }
+
+    fn section_entry(kind: u16, offset: usize, len: usize, item_count: u32) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        bytes.extend_from_slice(&kind.to_le_bytes());
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        bytes.extend_from_slice(&(offset as u64).to_le_bytes());
+        bytes.extend_from_slice(&(len as u64).to_le_bytes());
+        bytes.extend_from_slice(&item_count.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+
+        bytes
+    }
+
+    fn write_header(bytes: &mut [u8], section_count: u16, section_table_offset: u16, file_len: u64, computed_file_len: u64) {
+        let mut cursor = 0usize;
+
+        push_u32(bytes, &mut cursor, crate::policy::rgpf::constants::RGPF_MAGIC);
+        push_u16(bytes, &mut cursor, 1);
+        push_u16(bytes, &mut cursor, 0);
+        push_u16(bytes, &mut cursor, size_of::<RgpfHeader>() as u16);
+        push_u16(bytes, &mut cursor, section_count);
+        push_u32(bytes, &mut cursor, 0);
+        push_u64(bytes, &mut cursor, 7);
+        push_u64(bytes, &mut cursor, 1700000000000);
+        push_u64(bytes, &mut cursor, 0xABCDEF);
+        push_u64(bytes, &mut cursor, u64::from(section_table_offset));
+        push_u64(bytes, &mut cursor, computed_file_len.max(file_len));
+        push_u32(bytes, &mut cursor, 0);
+        push_u32(bytes, &mut cursor, 0);
+    }
+
+    fn push_u16(bytes: &mut [u8], cursor: &mut usize, value: u16) {
+        bytes[*cursor..*cursor + 2].copy_from_slice(&value.to_le_bytes());
+
+        *cursor += 2;
+    }
+
+    fn push_u32(bytes: &mut [u8], cursor: &mut usize, value: u32) {
+        bytes[*cursor..*cursor + 4].copy_from_slice(&value.to_le_bytes());
+
+        *cursor += 4;
+    }
+
+    fn push_u64(bytes: &mut [u8], cursor: &mut usize, value: u64) {
+        bytes[*cursor..*cursor + 8].copy_from_slice(&value.to_le_bytes());
+
+        *cursor += 8;
+    }
+
+    fn string_entry_offset(value: &str) -> u32 {
+        string_entry_len(value) as u32
+    }
+
+    fn string_entry_len(value: &str) -> usize {
+        4 + value.len()
+    }
+
+    fn file_crc32c_offset() -> usize {
+        56
+    }
+
+    fn crc32c_with_zeroed_field(bytes: &[u8], field_offset: usize) -> u32 {
+        let prefix = &bytes[..field_offset];
+        
+        let suffix = &bytes[field_offset + 4..];
+
+        let mut crc = crc32c_update(!0u32, prefix);
+        
+        crc = crc32c_update(crc, &[0, 0, 0, 0]);
+        crc = crc32c_update(crc, suffix);
+        
+        !crc
+    }
+
+    fn crc32c_update(mut crc: u32, bytes: &[u8]) -> u32 {
+        for byte in bytes {
+            crc ^= u32::from(*byte);
+            
+            for _ in 0..8 {
+                let mask = (crc & 1).wrapping_neg();
+                crc = (crc >> 1) ^ (0x82F63B78 & mask);
+            }
+        }
+
+        crc
+    }
+}

--- a/src/policy/rgpf/sections/mod.rs
+++ b/src/policy/rgpf/sections/mod.rs
@@ -1,0 +1,6 @@
+pub mod nat;
+pub mod rgpf_file;
+pub mod rule_tree;
+pub mod rgpf_header;
+pub mod string_table;
+pub mod section_table;

--- a/src/policy/rgpf/sections/nat/entries.rs
+++ b/src/policy/rgpf/sections/nat/entries.rs
@@ -1,0 +1,132 @@
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use crate::policy::rgpf::endian::{LeU16, LeU32, LeU64};
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct NatRuleSectionHeader {
+    pub rule_count: LeU32,
+    pub match_count: LeU32,
+    pub kind_count: LeU32,
+    pub timeout_count: LeU32,
+    pub rules_offset: LeU64,
+    pub matches_offset: LeU64,
+    pub kinds_offset: LeU64,
+    pub timeouts_offset: LeU64,
+    pub object_arena_offset: LeU64,
+    pub object_arena_len: LeU64,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct NatRuleEntry {
+    pub id_str_off: LeU32,
+    pub name_str_off: LeU32,
+    pub enabled: u8,
+    pub applies_at: u8,
+    pub reserved0: LeU16,
+    pub priority: LeU32,
+    pub match_index: LeU32,
+    pub kind_index: LeU32,
+    pub timeouts_index: LeU32,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct NatMatchEntry {
+    pub presence_bits: LeU32,
+    pub in_interface_str_off: LeU32,
+    pub out_interface_str_off: LeU32,
+    pub in_zone_str_off: LeU32,
+    pub out_zone_str_off: LeU32,
+    pub src_cidr_off: LeU32,
+    pub dst_cidr_off: LeU32,
+    pub proto_off: LeU32,
+    pub src_ports_off: LeU32,
+    pub dst_ports_off: LeU32,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct CidrEntry {
+    pub ip_version: u8,
+    pub prefix_len: u8,
+    pub reserved0: LeU16,
+    pub addr: [u8; 16],
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct NatProtoEntry {
+    pub proto_kind: u8,
+    pub reserved0: u8,
+    pub reserved1: LeU16,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct PortRangeEntry {
+    pub start: LeU16,
+    pub end: LeU16,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct NatKindEntryHeader {
+    pub kind_tag: u8,
+    pub reserved0: u8,
+    pub reserved1: LeU16,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct SnatKindEntry {
+    pub header: NatKindEntryHeader,
+    pub to_addr_off: LeU32,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct MasqueradeKindEntry {
+    pub header: NatKindEntryHeader,
+    pub interface_str_off: LeU32,
+    pub port_pool_off: LeU32,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct DnatKindEntry {
+    pub header: NatKindEntryHeader,
+    pub to_addr_off: LeU32,
+    pub to_port: LeU16,
+    pub reserved0: LeU16,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct PatKindEntry {
+    pub header: NatKindEntryHeader,
+    pub to_addr_off: LeU32,
+    pub interface_str_off: LeU32,
+    pub port_pool_off: LeU32,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct CidrAddressEntry {
+    pub ip_version: u8,
+    pub reserved0: u8,
+    pub reserved1: LeU16,
+    pub addr: [u8; 16],
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct NatTimeoutsEntry {
+    pub presence_bits: u8,
+    pub reserved0: u8,
+    pub reserved1: LeU16,
+    pub tcp_established_s: LeU64,
+    pub udp_s: LeU64,
+    pub icmp_s: LeU64,
+}

--- a/src/policy/rgpf/sections/nat/mod.rs
+++ b/src/policy/rgpf/sections/nat/mod.rs
@@ -1,0 +1,2 @@
+pub mod entries;
+pub mod sections;

--- a/src/policy/rgpf/sections/nat/sections.rs
+++ b/src/policy/rgpf/sections/nat/sections.rs
@@ -1,0 +1,122 @@
+use std::mem::size_of;
+use zerocopy::{FromBytes, Immutable, KnownLayout};
+
+use crate::policy::rgpf::errors::rgpf_error::RgpfError;
+use crate::policy::rgpf::sections::section_table::SectionTable;
+
+use crate::policy::rgpf::sections::nat::entries::{
+    NatKindEntryHeader, NatRuleSectionHeader,
+    NatRuleEntry, NatMatchEntry, NatTimeoutsEntry
+};
+
+#[derive(Clone, Copy)]
+pub struct NatSection<'a> {
+    section: SectionTable<'a>,
+    header: &'a NatRuleSectionHeader,
+    rules: &'a [NatRuleEntry],
+    matches: &'a [NatMatchEntry],
+    kinds: &'a [NatKindEntryHeader],
+    timeouts: &'a [NatTimeoutsEntry],
+    object_arena: &'a [u8],
+}
+
+impl<'a> NatSection<'a> {
+    pub fn parse(section: SectionTable<'a>) -> Result<Self, RgpfError> {
+        let header = NatRuleSectionHeader::ref_from_prefix(section.bytes)
+            .map_err(|_| RgpfError::InvalidLayout("invalid nat section header"))?.0;
+
+        let rule_count = usize::try_from(header.rule_count.get())
+            .map_err(|_| RgpfError::OffsetOutOfBounds)?;
+        
+        let match_count = usize::try_from(header.match_count.get())
+            .map_err(|_| RgpfError::OffsetOutOfBounds)?;
+        
+        let kind_count = usize::try_from(header.kind_count.get())
+            .map_err(|_| RgpfError::OffsetOutOfBounds)?;
+        
+        let timeout_count = usize::try_from(header.timeout_count.get())
+            .map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+        let rules = 
+            read_array::<NatRuleEntry>(section.bytes, header.rules_offset.get(), rule_count)?;
+        
+        let matches = 
+            read_array::<NatMatchEntry>(section.bytes, header.matches_offset.get(), match_count)?;
+        
+        let kinds = 
+            read_array::<NatKindEntryHeader>(section.bytes, header.kinds_offset.get(), kind_count)?;
+        
+        let timeouts = 
+            read_array::<NatTimeoutsEntry>(section.bytes, header.timeouts_offset.get(), timeout_count)?;
+        
+        let object_arena = read_bytes(section.bytes,
+            header.object_arena_offset.get(),
+            header.object_arena_len.get()
+        )?;
+
+        Ok(Self {
+            section,
+            header,
+            rules,
+            matches,
+            kinds,
+            timeouts,
+            object_arena,
+        })
+    }
+
+    pub fn section(&self) -> SectionTable<'a> {
+        self.section
+    }
+
+    pub fn header(&self) -> &'a NatRuleSectionHeader {
+        self.header
+    }
+
+    pub fn rules(&self) -> &'a [NatRuleEntry] {
+        self.rules
+    }
+
+    pub fn matches(&self) -> &'a [NatMatchEntry] {
+        self.matches
+    }
+
+    pub fn kinds(&self) -> &'a [NatKindEntryHeader] {
+        self.kinds
+    }
+
+    pub fn timeouts(&self) -> &'a [NatTimeoutsEntry] {
+        self.timeouts
+    }
+
+    pub fn object_arena(&self) -> &'a [u8] {
+        self.object_arena
+    }
+}
+
+fn read_bytes(bytes: &[u8], offset: u64, len: u64) -> Result<&[u8], RgpfError> {
+    let start = usize::try_from(offset).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+    
+    let len = usize::try_from(len).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+    
+    let end = start.checked_add(len).ok_or(RgpfError::IntegerOverflow)?;
+    
+    bytes.get(start..end).ok_or(RgpfError::OffsetOutOfBounds)
+}
+
+fn read_array<T>(bytes: &[u8], offset: u64, count: usize) -> Result<&[T], RgpfError> where
+    T: FromBytes + KnownLayout + Immutable
+{
+    let size = size_of::<T>();
+    
+    let len = size.checked_mul(count).ok_or(RgpfError::IntegerOverflow)?;
+    
+    let start = usize::try_from(offset).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+    
+    let end = start.checked_add(len).ok_or(RgpfError::IntegerOverflow)?;
+    
+    let window = bytes.get(start..end).ok_or(RgpfError::OffsetOutOfBounds)?;
+    
+    <[T]>::ref_from_bytes_with_elems(window, count)
+        .map_err(|_| RgpfError::InvalidLayout("invalid nat fixed-size array"))
+}

--- a/src/policy/rgpf/sections/rgpf_file.rs
+++ b/src/policy/rgpf/sections/rgpf_file.rs
@@ -1,0 +1,148 @@
+use std::mem::size_of;
+use zerocopy::FromBytes;
+
+use crate::policy::rgpf::errors::rgpf_error::RgpfError;
+use crate::policy::rgpf::sections::rgpf_header::RgpfHeader;
+use crate::policy::rgpf::sections::string_table::StringTable;
+use crate::policy::rgpf::sections::nat::sections::NatSection;
+use crate::policy::rgpf::sections::section_table::{SectionEntry, SectionTable};
+use crate::policy::rgpf::validators::{rgpf_file_validator, nat_validator, rule_tree_validator};
+use crate::policy::rgpf::sections::rule_tree::sections::{DefaultVerdictSection, RuleTreeSection};
+
+use crate::policy::rgpf::constants::{
+    RGPF_MAGIC,
+    RGPF_MAJOR,
+    RGPF_MINOR,
+    SECTION_STRING_TABLE,
+    SECTION_NAT_RULE_TABLE,
+    SECTION_DEFAULT_VERDICT,
+    SECTION_RULE_TREE_TABLE,
+};
+
+pub struct RgpfFile<'a> {
+    bytes: &'a [u8],
+    header: &'a RgpfHeader,
+    sections: &'a [SectionEntry],
+}
+
+impl<'a> RgpfFile<'a> {
+    pub fn parse(bytes: &'a [u8]) -> Result<Self, RgpfError> {
+        let header = RgpfHeader::ref_from_prefix(bytes)
+            .map_err(|_| RgpfError::InvalidLayout("file is shorter than header"))?.0;
+
+        rgpf_file_validator::validate_header(bytes, header)?;
+
+        let table_offset = usize::try_from(header.section_table_offset.get())
+            .map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+        let section_count = usize::from(header.section_count.get());
+
+        let table_len = size_of::<SectionEntry>().checked_mul(section_count)
+            .ok_or(RgpfError::IntegerOverflow)?;
+
+        let table_end = table_offset.checked_add(table_len).ok_or(RgpfError::IntegerOverflow)?;
+
+        let table_bytes = bytes.get(table_offset..table_end).ok_or(RgpfError::SectionOutOfBounds)?;
+
+        let sections = <[SectionEntry]>::ref_from_bytes_with_elems(table_bytes, section_count)
+            .map_err(|_| RgpfError::InvalidLayout("invalid section table layout"))?;
+
+        let file = Self { bytes, header, sections };
+
+        rgpf_file_validator::validate_sections(&file)?;
+
+        file.string_table()?;
+
+        let rule_tree = file.rule_tree()?;
+
+        rule_tree_validator::validate_rule_tree(&file, &rule_tree)?;
+
+        if let Some(nat) = file.nat_rules()? {
+            nat_validator::validate_nat(&file, &nat)?;
+        }
+
+        Ok(file)
+    }
+
+    pub fn bytes(&self) -> &'a [u8] {
+        self.bytes
+    }
+
+    pub fn header(&self) -> &'a RgpfHeader {
+        self.header
+    }
+
+    pub fn sections(&self) -> &'a [SectionEntry] {
+        self.sections
+    }
+
+    pub fn section(&self, kind: u16) -> Result<Option<SectionTable<'a>>, RgpfError> {
+        let mut found = None;
+
+        for entry in self.sections {
+            if entry.kind.get() != kind {
+                continue;
+            }
+
+            if found.is_some() {
+                return Err(RgpfError::DuplicateSection(kind));
+            }
+
+            let offset = usize::try_from(entry.offset.get()).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+            let len = usize::try_from(entry.length.get()).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+            let end = offset.checked_add(len).ok_or(RgpfError::IntegerOverflow)?;
+
+            let bytes = self.bytes.get(offset..end).ok_or(RgpfError::SectionOutOfBounds)?;
+
+            found = Some(SectionTable { entry, bytes });
+        }
+
+        Ok(found)
+    }
+
+    pub fn string_table(&self) -> Result<StringTable<'a>, RgpfError> {
+        let section = self.section(SECTION_STRING_TABLE)?
+            .ok_or(RgpfError::MissingSection("STRING_TABLE"))?;
+
+        Ok(StringTable::new(section.bytes))
+    }
+
+    pub fn rule_tree(&self) -> Result<RuleTreeSection<'a>, RgpfError> {
+        let section = self.section(SECTION_RULE_TREE_TABLE)?
+            .ok_or(RgpfError::MissingSection("RULE_TREE_TABLE"))?;
+
+        RuleTreeSection::parse(section)
+    }
+
+    pub fn default_verdict(&self) -> Result<DefaultVerdictSection<'a>, RgpfError> {
+        let section = self.section(SECTION_DEFAULT_VERDICT)?
+            .ok_or(RgpfError::MissingSection("DEFAULT_VERDICT"))?;
+
+        DefaultVerdictSection::parse(section)
+    }
+
+    pub fn nat_rules(&self) -> Result<Option<NatSection<'a>>, RgpfError> {
+        match self.section(SECTION_NAT_RULE_TABLE)? {
+            Some(section) => Ok(Some(NatSection::parse(section)?)),
+            None => Ok(None),
+        }
+    }
+}
+
+pub(crate) fn ensure_version(major: u16, minor: u16) -> Result<(), RgpfError> {
+    if major != RGPF_MAJOR || minor != RGPF_MINOR {
+        return Err(RgpfError::UnsupportedVersion { major, minor });
+    }
+
+    Ok(())
+}
+
+pub(crate) fn ensure_magic(magic: u32) -> Result<(), RgpfError> {
+    if magic != RGPF_MAGIC {
+        return Err(RgpfError::InvalidMagic(magic));
+    }
+
+    Ok(())
+}

--- a/src/policy/rgpf/sections/rgpf_header.rs
+++ b/src/policy/rgpf/sections/rgpf_header.rs
@@ -1,0 +1,22 @@
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use crate::policy::rgpf::endian::{LeU16, LeU32, LeU64};
+
+/// Nagłówek pliku `RGPF/1` mapowany bez kopiowania z wejściowego bufora.
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct RgpfHeader {
+    pub magic: LeU32,
+    pub major: LeU16,
+    pub minor: LeU16,
+    pub header_len: LeU16,
+    pub section_count: LeU16,
+    pub flags: LeU32,
+    pub revision_id: LeU64,
+    pub compiled_at_unix_ms: LeU64,
+    pub policy_hash: LeU64,
+    pub section_table_offset: LeU64,
+    pub file_len: LeU64,
+    pub file_crc32c: LeU32,
+    pub reserved: LeU32,
+}

--- a/src/policy/rgpf/sections/rule_tree/entries.rs
+++ b/src/policy/rgpf/sections/rule_tree/entries.rs
@@ -1,0 +1,147 @@
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use crate::policy::rgpf::endian::{LeU16, LeU32, LeU64};
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct RuleTreeSectionHeader {
+    pub rule_count: LeU32,
+    pub node_count: LeU32,
+    pub verdict_count: LeU32,
+    pub reserved0: LeU32,
+    pub rules_offset: LeU64,
+    pub nodes_offset: LeU64,
+    pub object_arena_offset: LeU64,
+    pub object_arena_len: LeU64,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct RuleEntry {
+    pub rule_id: LeU32,
+    pub name_str_off: LeU32,
+    pub desc_str_off: LeU32,
+    pub root_node_index: LeU32,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct RuleNode {
+    pub node_kind: u8,
+    pub match_kind: u8,
+    pub reserved0: LeU16,
+    pub pattern_off: LeU32,
+    pub yes_index: LeU32,
+    pub no_index: LeU32,
+    pub verdict_off: LeU32,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct PatternEntryHeader {
+    pub pattern_kind: u8,
+    pub reserved0: u8,
+    pub reserved1: LeU16,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct EqualPattern {
+    pub header: PatternEntryHeader,
+    pub field_value_off: LeU32,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct GlobPattern {
+    pub header: PatternEntryHeader,
+    pub field_value_off: LeU32,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct RangePattern {
+    pub header: PatternEntryHeader,
+    pub lo_value_off: LeU32,
+    pub hi_value_off: LeU32,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct ComparisonPattern {
+    pub header: PatternEntryHeader,
+    pub op: u8,
+    pub reserved0: u8,
+    pub reserved1: LeU16,
+    pub rhs_value_off: LeU32,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct FieldValueHeader {
+    pub type_tag: u8,
+    pub reserved0: u8,
+    pub reserved1: LeU16,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct IpValue {
+    pub header: FieldValueHeader,
+    pub octet0: u8,
+    pub octet1: u8,
+    pub octet2: u8,
+    pub octet3: u8,
+    pub mask0: u8,
+    pub mask1: u8,
+    pub mask2: u8,
+    pub mask3: u8,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct PortValue {
+    pub header: FieldValueHeader,
+    pub value: LeU16,
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct HourValue {
+    pub header: FieldValueHeader,
+    pub value: u8,
+    pub reserved: [u8; 3],
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct ProtocolValue {
+    pub header: FieldValueHeader,
+    pub value: u8,
+    pub reserved: [u8; 3],
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct DayOfWeekValue {
+    pub header: FieldValueHeader,
+    pub value: u8,
+    pub reserved: [u8; 3],
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct IpVerValue {
+    pub header: FieldValueHeader,
+    pub value: u8,
+    pub reserved: [u8; 3],
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct VerdictEntry {
+    pub verdict_kind: u8,
+    pub reserved0: u8,
+    pub reserved1: LeU16,
+    pub message_str_off: LeU32,
+}

--- a/src/policy/rgpf/sections/rule_tree/mod.rs
+++ b/src/policy/rgpf/sections/rule_tree/mod.rs
@@ -1,0 +1,2 @@
+pub mod entries;
+pub mod sections;

--- a/src/policy/rgpf/sections/rule_tree/sections.rs
+++ b/src/policy/rgpf/sections/rule_tree/sections.rs
@@ -1,0 +1,284 @@
+use std::mem::size_of;
+use zerocopy::{FromBytes, Immutable, KnownLayout};
+
+use crate::policy::rgpf::endian::LeU32;
+use crate::policy::rgpf::errors::rgpf_error::RgpfError;
+use crate::policy::rgpf::sections::section_table::SectionTable;
+
+use crate::policy::rgpf::constants::{
+    FIELD_VALUE_IP,
+    PATTERN_KIND_OR,
+    FIELD_VALUE_HOUR,
+    FIELD_VALUE_PORT,
+    PATTERN_KIND_GLOB,
+    FIELD_VALUE_IP_VER,
+    PATTERN_KIND_EQUAL,
+    PATTERN_KIND_RANGE,
+    FIELD_VALUE_PROTOCOL,
+    PATTERN_KIND_WILDCARD,
+    FIELD_VALUE_DAY_OF_WEEK,
+    PATTERN_KIND_COMPARISON
+};
+
+use crate::policy::rgpf::sections::rule_tree::entries::{
+    IpValue,
+    RuleNode,
+    HourValue,
+    PortValue,
+    RuleEntry,
+    IpVerValue,
+    GlobPattern,
+    EqualPattern,
+    VerdictEntry,
+    RangePattern,
+    ProtocolValue,
+    DayOfWeekValue,
+    FieldValueHeader,
+    ComparisonPattern,
+    PatternEntryHeader,
+    RuleTreeSectionHeader
+};
+
+#[derive(Clone, Copy)]
+pub struct RuleTreeSection<'a> {
+    section: SectionTable<'a>,
+    header: &'a RuleTreeSectionHeader,
+    rules: &'a [RuleEntry],
+    nodes: &'a [RuleNode],
+    object_arena: &'a [u8],
+}
+
+#[derive(Clone, Copy)]
+pub struct DefaultVerdictSection<'a> {
+    verdict: &'a VerdictEntry,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum FieldValueSection<'a> {
+    Ip(&'a IpValue),
+    IpVer(&'a IpVerValue),
+    DayOfWeek(&'a DayOfWeekValue),
+    Hour(&'a HourValue),
+    Protocol(&'a ProtocolValue),
+    Port(&'a PortValue),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct OrPatternSection<'a> {
+    pattern_offsets: &'a [LeU32],
+}
+
+impl<'a> OrPatternSection<'a> {
+    pub fn pattern_offsets(&self) -> &'a [LeU32] {
+        self.pattern_offsets
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum PatternSection<'a> {
+    Wildcard,
+    Equal(FieldValueSection<'a>),
+    Glob(FieldValueSection<'a>),
+    Range {
+        lo: FieldValueSection<'a>,
+        hi: FieldValueSection<'a>,
+    },
+    Comparison {
+        op: u8,
+        rhs: FieldValueSection<'a>,
+    },
+    Or(OrPatternSection<'a>),
+}
+
+impl<'a> RuleTreeSection<'a> {
+    pub fn parse(section: SectionTable<'a>) -> Result<Self, RgpfError> {
+        let header = RuleTreeSectionHeader::ref_from_prefix(section.bytes)
+            .map_err(|_| RgpfError::InvalidLayout("invalid rule tree section header"))?
+            .0;
+
+        let rule_count = usize::try_from(header.rule_count.get()).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+        let node_count = usize::try_from(header.node_count.get()).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+        let rules = read_array::<RuleEntry>(section.bytes, header.rules_offset.get(), rule_count)?;
+
+        let nodes = read_array::<RuleNode>(section.bytes, header.nodes_offset.get(), node_count)?;
+
+        let object_arena = read_bytes(
+            section.bytes,
+            header.object_arena_offset.get(),
+            header.object_arena_len.get(),
+        )?;
+
+        Ok(Self {
+            section,
+            header,
+            rules,
+            nodes,
+            object_arena,
+        })
+    }
+
+    pub fn section(&self) -> SectionTable<'a> {
+        self.section
+    }
+
+    pub fn header(&self) -> &'a RuleTreeSectionHeader {
+        self.header
+    }
+
+    pub fn rules(&self) -> &'a [RuleEntry] {
+        self.rules
+    }
+
+    pub fn nodes(&self) -> &'a [RuleNode] {
+        self.nodes
+    }
+
+    pub fn object_arena(&self) -> &'a [u8] {
+        self.object_arena
+    }
+
+    pub fn node(&self, index: u32) -> Result<&'a RuleNode, RgpfError> {
+        let index = usize::try_from(index).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+        self.nodes.get(index).ok_or(RgpfError::OffsetOutOfBounds)
+    }
+
+    pub fn pattern(&self, offset: u32) -> Result<PatternSection<'a>, RgpfError> {
+        let header = read_struct::<PatternEntryHeader>(self.object_arena, u64::from(offset))?;
+
+        match header.pattern_kind {
+            PATTERN_KIND_WILDCARD => Ok(PatternSection::Wildcard),
+            PATTERN_KIND_EQUAL => {
+                let pattern = read_struct::<EqualPattern>(self.object_arena, u64::from(offset))?;
+
+                Ok(PatternSection::Equal(self.field_value(pattern.field_value_off.get())?))
+            }
+            PATTERN_KIND_GLOB => {
+                let pattern = read_struct::<GlobPattern>(self.object_arena, u64::from(offset))?;
+
+                Ok(PatternSection::Glob(self.field_value(pattern.field_value_off.get())?))
+            }
+            PATTERN_KIND_RANGE => {
+                let pattern = read_struct::<RangePattern>(self.object_arena, u64::from(offset))?;
+
+                Ok(PatternSection::Range {
+                    lo: self.field_value(pattern.lo_value_off.get())?,
+                    hi: self.field_value(pattern.hi_value_off.get())?,
+                })
+            }
+            PATTERN_KIND_COMPARISON => {
+                let pattern = read_struct::<ComparisonPattern>(self.object_arena, u64::from(offset))?;
+
+                Ok(PatternSection::Comparison {
+                    op: pattern.op,
+                    rhs: self.field_value(pattern.rhs_value_off.get())?,
+                })
+            }
+            PATTERN_KIND_OR => {
+                let start = usize::try_from(offset).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+                let count_bytes = self.object_arena.get(start
+                        .checked_add(size_of::<PatternEntryHeader>()).ok_or(RgpfError::IntegerOverflow)?
+                        ..start.checked_add(size_of::<PatternEntryHeader>() + 4)
+                        .ok_or(RgpfError::IntegerOverflow)?
+                ).ok_or(RgpfError::OffsetOutOfBounds)?;
+
+                let count = u32::from_le_bytes(count_bytes.try_into().expect("exact count bytes"));
+
+                let offsets_start = start.checked_add(size_of::<PatternEntryHeader>() + 4)
+                    .ok_or(RgpfError::IntegerOverflow)?;
+
+                let offsets = read_u32_array(self.object_arena, offsets_start, count)?;
+
+                Ok(PatternSection::Or(OrPatternSection { pattern_offsets: offsets }))
+            }
+            value => Err(RgpfError::InvalidEnum {
+                field: "pattern_kind",
+                value: u64::from(value),
+            }),
+        }
+    }
+
+    pub fn field_value(&self, offset: u32) -> Result<FieldValueSection<'a>, RgpfError> {
+        let header = read_struct::<FieldValueHeader>(self.object_arena, u64::from(offset))?;
+
+        match header.type_tag {
+            FIELD_VALUE_IP => Ok(FieldValueSection::Ip(read_struct::<IpValue>(self.object_arena, u64::from(offset))?)),
+            FIELD_VALUE_IP_VER => Ok(FieldValueSection::IpVer(read_struct::<IpVerValue>(self.object_arena, u64::from(offset))?)),
+            FIELD_VALUE_DAY_OF_WEEK => Ok(FieldValueSection::DayOfWeek(read_struct::<DayOfWeekValue>(self.object_arena, u64::from(offset))?)),
+            FIELD_VALUE_HOUR => Ok(FieldValueSection::Hour(read_struct::<HourValue>(self.object_arena, u64::from(offset))?)),
+            FIELD_VALUE_PROTOCOL => Ok(FieldValueSection::Protocol(read_struct::<ProtocolValue>(self.object_arena, u64::from(offset))?)),
+            FIELD_VALUE_PORT => Ok(FieldValueSection::Port(read_struct::<PortValue>(self.object_arena, u64::from(offset))?)),
+            value => Err(RgpfError::InvalidEnum {
+                field: "field_value.type_tag",
+                value: u64::from(value),
+            }),
+        }
+    }
+
+    pub fn verdict(&self, offset: u32) -> Result<&'a VerdictEntry, RgpfError> {
+        read_struct::<VerdictEntry>(self.object_arena, u64::from(offset))
+    }
+}
+
+impl<'a> DefaultVerdictSection<'a> {
+    pub fn parse(section: SectionTable<'a>) -> Result<Self, RgpfError> {
+        let verdict = VerdictEntry::ref_from_bytes(section.bytes)
+            .map_err(|_| RgpfError::InvalidLayout("invalid default verdict layout"))?;
+
+        Ok(Self { verdict })
+    }
+
+    pub fn verdict(&self) -> &'a VerdictEntry {
+        self.verdict
+    }
+}
+
+fn read_bytes(bytes: &[u8], offset: u64, len: u64) -> Result<&[u8], RgpfError> {
+    let start = usize::try_from(offset).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+    let len = usize::try_from(len).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+    let end = start.checked_add(len).ok_or(RgpfError::IntegerOverflow)?;
+
+    bytes.get(start..end).ok_or(RgpfError::OffsetOutOfBounds)
+}
+
+fn read_struct<T>(bytes: &[u8], offset: u64) -> Result<&T, RgpfError> where T: FromBytes + KnownLayout + Immutable {
+    let start = usize::try_from(offset).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+    let end = start.checked_add(size_of::<T>()).ok_or(RgpfError::IntegerOverflow)?;
+
+    let window = bytes.get(start..end).ok_or(RgpfError::OffsetOutOfBounds)?;
+
+    T::ref_from_bytes(window).map_err(|_| RgpfError::InvalidLayout("invalid fixed-size object"))
+}
+
+fn read_array<T>(bytes: &[u8], offset: u64, count: usize) -> Result<&[T], RgpfError> where
+    T: FromBytes + KnownLayout + Immutable,
+{
+    let size = size_of::<T>();
+
+    let len = size.checked_mul(count).ok_or(RgpfError::IntegerOverflow)?;
+
+    let start = usize::try_from(offset).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+    let end = start.checked_add(len).ok_or(RgpfError::IntegerOverflow)?;
+
+    let window = bytes.get(start..end).ok_or(RgpfError::OffsetOutOfBounds)?;
+
+    <[T]>::ref_from_bytes_with_elems(window, count).map_err(|_| RgpfError::InvalidLayout("invalid fixed-size array"))
+}
+
+fn read_u32_array(bytes: &[u8], start: usize, count: u32) -> Result<&[LeU32], RgpfError> {
+    let count = usize::try_from(count).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+    let len = size_of::<LeU32>().checked_mul(count).ok_or(RgpfError::IntegerOverflow)?;
+
+    let end = start.checked_add(len).ok_or(RgpfError::IntegerOverflow)?;
+
+    let window = bytes.get(start..end).ok_or(RgpfError::OffsetOutOfBounds)?;
+
+    <[LeU32]>::ref_from_bytes_with_elems(window, count).map_err(|_| RgpfError::InvalidLayout("invalid u32 array"))
+}

--- a/src/policy/rgpf/sections/section_table.rs
+++ b/src/policy/rgpf/sections/section_table.rs
@@ -1,0 +1,31 @@
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
+
+use crate::policy::rgpf::endian::{LeU16, LeU32, LeU64};
+
+#[derive(Clone, Copy)]
+pub struct SectionTable<'a> {
+    pub entry: &'a SectionEntry,
+    pub bytes: &'a [u8],
+}
+
+impl<'a> SectionTable<'a> {
+    pub fn kind(&self) -> u16 {
+        self.entry.kind.get()
+    }
+
+    pub fn item_count(&self) -> u32 {
+        self.entry.item_count.get()
+    }
+}
+
+#[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct SectionEntry {
+    pub kind: LeU16,
+    pub flags: LeU16,
+    pub offset: LeU64,
+    pub length: LeU64,
+    pub item_count: LeU32,
+    pub reserved: LeU32,
+    pub section_hash: LeU64,
+}

--- a/src/policy/rgpf/sections/string_table.rs
+++ b/src/policy/rgpf/sections/string_table.rs
@@ -1,0 +1,35 @@
+use crate::policy::rgpf::errors::rgpf_error::RgpfError;
+
+#[derive(Clone, Copy)]
+pub struct StringTable<'a> {
+    bytes: &'a [u8],
+}
+
+impl<'a> StringTable<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes }
+    }
+
+    pub fn bytes(&self) -> &'a [u8] {
+        self.bytes
+    }
+
+    /// Odczytuje string zapisany jako `u32 length + bytes[length]`.
+    pub fn get(&self, offset: u32) -> Result<&'a str, RgpfError> {
+        let start = usize::try_from(offset).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+        
+        let len_end = start.checked_add(4).ok_or(RgpfError::IntegerOverflow)?;
+        
+        let len_bytes = self.bytes.get(start..len_end).ok_or(RgpfError::OffsetOutOfBounds)?;
+        
+        let len = u32::from_le_bytes(len_bytes.try_into().expect("exact 4 bytes"));
+        
+        let data_end = len_end
+            .checked_add(usize::try_from(len).map_err(|_| RgpfError::OffsetOutOfBounds)?)
+            .ok_or(RgpfError::IntegerOverflow)?;
+        
+        let data = self.bytes.get(len_end..data_end).ok_or(RgpfError::OffsetOutOfBounds)?;
+        
+        std::str::from_utf8(data).map_err(|_| RgpfError::InvalidUtf8)
+    }
+}

--- a/src/policy/rgpf/validators/mod.rs
+++ b/src/policy/rgpf/validators/mod.rs
@@ -1,0 +1,3 @@
+pub mod nat_validator;
+pub mod rgpf_file_validator;
+pub mod rule_tree_validator;

--- a/src/policy/rgpf/validators/nat_validator.rs
+++ b/src/policy/rgpf/validators/nat_validator.rs
@@ -1,0 +1,82 @@
+use crate::policy::rgpf::errors::rgpf_error::RgpfError;
+use crate::policy::rgpf::sections::rgpf_file::RgpfFile;
+use crate::policy::rgpf::sections::nat::sections::NatSection;
+
+use crate::policy::rgpf::constants::{
+    NAT_KIND_PAT,
+    NAT_KIND_DNAT,
+    NAT_KIND_SNAT,
+    NAT_PROTO_ANY,
+    NAT_PROTO_TCP,
+    NAT_PROTO_UDP,
+    NAT_PROTO_ICMP,
+    NAT_KIND_MASQUERADE,
+    NAT_STAGE_PREROUTING,
+    NAT_STAGE_POSTROUTING,
+};
+
+pub fn validate_nat(file: &RgpfFile<'_>, nat: &NatSection<'_>) -> Result<(), RgpfError> {
+    let strings = file.string_table()?;
+
+    for rule in nat.rules() {
+        strings.get(rule.id_str_off.get())?;
+        
+        if rule.name_str_off.get() != 0 {
+            strings.get(rule.name_str_off.get())?;
+        }
+
+        if !matches!(rule.enabled, 0 | 1) {
+            return Err(RgpfError::InvalidBool(rule.enabled));
+        }
+
+        if !matches!(rule.applies_at, NAT_STAGE_PREROUTING | NAT_STAGE_POSTROUTING) {
+            return Err(RgpfError::InvalidEnum {
+                field: "nat_rule.applies_at",
+                value: u64::from(rule.applies_at),
+            });
+        }
+
+        let match_index = usize::try_from(rule.match_index.get()).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+        
+        let kind_index = usize::try_from(rule.kind_index.get()).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+        
+        let timeout_index = usize::try_from(rule.timeouts_index.get()).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+        let match_entry = nat.matches().get(match_index).ok_or(RgpfError::OffsetOutOfBounds)?;
+        
+        let kind = nat.kinds().get(kind_index).ok_or(RgpfError::OffsetOutOfBounds)?;
+        
+        nat.timeouts().get(timeout_index).ok_or(RgpfError::OffsetOutOfBounds)?;
+
+        if !matches!(kind.kind_tag, NAT_KIND_SNAT | NAT_KIND_MASQUERADE | NAT_KIND_DNAT | NAT_KIND_PAT) {
+            return Err(RgpfError::InvalidEnum {
+                field: "nat_kind.kind_tag",
+                value: u64::from(kind.kind_tag),
+            });
+        }
+
+        let _ = match_entry.presence_bits.get();
+    }
+
+    let arena = nat.object_arena();
+    
+    let mut cursor = 0;
+    
+    while cursor < arena.len() {
+        if arena.len() - cursor < 4 {
+            break;
+        }
+        
+        let proto_kind = arena[cursor];
+        
+        if matches!(proto_kind, NAT_PROTO_ANY | NAT_PROTO_TCP | NAT_PROTO_UDP | NAT_PROTO_ICMP) {
+            cursor += 4;
+            
+            continue;
+        }
+        
+        cursor += 1;
+    }
+
+    Ok(())
+}

--- a/src/policy/rgpf/validators/rgpf_file_validator.rs
+++ b/src/policy/rgpf/validators/rgpf_file_validator.rs
@@ -1,0 +1,118 @@
+use std::mem::size_of;
+use std::collections::BTreeSet;
+
+use crate::policy::rgpf::errors::rgpf_error::RgpfError;
+use crate::policy::rgpf::sections::rgpf_header::RgpfHeader;
+use crate::policy::rgpf::sections::rgpf_file::{ensure_magic, ensure_version, RgpfFile};
+
+use crate::policy::rgpf::constants::{
+    SECTION_STRING_TABLE,
+    SECTION_NAT_RULE_TABLE,
+    SECTION_DEFAULT_VERDICT,
+    SECTION_RULE_TREE_TABLE,
+};
+
+pub fn validate_header(bytes: &[u8], header: &RgpfHeader) -> Result<(), RgpfError> {
+    ensure_magic(header.magic.get())?;
+
+    ensure_version(header.major.get(), header.minor.get())?;
+
+    let header_len = usize::from(header.header_len.get());
+
+    if header_len != size_of::<RgpfHeader>() {
+        return Err(RgpfError::InvalidHeaderLength(header.header_len.get()));
+    }
+
+    let declared_len = usize::try_from(header.file_len.get()).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+    if declared_len != bytes.len() {
+        return Err(RgpfError::InvalidFileLength {
+            declared: header.file_len.get(),
+            actual: bytes.len(),
+        });
+    }
+
+    let expected_crc = header.file_crc32c.get();
+
+    let actual_crc = crc32c_with_zeroed_field(bytes, file_crc32c_offset());
+
+    if expected_crc != actual_crc {
+        return Err(RgpfError::InvalidCrc32c);
+    }
+
+    Ok(())
+}
+
+pub fn validate_sections(file: &RgpfFile<'_>) -> Result<(), RgpfError> {
+    let mut kinds = BTreeSet::new();
+
+    for section in file.sections() {
+        let kind = section.kind.get();
+
+        if !kinds.insert(kind) {
+            return Err(RgpfError::DuplicateSection(kind));
+        }
+
+        let offset = usize::try_from(section.offset.get()).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+        let length = usize::try_from(section.length.get()).map_err(|_| RgpfError::OffsetOutOfBounds)?;
+
+        let end = offset.checked_add(length).ok_or(RgpfError::IntegerOverflow)?;
+
+        if end > file.bytes().len() {
+            return Err(RgpfError::SectionOutOfBounds);
+        }
+    }
+
+    if !kinds.contains(&SECTION_STRING_TABLE) {
+        return Err(RgpfError::MissingSection("STRING_TABLE"));
+    }
+
+    if !kinds.contains(&SECTION_RULE_TREE_TABLE) {
+        return Err(RgpfError::MissingSection("RULE_TREE_TABLE"));
+    }
+
+    if !kinds.contains(&SECTION_DEFAULT_VERDICT) {
+        return Err(RgpfError::MissingSection("DEFAULT_VERDICT"));
+    }
+
+    for kind in kinds {
+        if !matches!(
+            kind,
+            SECTION_STRING_TABLE | SECTION_RULE_TREE_TABLE | SECTION_DEFAULT_VERDICT | SECTION_NAT_RULE_TABLE
+        ) {
+            return Err(RgpfError::InvalidSection("unknown section kind"));
+        }
+    }
+
+    Ok(())
+}
+
+fn file_crc32c_offset() -> usize { 56 }
+
+fn crc32c_with_zeroed_field(bytes: &[u8], field_offset: usize) -> u32 {
+    let prefix = &bytes[..field_offset];
+    
+    let suffix = &bytes[field_offset + 4..];
+
+    let mut crc = crc32c_update(!0u32, prefix);
+    
+    crc = crc32c_update(crc, &[0, 0, 0, 0]);
+    crc = crc32c_update(crc, suffix);
+    
+    !crc
+}
+
+fn crc32c_update(mut crc: u32, bytes: &[u8]) -> u32 {
+    for byte in bytes {
+        crc ^= u32::from(*byte);
+        
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            
+            crc = (crc >> 1) ^ (0x82F63B78 & mask);
+        }
+    }
+
+    crc
+}

--- a/src/policy/rgpf/validators/rule_tree_validator.rs
+++ b/src/policy/rgpf/validators/rule_tree_validator.rs
@@ -1,0 +1,253 @@
+use crate::policy::rgpf::errors::rgpf_error::RgpfError;
+use crate::policy::rgpf::sections::rgpf_file::RgpfFile;
+use crate::policy::rgpf::sections::rule_tree::sections::{FieldValueSection, PatternSection, RuleTreeSection};
+
+use crate::policy::rgpf::constants::{
+    IP_VER_V4,
+    IP_VER_V6,
+    WEEKDAY_FRI,
+    WEEKDAY_MON,
+    WEEKDAY_SAT,
+    WEEKDAY_SUN,
+    WEEKDAY_THU,
+    WEEKDAY_TUE,
+    WEEKDAY_WED,
+    VERDICT_DROP,
+    PROTOCOL_TCP,
+    PROTOCOL_UDP,
+    PROTOCOL_ICMP,
+    VERDICT_ALLOW,
+    FIELD_VALUE_IP,
+    MATCH_KIND_HOUR,
+    NODE_KIND_MATCH,
+    PATTERN_KIND_OR,
+    FIELD_VALUE_PORT,
+    FIELD_VALUE_HOUR,
+    VERDICT_DROP_WARN,
+    NODE_KIND_VERDICT,
+    PATTERN_KIND_GLOB,
+    MATCH_KIND_SRC_IP,
+    MATCH_KIND_DST_IP,
+    COMPARISON_LESSER,
+    MATCH_KIND_IP_VER,
+    PATTERN_KIND_EQUAL,
+    VERDICT_ALLOW_WARN,
+    PATTERN_KIND_RANGE,
+    FIELD_VALUE_IP_VER,
+    COMPARISON_GREATER,
+    MATCH_KIND_SRC_PORT,
+    MATCH_KIND_DST_PORT,
+    MATCH_KIND_PROTOCOL,
+    FIELD_VALUE_PROTOCOL,
+    PATTERN_KIND_WILDCARD,
+    MATCH_KIND_DAY_OF_WEEK,
+    PATTERN_KIND_COMPARISON,
+    FIELD_VALUE_DAY_OF_WEEK,
+    COMPARISON_LESSER_OR_EQUAL,
+    COMPARISON_GREATER_OR_EQUAL,
+};
+
+pub fn validate_rule_tree(file: &RgpfFile<'_>, section: &RuleTreeSection<'_>) -> Result<(), RgpfError> {
+    let strings = file.string_table()?;
+
+    for rule in section.rules() {
+        strings.get(rule.name_str_off.get())?;
+        
+        if rule.desc_str_off.get() != 0 {
+            strings.get(rule.desc_str_off.get())?;
+        }
+        
+        section.node(rule.root_node_index.get())?;
+    }
+
+    for node in section.nodes() {
+        match node.node_kind {
+            NODE_KIND_MATCH => {
+                if node.pattern_off.get() == 0 || node.verdict_off.get() != 0 {
+                    return Err(RgpfError::InvalidLayout("match node has invalid payload offsets"));
+                }
+
+                validate_match_kind(node.match_kind)?;
+
+                if node.yes_index.get() == u32::MAX {
+                    return Err(RgpfError::InvalidLayout("match node must have yes_index"));
+                }
+
+                section.node(node.yes_index.get())?;
+                
+                if node.no_index.get() != u32::MAX {
+                    section.node(node.no_index.get())?;
+                }
+
+                validate_pattern(section, node.match_kind, node.pattern_off.get())?;
+            }
+            NODE_KIND_VERDICT => {
+                if node.pattern_off.get() != 0 || node.verdict_off.get() == 0 {
+                    return Err(RgpfError::InvalidLayout("verdict node has invalid payload offsets"));
+                }
+
+                validate_verdict(file, section.verdict(node.verdict_off.get())?)?;
+            }
+            value => {
+                return Err(RgpfError::InvalidEnum {
+                    field: "rule_node.node_kind",
+                    value: u64::from(value),
+                });
+            }
+        }
+    }
+
+    validate_verdict(file, file.default_verdict()?.verdict())?;
+
+    Ok(())
+}
+
+fn validate_match_kind(value: u8) -> Result<(), RgpfError> {
+    if matches!(
+        value,
+        MATCH_KIND_SRC_IP
+            | MATCH_KIND_DST_IP
+            | MATCH_KIND_IP_VER
+            | MATCH_KIND_DAY_OF_WEEK
+            | MATCH_KIND_HOUR
+            | MATCH_KIND_PROTOCOL
+            | MATCH_KIND_SRC_PORT
+            | MATCH_KIND_DST_PORT
+    ) {
+        return Ok(());
+    }
+
+    Err(RgpfError::InvalidEnum {
+        field: "rule_node.match_kind",
+        value: u64::from(value),
+    })
+}
+
+fn validate_pattern(section: &RuleTreeSection<'_>, match_kind: u8, offset: u32) -> Result<(), RgpfError> {
+    match section.pattern(offset)? {
+        PatternSection::Wildcard => Ok(()),
+        PatternSection::Equal(value) => validate_field_value(value),
+        PatternSection::Glob(value) => {
+            if !matches!(match_kind, MATCH_KIND_SRC_IP | MATCH_KIND_DST_IP) {
+                return Err(RgpfError::InvalidLayout("glob is only valid for ip matches"));
+            }
+            match value {
+                FieldValueSection::Ip(_) => Ok(()),
+                _ => Err(RgpfError::InvalidLayout("glob requires ip field value")),
+            }
+        }
+        PatternSection::Range { lo, hi } => {
+            if !matches!(match_kind, MATCH_KIND_SRC_PORT | MATCH_KIND_DST_PORT | MATCH_KIND_HOUR) {
+                return Err(RgpfError::InvalidLayout("range is invalid for this match kind"));
+            }
+            
+            validate_field_value(lo)?;
+            
+            validate_field_value(hi)
+        }
+        PatternSection::Comparison { op, rhs } => {
+            if !matches!(match_kind, MATCH_KIND_SRC_PORT | MATCH_KIND_DST_PORT | MATCH_KIND_HOUR | MATCH_KIND_DAY_OF_WEEK) {
+                return Err(RgpfError::InvalidLayout("comparison is invalid for this match kind"));
+            }
+            
+            if !matches!(op, COMPARISON_GREATER | COMPARISON_LESSER | COMPARISON_GREATER_OR_EQUAL | COMPARISON_LESSER_OR_EQUAL) {
+                return Err(RgpfError::InvalidEnum {
+                    field: "comparison.op",
+                    value: u64::from(op),
+                });
+            }
+            
+            validate_field_value(rhs)
+        }
+        PatternSection::Or(or_pattern) => {
+            if !matches!(
+                match_kind,
+                MATCH_KIND_PROTOCOL | MATCH_KIND_DAY_OF_WEEK | MATCH_KIND_IP_VER | MATCH_KIND_HOUR | MATCH_KIND_SRC_IP | MATCH_KIND_DST_IP
+            ) {
+                return Err(RgpfError::InvalidLayout("or is invalid for this match kind"));
+            }
+
+            for nested in or_pattern.pattern_offsets() {
+                match section.pattern(nested.get())? {
+                    PatternSection::Wildcard
+                    | PatternSection::Range { .. }
+                    | PatternSection::Comparison { .. }
+                    | PatternSection::Or(_) => return Err(RgpfError::InvalidLayout("nested or only supports simple patterns")),
+                    PatternSection::Equal(value) | PatternSection::Glob(value) => validate_field_value(value)?,
+                }
+            }
+
+            Ok(())
+        }
+    }
+}
+
+fn validate_field_value(value: FieldValueSection<'_>) -> Result<(), RgpfError> {
+    match value {
+        FieldValueSection::Ip(ip) => {
+            for mask in [ip.mask0, ip.mask1, ip.mask2, ip.mask3] {
+                if !matches!(mask, 0 | 1) {
+                    return Err(RgpfError::InvalidBool(mask));
+                }
+            }
+            
+            Ok(())
+        }
+        FieldValueSection::IpVer(value) => {
+            if !matches!(value.value, IP_VER_V4 | IP_VER_V6) {
+                return Err(RgpfError::InvalidEnum {
+                    field: "ip_ver.value",
+                    value: u64::from(value.value),
+                });
+            }
+            
+            Ok(())
+        }
+        FieldValueSection::DayOfWeek(value) => {
+            if !matches!(value.value, WEEKDAY_MON | WEEKDAY_TUE | WEEKDAY_WED | WEEKDAY_THU | WEEKDAY_FRI | WEEKDAY_SAT | WEEKDAY_SUN) {
+                return Err(RgpfError::InvalidEnum {
+                    field: "day_of_week.value",
+                    value: u64::from(value.value),
+                });
+            }
+            
+            Ok(())
+        }
+        FieldValueSection::Hour(value) => {
+            if value.value > 23 {
+                return Err(RgpfError::InvalidEnum {
+                    field: "hour.value",
+                    value: u64::from(value.value),
+                });
+            }
+            
+            Ok(())
+        }
+        FieldValueSection::Protocol(value) => {
+            if !matches!(value.value, PROTOCOL_TCP | PROTOCOL_UDP | PROTOCOL_ICMP) {
+                return Err(RgpfError::InvalidEnum {
+                    field: "protocol.value",
+                    value: u64::from(value.value),
+                });
+            }
+            
+            Ok(())
+        }
+        FieldValueSection::Port(_) => Ok(()),
+    }
+}
+
+fn validate_verdict(file: &RgpfFile<'_>, verdict: &crate::policy::rgpf::sections::rule_tree::entries::VerdictEntry) -> Result<(), RgpfError> {
+    if !matches!(verdict.verdict_kind, VERDICT_ALLOW | VERDICT_DROP | VERDICT_ALLOW_WARN | VERDICT_DROP_WARN) {
+        return Err(RgpfError::InvalidEnum {
+            field: "verdict.kind",
+            value: u64::from(verdict.verdict_kind),
+        });
+    }
+
+    if verdict.message_str_off.get() != 0 {
+        file.string_table()?.get(verdict.message_str_off.get())?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Add a zero-copy parser for the RGPF/1 binary policy format using `zerocopy`. Split the implementation into section headers, entries, constants, endian helpers, and error handling.
Validate rule-tree and NAT sections, including layouts, offsets, and CRC32C, and update the documentation for firewall runtime integration.