### PR TITLE
feat(config): add GET /config/history endpoint to list config snapshots

### DIFF
--- a/backend/data/json-db/users.json
+++ b/backend/data/json-db/users.json
@@ -4,10 +4,10 @@
       "id": "00000000-0000-4000-8000-000000000001",
       "username": "admin",
       "passwordHash": "$2b$12$IvZ.EXRyRNI9y7iQFoV.8emVe9hYXwK8lF.lkj.aPLmnFVUaD5KjW",
-      "refreshToken": "b8344406-2791-4d26-9b12-d44a66797178",
-      "refreshTokenExpiry": "2026-03-23T18:35:08.517Z",
+      "refreshToken": "bce8b10b-3de7-4695-8239-4a0f430f66f3",
+      "refreshTokenExpiry": "2026-03-24T08:02:45.205Z",
       "createdAt": "2026-03-18T21:30:42.644Z",
-      "updatedAt": "2026-03-23T17:35:08.517Z"
+      "updatedAt": "2026-03-24T07:02:45.205Z"
     }
   ]
 }

--- a/backend/src/application/dtos/get-config-history.dto.ts
+++ b/backend/src/application/dtos/get-config-history.dto.ts
@@ -1,0 +1,5 @@
+import { ConfigurationSnapshot } from 'src/domain/entities/configuration-snapshot.entity';
+
+export class GetConfigHistoryDto {
+  configHistory: ConfigurationSnapshot[];
+}

--- a/backend/src/application/use-cases/get-config-history.use-case.ts
+++ b/backend/src/application/use-cases/get-config-history.use-case.ts
@@ -1,0 +1,19 @@
+import { CONFIG_SNAPSHOT_REPOSITORY_TOKEN } from 'src/domain/repositories/config-snapshot.repository';
+import type { IConfigSnapshotRepository } from 'src/domain/repositories/config-snapshot.repository';
+import { Inject, Injectable } from '@nestjs/common';
+import { GetConfigHistoryDto } from '../dtos/get-config-history.dto';
+
+@Injectable()
+export class GetConfigHistoryUseCase {
+  constructor(
+    @Inject(CONFIG_SNAPSHOT_REPOSITORY_TOKEN)
+    private readonly configSnapshotRepository: IConfigSnapshotRepository,
+  ) {}
+
+  async execute(): Promise<GetConfigHistoryDto> {
+    const configHistory =
+      await this.configSnapshotRepository.findAllSnapshots();
+
+    return { configHistory };
+  }
+}

--- a/backend/src/modules/config-snapshot.module.ts
+++ b/backend/src/modules/config-snapshot.module.ts
@@ -1,13 +1,18 @@
+import { JsonRolePermissionsRepository } from 'src/infrastructure/persistence/repositories/json-role-permissions.repository';
 import { JsonConfigSnapshotRepository } from 'src/infrastructure/persistence/repositories/json-config-snapshot.repository';
 import { JsonPermissionRepository } from 'src/infrastructure/persistence/repositories/json-permission.repository';
+import { JsonUserRoleRepository } from 'src/infrastructure/persistence/repositories/json-user-role.repository';
 import { JsonZonePairRepository } from 'src/infrastructure/persistence/repositories/json-zone-pair.repository';
 import { JsonNatRuleRepository } from 'src/infrastructure/persistence/repositories/json-nat-rule.repository';
+import { ROLE_PERMISSIONS_REPOSITORY_TOKEN } from 'src/domain/repositories/role-permissions.repository';
 import { ApplyConfigSnapshotUseCase } from 'src/application/use-cases/apply-config-snapshot.use-case';
 import { CONFIG_SNAPSHOT_REPOSITORY_TOKEN } from 'src/domain/repositories/config-snapshot.repository';
 import { JsonRuleRepository } from 'src/infrastructure/persistence/repositories/json-rule.repository';
 import { JsonRoleRepository } from 'src/infrastructure/persistence/repositories/json-role.repository';
 import { JsonUserRepository } from 'src/infrastructure/persistence/repositories/json-user.repository';
 import { JsonZoneRepository } from 'src/infrastructure/persistence/repositories/json-zone.repository';
+import { GetConfigHistoryUseCase } from 'src/application/use-cases/get-config-history.use-case';
+import { USER_ROLES_REPOSITORY_TOKEN } from 'src/domain/repositories/user-roles.repository';
 import { PERMISSION_REPOSITORY_TOKEN } from 'src/domain/repositories/permission.repository';
 import { ZONE_PAIR_REPOSITORY_TOKEN } from 'src/domain/repositories/zone-pair.repository';
 import { NAT_RULES_REPOSITORY_TOKEN } from 'src/domain/repositories/nat-rules.repository';
@@ -22,16 +27,13 @@ import { FileStore } from 'src/infrastructure/persistence/json/file-store';
 import { Mutex } from 'src/infrastructure/persistence/json/file-mutex';
 import { JwtService } from '@nestjs/jwt';
 import { Module } from '@nestjs/common';
-import { USER_ROLES_REPOSITORY_TOKEN } from 'src/domain/repositories/user-roles.repository';
-import { JsonUserRoleRepository } from 'src/infrastructure/persistence/repositories/json-user-role.repository';
-import { ROLE_PERMISSIONS_REPOSITORY_TOKEN } from 'src/domain/repositories/role-permissions.repository';
-import { JsonRolePermissionsRepository } from 'src/infrastructure/persistence/repositories/json-role-permissions.repository';
 
 @Module({
   imports: [],
   controllers: [ConfigController],
   providers: [
     ApplyConfigSnapshotUseCase,
+    GetConfigHistoryUseCase,
     FileStore,
     Mutex,
     {

--- a/backend/src/presentation/controllers/config.controller.ts
+++ b/backend/src/presentation/controllers/config.controller.ts
@@ -1,9 +1,11 @@
 import { ApplyConfigSnapshotUseCase } from 'src/application/use-cases/apply-config-snapshot.use-case';
 import { RequirePermissions } from 'src/infrastructure/decorators/require-permissions.decorator';
+import { GetConfigHistoryUseCase } from 'src/application/use-cases/get-config-history.use-case';
+import { GetConfigHistoryResponseDto } from '../dtos/get-config-history-response.dto';
 import { ExtractToken } from 'src/infrastructure/decorators/extract-token.decorator';
 import { ApplyConfigSnapshotDto } from '../dtos/apply-config-snapshot.dto';
 import { Roles } from 'src/infrastructure/decorators/roles.decorator';
-import { Body, Controller, Inject, Post } from '@nestjs/common';
+import { Body, Controller, Get, Inject, Post } from '@nestjs/common';
 import { Permission } from 'src/domain/enums/permissions.enum';
 import { Role } from 'src/domain/enums/role.enum';
 import { ApiOperation } from '@nestjs/swagger';
@@ -13,6 +15,8 @@ export class ConfigController {
   constructor(
     @Inject(ApplyConfigSnapshotUseCase)
     private readonly applyConfigSnapshotUseCase: ApplyConfigSnapshotUseCase,
+    @Inject(GetConfigHistoryUseCase)
+    private readonly getConfigHistoryUseCase: GetConfigHistoryUseCase,
   ) {}
 
   @ApiOperation({
@@ -28,5 +32,17 @@ export class ConfigController {
     @ExtractToken() accessToken: string,
   ): Promise<void> {
     await this.applyConfigSnapshotUseCase.execute({ ...dto, accessToken });
+  }
+
+  @ApiOperation({
+    summary: 'History of configuration snapshots',
+    description:
+      'Gets the history of all configuration snapshots, including active and inactive ones.',
+  })
+  @Roles(Role.Viewer)
+  @Get('history')
+  async getConfigHistory(): Promise<GetConfigHistoryResponseDto> {
+    const configHistory = await this.getConfigHistoryUseCase.execute();
+    return configHistory;
   }
 }

--- a/backend/src/presentation/dtos/get-config-history-response.dto.ts
+++ b/backend/src/presentation/dtos/get-config-history-response.dto.ts
@@ -1,0 +1,5 @@
+import { ConfigurationSnapshot } from 'src/domain/entities/configuration-snapshot.entity';
+
+export class GetConfigHistoryResponseDto {
+  configHistory: ConfigurationSnapshot[];
+}


### PR DESCRIPTION
This pull request introduces a new feature to retrieve the history of configuration snapshots through the API. It adds a use case, DTOs, and a new endpoint in the `ConfigController` to expose all configuration snapshots (active and inactive) to users with the Viewer role. Additionally, it makes minor updates to the user database.

**New configuration snapshot history feature:**

* Added `GetConfigHistoryUseCase` to encapsulate the logic for fetching all configuration snapshots from the repository.
* Created DTOs: `GetConfigHistoryDto` for the application layer and `GetConfigHistoryResponseDto` for the presentation layer, both containing a list of `ConfigurationSnapshot` objects. [[1]](diffhunk://#diff-47a0ffc486e955ecba152b244b3e6c27eb40ca5b1223cd575edd59cccb3dbc1eR1-R5) [[2]](diffhunk://#diff-ed3fd7c91d722c8515345a1a898ab2b06437aec49f57e37b9d92d76dc48d55baR1-R5)
* Registered the new use case in the `ConfigSnapshotModule` providers. [[1]](diffhunk://#diff-57cd82af178792bb15586c9bb1f01b41370503fd2a882e3937179d2fecc806c7R1-R15) [[2]](diffhunk://#diff-57cd82af178792bb15586c9bb1f01b41370503fd2a882e3937179d2fecc806c7L25-R36)
* Added a new `GET /history` endpoint to `ConfigController` for retrieving configuration snapshot history, accessible to users with the Viewer role. [[1]](diffhunk://#diff-06fa5f12f3d50eee5f2922744811fe455b87cdbfaf842875e1e139170e6fff8fR3-R8) [[2]](diffhunk://#diff-06fa5f12f3d50eee5f2922744811fe455b87cdbfaf842875e1e139170e6fff8fR18-R19) [[3]](diffhunk://#diff-06fa5f12f3d50eee5f2922744811fe455b87cdbfaf842875e1e139170e6fff8fR36-R47)

**Other changes:**

* Updated the `admin` user's refresh token and expiry in `users.json` for token validity.