### PR TITLE
feat(firewall): implement IPS runtime with hot-swappable config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,7 @@ dependencies = [
  "protoc-bin-vendored",
  "rcgen",
  "redb",
+ "regex",
  "ring",
  "ringbuffer",
  "rustc-hash",

--- a/crates/raptorgate/Cargo.toml
+++ b/crates/raptorgate/Cargo.toml
@@ -44,6 +44,7 @@ mockall = "0.14.0"
 simple-dns = "0.11.2"
 tls-parser = "0.12.2"
 httparse = "1.10"
+regex = "1.12.2"
 
 [dev-dependencies]
 serial_test = "3.2.0"

--- a/crates/raptorgate/src/data_plane/ips/config.rs
+++ b/crates/raptorgate/src/data_plane/ips/config.rs
@@ -1,0 +1,475 @@
+use regex::bytes::Regex;
+use serde::{Deserialize, Serialize};
+use anyhow::{Context, Result, anyhow, bail};
+
+use crate::dpi::AppProto;
+use crate::proto::{common, config as proto};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct IpsConfig {
+    pub general: IpsGeneralConfig,
+    pub detection: IpsDetectionConfig,
+    pub signatures: Vec<IpsSignatureConfig>,
+}
+
+impl Default for IpsConfig {
+    fn default() -> Self {
+        Self {
+            general: IpsGeneralConfig::default(),
+            detection: IpsDetectionConfig::default(),
+            signatures: Vec::new(),
+        }
+    }
+}
+
+impl IpsConfig {
+    pub fn to_proto(&self) -> proto::IpsConfig {
+        proto::IpsConfig {
+            general: Some(self.general.to_proto()),
+            detection: Some(self.detection.to_proto()),
+            signatures: self
+                .signatures
+                .iter()
+                .map(IpsSignatureConfig::to_proto)
+                .collect(),
+        }
+    }
+
+    pub fn from_proto(proto_config: proto::IpsConfig) -> Result<Self> {
+        Ok(Self {
+            general: IpsGeneralConfig::from_proto(proto_config.general.unwrap_or_default()),
+            detection: IpsDetectionConfig::from_proto(proto_config.detection.unwrap_or_default())?,
+            signatures: proto_config
+                .signatures
+                .into_iter()
+                .map(IpsSignatureConfig::from_proto)
+                .collect::<Result<Vec<_>>>()?,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct IpsGeneralConfig {
+    pub enabled: bool,
+}
+
+impl Default for IpsGeneralConfig {
+    fn default() -> Self {
+        Self { enabled: false }
+    }
+}
+
+impl IpsGeneralConfig {
+    fn to_proto(&self) -> proto::IpsGeneralConfig {
+        proto::IpsGeneralConfig {
+            enabled: self.enabled,
+        }
+    }
+
+    fn from_proto(proto_config: proto::IpsGeneralConfig) -> Self {
+        Self {
+            enabled: proto_config.enabled,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct IpsDetectionConfig {
+    pub enabled: bool,
+    pub max_payload_bytes: usize,
+    pub max_matches_per_packet: usize,
+}
+
+impl Default for IpsDetectionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_payload_bytes: 4096,
+            max_matches_per_packet: 8,
+        }
+    }
+}
+
+impl IpsDetectionConfig {
+    fn to_proto(&self) -> proto::IpsDetectionConfig {
+        proto::IpsDetectionConfig {
+            enabled: self.enabled,
+            max_payload_bytes: self.max_payload_bytes as u32,
+            max_matches_per_packet: self.max_matches_per_packet as u32,
+        }
+    }
+
+    fn from_proto(proto_config: proto::IpsDetectionConfig) -> Result<Self> {
+        let defaults = Self::default();
+        let max_payload_bytes = if proto_config.max_payload_bytes == 0 {
+            defaults.max_payload_bytes
+        } else {
+            usize::try_from(proto_config.max_payload_bytes)
+                .context("ips.detection.max_payload_bytes does not fit into usize")?
+        };
+        let max_matches_per_packet = if proto_config.max_matches_per_packet == 0 {
+            defaults.max_matches_per_packet
+        } else {
+            usize::try_from(proto_config.max_matches_per_packet)
+                .context("ips.detection.max_matches_per_packet does not fit into usize")?
+        };
+
+        Ok(Self {
+            enabled: proto_config.enabled,
+            max_payload_bytes,
+            max_matches_per_packet,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct IpsSignatureConfig {
+    pub id: String,
+    pub name: String,
+    pub enabled: bool,
+    pub category: String,
+    pub pattern: String,
+    pub severity: IpsSeverity,
+    pub action: IpsAction,
+    pub app_protocols: Vec<IpsAppProtocol>,
+    pub src_ports: Vec<u16>,
+    pub dst_ports: Vec<u16>,
+}
+
+impl Default for IpsSignatureConfig {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            name: String::new(),
+            enabled: false,
+            category: "other".to_string(),
+            pattern: String::new(),
+            severity: IpsSeverity::default(),
+            action: IpsAction::default(),
+            app_protocols: Vec::new(),
+            src_ports: Vec::new(),
+            dst_ports: Vec::new(),
+        }
+    }
+}
+
+impl IpsSignatureConfig {
+    fn to_proto(&self) -> proto::IpsSignatureConfig {
+        proto::IpsSignatureConfig {
+            id: self.id.clone(),
+            name: self.name.clone(),
+            enabled: self.enabled,
+            category: self.category.clone(),
+            pattern: self.pattern.clone(),
+            severity: self.severity.to_proto() as i32,
+            action: self.action.to_proto() as i32,
+            app_protocols: self
+                .app_protocols
+                .iter()
+                .map(|proto| proto.to_proto() as i32)
+                .collect(),
+            src_ports: self.src_ports.iter().map(|port| u32::from(*port)).collect(),
+            dst_ports: self.dst_ports.iter().map(|port| u32::from(*port)).collect(),
+        }
+    }
+
+    fn from_proto(proto_config: proto::IpsSignatureConfig) -> Result<Self> {
+        if proto_config.id.trim().is_empty() {
+            bail!("ips signature id must not be empty");
+        }
+        if proto_config.name.trim().is_empty() {
+            bail!("ips signature name must not be empty");
+        }
+        if proto_config.pattern.trim().is_empty() {
+            bail!("ips signature pattern must not be empty");
+        }
+
+        Regex::new(&proto_config.pattern).with_context(|| {
+            format!(
+                "ips signature '{}' has invalid regex pattern",
+                proto_config.id
+            )
+        })?;
+
+        let src_ports = proto_config
+            .src_ports
+            .into_iter()
+            .map(parse_port)
+            .collect::<Result<Vec<_>>>()?;
+        let dst_ports = proto_config
+            .dst_ports
+            .into_iter()
+            .map(parse_port)
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self {
+            id: proto_config.id,
+            name: proto_config.name,
+            enabled: proto_config.enabled,
+            category: normalize_category(proto_config.category),
+            pattern: proto_config.pattern,
+            severity: IpsSeverity::from_proto(proto_config.severity)?,
+            action: IpsAction::from_proto(proto_config.action)?,
+            app_protocols: proto_config
+                .app_protocols
+                .into_iter()
+                .map(IpsAppProtocol::from_proto)
+                .collect::<Result<Vec<_>>>()?,
+            src_ports,
+            dst_ports,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum IpsSeverity {
+    Info,
+    #[default]
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+impl IpsSeverity {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Critical => "critical",
+        }
+    }
+
+    fn to_proto(self) -> common::Severity {
+        match self {
+            Self::Info => common::Severity::Info,
+            Self::Low => common::Severity::Low,
+            Self::Medium => common::Severity::Medium,
+            Self::High => common::Severity::High,
+            Self::Critical => common::Severity::Critical,
+        }
+    }
+
+    fn from_proto(value: i32) -> Result<Self> {
+        let severity = common::Severity::try_from(value)
+            .map_err(|_| anyhow!("invalid ips severity value: {value}"))?;
+
+        Ok(match severity {
+            common::Severity::Unspecified => Self::default(),
+            common::Severity::Info => Self::Info,
+            common::Severity::Low => Self::Low,
+            common::Severity::Medium => Self::Medium,
+            common::Severity::High => Self::High,
+            common::Severity::Critical => Self::Critical,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum IpsAction {
+    #[default]
+    Alert,
+    Block,
+}
+
+impl IpsAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Alert => "alert",
+            Self::Block => "block",
+        }
+    }
+
+    fn to_proto(self) -> proto::IpsAction {
+        match self {
+            Self::Alert => proto::IpsAction::Alert,
+            Self::Block => proto::IpsAction::Block,
+        }
+    }
+
+    fn from_proto(value: i32) -> Result<Self> {
+        let action = proto::IpsAction::try_from(value)
+            .map_err(|_| anyhow!("invalid ips action value: {value}"))?;
+
+        Ok(match action {
+            proto::IpsAction::Unspecified | proto::IpsAction::Alert => Self::Alert,
+            proto::IpsAction::Block => Self::Block,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum IpsAppProtocol {
+    Http,
+    Tls,
+    Dns,
+    Ssh,
+    Ftp,
+    Smtp,
+    Rdp,
+    Smb,
+    Quic,
+    Unknown,
+}
+
+impl IpsAppProtocol {
+    pub fn matches(self, proto: AppProto) -> bool {
+        matches!(
+            (self, proto),
+            (Self::Http, AppProto::Http)
+                | (Self::Tls, AppProto::Tls)
+                | (Self::Dns, AppProto::Dns)
+                | (Self::Ssh, AppProto::Ssh)
+                | (Self::Ftp, AppProto::Ftp)
+                | (Self::Smtp, AppProto::Smtp)
+                | (Self::Rdp, AppProto::Rdp)
+                | (Self::Smb, AppProto::Smb)
+                | (Self::Quic, AppProto::Quic)
+                | (Self::Unknown, AppProto::Unknown)
+        )
+    }
+
+    fn to_proto(self) -> proto::IpsAppProtocol {
+        match self {
+            Self::Http => proto::IpsAppProtocol::Http,
+            Self::Tls => proto::IpsAppProtocol::Tls,
+            Self::Dns => proto::IpsAppProtocol::Dns,
+            Self::Ssh => proto::IpsAppProtocol::Ssh,
+            Self::Ftp => proto::IpsAppProtocol::Ftp,
+            Self::Smtp => proto::IpsAppProtocol::Smtp,
+            Self::Rdp => proto::IpsAppProtocol::Rdp,
+            Self::Smb => proto::IpsAppProtocol::Smb,
+            Self::Quic => proto::IpsAppProtocol::Quic,
+            Self::Unknown => proto::IpsAppProtocol::Unknown,
+        }
+    }
+
+    fn from_proto(value: i32) -> Result<Self> {
+        let protocol = proto::IpsAppProtocol::try_from(value)
+            .map_err(|_| anyhow!("invalid ips app protocol value: {value}"))?;
+
+        Ok(match protocol {
+            proto::IpsAppProtocol::Http => Self::Http,
+            proto::IpsAppProtocol::Tls => Self::Tls,
+            proto::IpsAppProtocol::Dns => Self::Dns,
+            proto::IpsAppProtocol::Ssh => Self::Ssh,
+            proto::IpsAppProtocol::Ftp => Self::Ftp,
+            proto::IpsAppProtocol::Smtp => Self::Smtp,
+            proto::IpsAppProtocol::Rdp => Self::Rdp,
+            proto::IpsAppProtocol::Smb => Self::Smb,
+            proto::IpsAppProtocol::Quic => Self::Quic,
+            proto::IpsAppProtocol::Unknown => Self::Unknown,
+            proto::IpsAppProtocol::Unspecified => {
+                bail!("ips app protocol filter must not contain unspecified");
+            }
+        })
+    }
+}
+
+fn parse_port(value: u32) -> Result<u16> {
+    let port = u16::try_from(value).context("ips port filter does not fit into u16")?;
+    if port == 0 {
+        bail!("ips port filter must be greater than zero");
+    }
+    Ok(port)
+}
+
+fn normalize_category(category: String) -> String {
+    let trimmed = category.trim();
+    if trimmed.is_empty() {
+        "other".to_string()
+    } else {
+        trimmed.to_lowercase()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proto_roundtrip_keeps_signature_filters() {
+        let config = IpsConfig {
+            general: IpsGeneralConfig { enabled: true },
+            detection: IpsDetectionConfig {
+                enabled: true,
+                max_payload_bytes: 1024,
+                max_matches_per_packet: 2,
+            },
+            signatures: vec![IpsSignatureConfig {
+                id: "sig-1".into(),
+                name: "SQLi".into(),
+                enabled: true,
+                category: "sqli".into(),
+                pattern: "(?i)union\\s+select".into(),
+                severity: IpsSeverity::High,
+                action: IpsAction::Block,
+                app_protocols: vec![IpsAppProtocol::Http],
+                src_ports: vec![12345],
+                dst_ports: vec![80, 8080],
+            }],
+        };
+
+        let roundtrip = IpsConfig::from_proto(config.to_proto()).expect("config should roundtrip");
+        assert_eq!(roundtrip, config);
+    }
+
+    #[test]
+    fn from_proto_rejects_invalid_regex() {
+        let err = IpsConfig::from_proto(proto::IpsConfig {
+            general: Some(proto::IpsGeneralConfig { enabled: true }),
+            detection: Some(proto::IpsDetectionConfig {
+                enabled: true,
+                max_payload_bytes: 1024,
+                max_matches_per_packet: 1,
+            }),
+            signatures: vec![proto::IpsSignatureConfig {
+                id: "sig-1".into(),
+                name: "broken".into(),
+                enabled: true,
+                category: "other".into(),
+                pattern: "(".into(),
+                severity: common::Severity::High as i32,
+                action: proto::IpsAction::Block as i32,
+                app_protocols: vec![],
+                src_ports: vec![],
+                dst_ports: vec![],
+            }],
+        })
+        .expect_err("invalid regex should be rejected");
+
+        assert!(err.to_string().contains("invalid regex"));
+    }
+
+    #[test]
+    fn zero_detection_limits_fall_back_to_defaults() {
+        let config = IpsConfig::from_proto(proto::IpsConfig {
+            general: Some(proto::IpsGeneralConfig { enabled: true }),
+            detection: Some(proto::IpsDetectionConfig {
+                enabled: true,
+                max_payload_bytes: 0,
+                max_matches_per_packet: 0,
+            }),
+            signatures: vec![],
+        })
+        .expect("zero values should be normalized");
+
+        assert_eq!(
+            config.detection.max_payload_bytes,
+            IpsDetectionConfig::default().max_payload_bytes
+        );
+        assert_eq!(
+            config.detection.max_matches_per_packet,
+            IpsDetectionConfig::default().max_matches_per_packet
+        );
+    }
+}

--- a/crates/raptorgate/src/data_plane/ips/ips.rs
+++ b/crates/raptorgate/src/data_plane/ips/ips.rs
@@ -1,0 +1,334 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use arc_swap::ArcSwap;
+use regex::bytes::Regex;
+use anyhow::{Context, Result};
+use etherparse::TransportSlice;
+
+use crate::data_plane::ips::config::{
+    IpsAction, IpsAppProtocol, IpsConfig, IpsSeverity, IpsSignatureConfig,
+};
+
+use crate::dpi::AppProto;
+use crate::data_plane::packet_context::PacketContext;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IpsVerdict {
+    Allow,
+    Alert(String),
+    Block(String),
+}
+
+pub struct Ips {
+    enabled: AtomicBool,
+    detection_enabled: AtomicBool,
+    state: ArcSwap<CompiledIpsState>,
+}
+
+impl Ips {
+    pub fn new(config: IpsConfig) -> Result<Arc<Self>> {
+        Ok(Arc::new(Self {
+            enabled: AtomicBool::new(config.general.enabled),
+            detection_enabled: AtomicBool::new(config.detection.enabled),
+            state: ArcSwap::new(Arc::new(CompiledIpsState::from_config(&config)?)),
+        }))
+    }
+
+    pub fn update_config(&self, config: &IpsConfig) -> Result<()> {
+        self.enabled
+            .store(config.general.enabled, Ordering::Release);
+        self.detection_enabled
+            .store(config.detection.enabled, Ordering::Release);
+        self.state
+            .store(Arc::new(CompiledIpsState::from_config(config)?));
+        Ok(())
+    }
+
+    pub fn inspect_packet(&self, ctx: &PacketContext) -> IpsVerdict {
+        if !self.enabled.load(Ordering::Acquire) || !self.detection_enabled.load(Ordering::Acquire)
+        {
+            return IpsVerdict::Allow;
+        }
+
+        let dpi_app_proto = ctx
+            .borrow_dpi_ctx()
+            .as_ref()
+            .and_then(|dpi_ctx| dpi_ctx.app_proto);
+
+        let sliced_packet = ctx.borrow_sliced_packet();
+        
+        let (payload, src_port, dst_port) = match &sliced_packet.transport {
+            Some(TransportSlice::Tcp(tcp)) => {
+                (tcp.payload(), tcp.source_port(), tcp.destination_port())
+            }
+            Some(TransportSlice::Udp(udp)) => {
+                (udp.payload(), udp.source_port(), udp.destination_port())
+            }
+            _ => return IpsVerdict::Allow,
+        };
+
+        if payload.is_empty() {
+            return IpsVerdict::Allow;
+        }
+
+        let state = self.state.load();
+        
+        let inspected = if payload.len() > state.max_payload_bytes {
+            &payload[..state.max_payload_bytes]
+        } else {
+            payload
+        };
+
+        let mut alerts = Vec::new();
+        let mut matches = 0usize;
+
+        for signature in &state.signatures {
+            if matches >= state.max_matches_per_packet {
+                break;
+            }
+            if !signature.matches_filters(dpi_app_proto, src_port, dst_port) {
+                continue;
+            }
+            if !signature.regex.is_match(inspected) {
+                continue;
+            }
+
+            matches += 1;
+            let message = signature.verdict_message();
+            if signature.action == IpsAction::Block {
+                return IpsVerdict::Block(message);
+            }
+            alerts.push(message);
+        }
+
+        if alerts.is_empty() {
+            IpsVerdict::Allow
+        } else {
+            IpsVerdict::Alert(alerts.join("; "))
+        }
+    }
+}
+
+#[derive(Clone)]
+struct CompiledIpsState {
+    max_payload_bytes: usize,
+    max_matches_per_packet: usize,
+    signatures: Vec<CompiledSignature>,
+}
+
+impl CompiledIpsState {
+    fn from_config(config: &IpsConfig) -> Result<Self> {
+        Ok(Self {
+            max_payload_bytes: config.detection.max_payload_bytes,
+            max_matches_per_packet: config.detection.max_matches_per_packet,
+            signatures: config
+                .signatures
+                .iter()
+                .filter(|signature| signature.enabled)
+                .map(CompiledSignature::from_config)
+                .collect::<Result<Vec<_>>>()?,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct CompiledSignature {
+    id: String,
+    name: String,
+    category: String,
+    severity: IpsSeverity,
+    action: IpsAction,
+    app_protocols: Vec<IpsAppProtocol>,
+    src_ports: Vec<u16>,
+    dst_ports: Vec<u16>,
+    regex: Regex,
+}
+
+impl CompiledSignature {
+    fn from_config(config: &IpsSignatureConfig) -> Result<Self> {
+        Ok(Self {
+            id: config.id.clone(),
+            name: config.name.clone(),
+            category: config.category.clone(),
+            severity: config.severity,
+            action: config.action,
+            app_protocols: config.app_protocols.clone(),
+            src_ports: config.src_ports.clone(),
+            dst_ports: config.dst_ports.clone(),
+            regex: Regex::new(&config.pattern)
+                .with_context(|| format!("failed to compile ips signature '{}'", config.id))?,
+        })
+    }
+
+    fn matches_filters(&self, app_proto: Option<AppProto>, src_port: u16, dst_port: u16) -> bool {
+        (self.app_protocols.is_empty()
+            || app_proto.is_some_and(|proto| {
+                self.app_protocols
+                    .iter()
+                    .any(|filter| filter.matches(proto))
+            }))
+            && (self.src_ports.is_empty() || self.src_ports.contains(&src_port))
+            && (self.dst_ports.is_empty() || self.dst_ports.contains(&dst_port))
+    }
+
+    fn verdict_message(&self) -> String {
+        format!(
+            "IPS {}: signature '{}' matched (id={}, category={}, severity={})",
+            self.action.as_str(),
+            self.name,
+            self.id,
+            self.category,
+            self.severity.as_str(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::SystemTime;
+
+    use etherparse::PacketBuilder;
+
+    use super::*;
+    use crate::data_plane::ips::config::{IpsDetectionConfig, IpsGeneralConfig};
+    use crate::dpi::{AppProto, DpiContext};
+
+    fn make_config() -> IpsConfig {
+        IpsConfig {
+            general: IpsGeneralConfig { enabled: true },
+            detection: IpsDetectionConfig {
+                enabled: true,
+                max_payload_bytes: 512,
+                max_matches_per_packet: 4,
+            },
+            signatures: vec![
+                IpsSignatureConfig {
+                    id: "http-sqli".into(),
+                    name: "SQLi".into(),
+                    enabled: true,
+                    category: "sqli".into(),
+                    pattern: "(?i)union\\s+select".into(),
+                    severity: IpsSeverity::High,
+                    action: IpsAction::Block,
+                    app_protocols: vec![IpsAppProtocol::Http],
+                    src_ports: vec![],
+                    dst_ports: vec![80],
+                },
+                IpsSignatureConfig {
+                    id: "ua-curl".into(),
+                    name: "Curl UA".into(),
+                    enabled: true,
+                    category: "other".into(),
+                    pattern: "(?i)curl/".into(),
+                    severity: IpsSeverity::Low,
+                    action: IpsAction::Alert,
+                    app_protocols: vec![IpsAppProtocol::Http],
+                    src_ports: vec![],
+                    dst_ports: vec![],
+                },
+            ],
+        }
+    }
+
+    fn build_tcp_packet(payload: &[u8], dst_port: u16) -> PacketContext {
+        let builder = PacketBuilder::ethernet2([1, 1, 1, 1, 1, 1], [2, 2, 2, 2, 2, 2])
+            .ipv4([10, 0, 0, 1], [10, 0, 0, 2], 64)
+            .tcp(12345, dst_port, 1, 1024);
+
+        let mut raw = Vec::with_capacity(builder.size(payload.len()));
+        builder
+            .write(&mut raw, payload)
+            .expect("packet should serialize");
+
+        PacketContext::from_raw_full(
+            raw,
+            Arc::<str>::from("eth1"),
+            Vec::new(),
+            SystemTime::now(),
+            Some(DpiContext {
+                app_proto: Some(AppProto::Http),
+                ..Default::default()
+            }),
+        )
+        .expect("packet context should parse")
+    }
+
+    #[test]
+    fn block_signature_halts_packet() {
+        let ips = Ips::new(make_config()).expect("ips should initialize");
+        let ctx = build_tcp_packet(b"GET /?q=UNION SELECT 1 HTTP/1.1\r\nHost: x\r\n\r\n", 80);
+
+        let verdict = ips.inspect_packet(&ctx);
+        assert!(matches!(verdict, IpsVerdict::Block(msg) if msg.contains("SQLi")));
+    }
+
+    #[test]
+    fn alert_signature_warns_without_block() {
+        let ips = Ips::new(make_config()).expect("ips should initialize");
+        let ctx = build_tcp_packet(
+            b"GET / HTTP/1.1\r\nHost: example.com\r\nUser-Agent: curl/8.0.1\r\n\r\n",
+            8080,
+        );
+
+        let verdict = ips.inspect_packet(&ctx);
+        assert!(matches!(verdict, IpsVerdict::Alert(msg) if msg.contains("Curl UA")));
+    }
+
+    #[test]
+    fn protocol_filter_prevents_match_without_dpi_context() {
+        let ips = Ips::new(make_config()).expect("ips should initialize");
+        let builder = PacketBuilder::ethernet2([1, 1, 1, 1, 1, 1], [2, 2, 2, 2, 2, 2])
+            .ipv4([10, 0, 0, 1], [10, 0, 0, 2], 64)
+            .tcp(12345, 80, 1, 1024);
+        let mut raw = Vec::with_capacity(builder.size(64));
+        builder
+            .write(
+                &mut raw,
+                b"GET /?q=UNION SELECT 1 HTTP/1.1\r\nHost: x\r\n\r\n",
+            )
+            .expect("packet should serialize");
+        let ctx = PacketContext::from_raw_full(
+            raw,
+            Arc::<str>::from("eth1"),
+            Vec::new(),
+            SystemTime::now(),
+            None,
+        )
+        .expect("packet context should parse");
+
+        assert_eq!(ips.inspect_packet(&ctx), IpsVerdict::Allow);
+    }
+
+    #[test]
+    fn update_config_hot_swaps_signatures() {
+        let ips = Ips::new(make_config()).expect("ips should initialize");
+        let before = build_tcp_packet(
+            b"GET / HTTP/1.1\r\nHost: example.com\r\nUser-Agent: curl/8.0.1\r\n\r\n",
+            8080,
+        );
+        assert!(matches!(ips.inspect_packet(&before), IpsVerdict::Alert(_)));
+
+        let mut new_config = make_config();
+        new_config.signatures[1].pattern = "(?i)wget/".into();
+        ips.update_config(&new_config)
+            .expect("config should hot swap");
+
+        let after = build_tcp_packet(
+            b"GET / HTTP/1.1\r\nHost: example.com\r\nUser-Agent: curl/8.0.1\r\n\r\n",
+            8080,
+        );
+        assert_eq!(ips.inspect_packet(&after), IpsVerdict::Allow);
+    }
+
+    #[test]
+    fn global_disable_skips_detection() {
+        let mut config = make_config();
+        config.general.enabled = false;
+        let ips = Ips::new(config).expect("ips should initialize");
+        let ctx = build_tcp_packet(b"GET /?q=UNION SELECT 1 HTTP/1.1\r\nHost: x\r\n\r\n", 80);
+
+        assert_eq!(ips.inspect_packet(&ctx), IpsVerdict::Allow);
+    }
+}

--- a/crates/raptorgate/src/data_plane/ips/mod.rs
+++ b/crates/raptorgate/src/data_plane/ips/mod.rs
@@ -1,0 +1,3 @@
+pub mod ips;
+pub mod config;
+pub mod provider;

--- a/crates/raptorgate/src/data_plane/ips/provider.rs
+++ b/crates/raptorgate/src/data_plane/ips/provider.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+use std::path::PathBuf;
+
+use arc_swap::ArcSwap;
+use anyhow::{Context, Result};
+
+use crate::disk_store::SingleDiskStore;
+use crate::data_plane::ips::config::IpsConfig;
+
+pub struct IpsConfigProvider {
+    config: ArcSwap<IpsConfig>,
+    store: SingleDiskStore<IpsConfig>,
+}
+
+impl IpsConfigProvider {
+    pub async fn from_disk(data_dir: PathBuf) -> Self {
+        let store = SingleDiskStore::new("ips_config", data_dir);
+
+        let config = match store.load().await {
+            Ok(loaded) => {
+                tracing::info!("ips config loaded from disk");
+                loaded
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "failed to load ips config from disk, using default");
+                IpsConfig::default()
+            }
+        };
+
+        Self {
+            config: ArcSwap::new(Arc::new(config)),
+            store,
+        }
+    }
+
+    pub async fn swap_config(&self, new_config: IpsConfig) -> Result<()> {
+        let old = self.config.load_full();
+
+        self.store
+            .save(new_config.clone())
+            .await
+            .context("failed to save new ips config to disk")?;
+
+        let verified = self
+            .store
+            .load()
+            .await
+            .context("ips config round-trip verification failed after save");
+
+        match verified {
+            Ok(_) => {
+                self.config.store(Arc::new(new_config));
+                tracing::info!("ips config swapped successfully");
+                Ok(())
+            }
+            Err(err) => {
+                tracing::error!(error = %err, "ips config verification failed, rolling back");
+
+                if let Err(rollback_err) = self.store.save((*old).clone()).await {
+                    tracing::error!(
+                        error = %rollback_err,
+                        "CRITICAL: failed to roll back ips config to disk"
+                    );
+                }
+
+                Err(err)
+            }
+        }
+    }
+
+    pub fn get_config(&self) -> arc_swap::Guard<Arc<IpsConfig>> {
+        self.config.load()
+    }
+}

--- a/crates/raptorgate/src/data_plane/mod.rs
+++ b/crates/raptorgate/src/data_plane/mod.rs
@@ -1,6 +1,7 @@
-pub mod nat;
-pub mod tun_forwarder;
 pub mod dns_inspection;
-pub mod packet_context;
 pub mod interface_sniffer;
+pub mod ips;
+pub mod nat;
+pub mod packet_context;
 pub mod tcp_session_tracker;
+pub mod tun_forwarder;

--- a/crates/raptorgate/src/main.rs
+++ b/crates/raptorgate/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod config_provider;
 mod data_plane;
+mod disk_store;
 mod dpi;
 mod events;
 mod ip_defrag;
@@ -11,50 +12,63 @@ mod proto;
 mod query_server;
 mod rule_tree;
 mod tls;
-mod disk_store;
 mod zones;
 
-use std::collections::HashMap;
-use std::net::IpAddr;
-use std::sync::Arc;
-use etherparse::NetSlice;
-use tokio::sync::Mutex;
-use ipnet::IpNet;
 use crate::config_provider::AppConfigProvider;
 use crate::data_plane::dns_inspection::dns_inspection::DnsInspection;
 use crate::data_plane::dns_inspection::dnssec::DnssecProvider;
 use crate::data_plane::dns_inspection::provider::DnsInspectionConfigProvider;
 use crate::data_plane::interface_sniffer::InterfaceSniffer;
+use crate::data_plane::ips::ips::Ips;
+use crate::data_plane::ips::provider::IpsConfigProvider;
 use crate::data_plane::nat::NatEngine;
 use crate::data_plane::tcp_session_tracker::TcpSessionTracker;
 use crate::data_plane::tun_forwarder::TunForwarder;
-use crate::ip_defrag::{DefragConfig, IpDefragEngine};
-use crate::pipeline::{Chain, Stage, StageOutcome};
 use crate::dpi::DpiClassifier;
+use crate::ip_defrag::{DefragConfig, IpDefragEngine};
 use crate::pipeline::wrappers::{
-    DnsBlockListStage, DnsTunnelingStage, DpiStage, FtpAlgStage,
-    NatPostroutingStage, NatPreroutingStage, PolicyEvalStage,
-    TcpClassificationStage, ValidationStage,
+    DnsBlockListStage, DnsTunnelingStage, DpiStage, FtpAlgStage, IpsStage, NatPostroutingStage,
+    NatPreroutingStage, PolicyEvalStage, TcpClassificationStage, ValidationStage,
 };
+use crate::pipeline::{Chain, Stage, StageOutcome};
 use crate::policy::nat::nat_rule::{NatAction, NatProtocol, NatRule};
 use crate::policy::nat::nat_rules::NatRules;
 use crate::policy::provider::DiskPolicyProvider;
 use crate::query_server::{QueryHandler, QueryServer};
 use crate::tls::CaManager;
+use etherparse::NetSlice;
+use ipnet::IpNet;
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 #[tokio::main]
 #[allow(clippy::too_many_lines)]
 async fn main() {
-    type DataPipeline =
-        Chain<ValidationStage,
-        Chain<DpiStage,
-        Chain<DnsBlockListStage,
-        Chain<DnsTunnelingStage,
-        Chain<NatPreroutingStage,
-        Chain<TcpClassificationStage,
-        Chain<PolicyEvalStage,
-        Chain<NatPostroutingStage, FtpAlgStage>>>>>>>>;
+    type DataPipeline = Chain<
+        ValidationStage,
+        Chain<
+            DpiStage,
+            Chain<
+                DnsBlockListStage,
+                Chain<
+                    DnsTunnelingStage,
+                    Chain<
+                        IpsStage,
+                        Chain<
+                            NatPreroutingStage,
+                            Chain<
+                                TcpClassificationStage,
+                                Chain<PolicyEvalStage, Chain<NatPostroutingStage, FtpAlgStage>>,
+                            >,
+                        >,
+                    >,
+                >,
+            >,
+        >,
+    >;
 
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::TRACE)
@@ -85,27 +99,46 @@ async fn main() {
     };
 
     let tcp_session_tracker = TcpSessionTracker::new();
-    let policy_provider = Arc::new(DiskPolicyProvider::from_loaded(&config).await.expect("Failed to initialize policy provider"));
+    let policy_provider = Arc::new(
+        DiskPolicyProvider::from_loaded(&config)
+            .await
+            .expect("Failed to initialize policy provider"),
+    );
     let zones = Arc::new(crate::zones::provider::ZoneProvider::from_disk(&config).await);
     let zone_pairs = Arc::new(crate::zones::provider::ZonePairProvider::from_disk(&config).await);
 
-    config_provider.register(Arc::clone(&policy_provider), "DiskPolicyProvider").await;
-    config_provider.register(Arc::clone(&zones), "ZoneProvider").await;
-    config_provider.register(Arc::clone(&zone_pairs), "ZonePairProvider").await;
+    config_provider
+        .register(Arc::clone(&policy_provider), "DiskPolicyProvider")
+        .await;
+    config_provider
+        .register(Arc::clone(&zones), "ZoneProvider")
+        .await;
+    config_provider
+        .register(Arc::clone(&zone_pairs), "ZonePairProvider")
+        .await;
 
     tokio::spawn(events::init_event_queue());
     let nat_engine = build_test_nat();
 
     // Inicjalizacja providera konfiguracji DNS inspection.
-    let dns_inspection_store = Arc::new(
-        DnsInspectionConfigProvider::from_disk(config.data_dir.clone()).await
-    );
+    let dns_inspection_store =
+        Arc::new(DnsInspectionConfigProvider::from_disk(config.data_dir.clone()).await);
     let dns_initial_config = dns_inspection_store.get_config().clone();
 
     let dns_inspection = match DnsInspection::new((*dns_initial_config).clone()) {
         Ok(inspection) => inspection,
         Err(err) => {
             tracing::error!(error = %err, "failed to initialize DNS inspection");
+            return;
+        }
+    };
+
+    let ips_store = Arc::new(IpsConfigProvider::from_disk(config.data_dir.clone()).await);
+    let ips_initial_config = ips_store.get_config().clone();
+    let ips = match Ips::new((*ips_initial_config).clone()) {
+        Ok(inspection) => inspection,
+        Err(err) => {
+            tracing::error!(error = %err, "failed to initialize IPS");
             return;
         }
     };
@@ -122,6 +155,8 @@ async fn main() {
             config_provider: Arc::clone(&config_provider),
             dns_inspection_store: Arc::clone(&dns_inspection_store),
             dns_inspection: Arc::clone(&dns_inspection),
+            ips_store: Arc::clone(&ips_store),
+            ips: Arc::clone(&ips),
         },
         &config.query_socket_path,
         CancellationToken::new(),
@@ -131,44 +166,68 @@ async fn main() {
     let defrag = IpDefragEngine::new(DefragConfig::default());
 
     let tun = TunForwarder::new(&config);
-    config_provider.register(Arc::clone(&tun), "TunForwarder").await;
+    config_provider
+        .register(Arc::clone(&tun), "TunForwarder")
+        .await;
 
     let (sniffer, mut raw_rx, errs) = InterfaceSniffer::with_sniffing(&config);
     let sniffer = Arc::new(sniffer);
-    config_provider.register(Arc::clone(&sniffer), "InterfaceSniffer").await;
+    config_provider
+        .register(Arc::clone(&sniffer), "InterfaceSniffer")
+        .await;
     for e in errs {
         tracing::error!(error = %e, "interface sniffer error");
     }
 
     // Rzutujemy DnsInspection na DnssecProvider i wstrzykujemy do PolicyEvalStage.
-    let dnssec_provider: Arc<dyn DnssecProvider> = Arc::clone(&dns_inspection) as Arc<dyn DnssecProvider>;
+    let dnssec_provider: Arc<dyn DnssecProvider> =
+        Arc::clone(&dns_inspection) as Arc<dyn DnssecProvider>;
 
     let pipeline = DataPipeline {
         head: ValidationStage,
         tail: Chain {
-            head: DpiStage { classifier: Arc::clone(&dpi_classifier) },
+            head: DpiStage {
+                classifier: Arc::clone(&dpi_classifier),
+            },
             tail: Chain {
-                head: DnsBlockListStage { inspection: Arc::clone(&dns_inspection) },
+                head: DnsBlockListStage {
+                    inspection: Arc::clone(&dns_inspection),
+                },
                 tail: Chain {
-                    head: DnsTunnelingStage { inspection: Arc::clone(&dns_inspection) },
+                    head: DnsTunnelingStage {
+                        inspection: Arc::clone(&dns_inspection),
+                    },
                     tail: Chain {
-                        head: NatPreroutingStage { engine: Arc::clone(&nat_engine) },
+                        head: IpsStage {
+                            inspection: Arc::clone(&ips),
+                        },
                         tail: Chain {
-                            head: TcpClassificationStage { tracker: Arc::clone(&tcp_session_tracker) },
+                            head: NatPreroutingStage {
+                                engine: Arc::clone(&nat_engine),
+                            },
                             tail: Chain {
-                                head: PolicyEvalStage {
-                                    provider: Arc::clone(&policy_provider),
-                                    dnssec: Some(dnssec_provider),
+                                head: TcpClassificationStage {
+                                    tracker: Arc::clone(&tcp_session_tracker),
                                 },
                                 tail: Chain {
-                                    head: NatPostroutingStage { engine: Arc::clone(&nat_engine) },
-                                    tail: FtpAlgStage { engine: Arc::clone(&nat_engine) },
+                                    head: PolicyEvalStage {
+                                        provider: Arc::clone(&policy_provider),
+                                        dnssec: Some(dnssec_provider),
+                                    },
+                                    tail: Chain {
+                                        head: NatPostroutingStage {
+                                            engine: Arc::clone(&nat_engine),
+                                        },
+                                        tail: FtpAlgStage {
+                                            engine: Arc::clone(&nat_engine),
+                                        },
+                                    },
                                 },
                             },
                         },
                     },
                 },
-            }
+            },
         },
     };
 
@@ -211,22 +270,20 @@ fn build_test_nat() -> Arc<Mutex<NatEngine>> {
         ),
     ]);
 
-    let rules = NatRules::new(vec![
-        NatRule::new(
-            "dnat-portfwd-8080-to-h1-80".to_string(),
-            20,
-            Some("eth2".to_string()),
-            None,
-            None,
-            None,
-            None,
-            Some("192.168.10.10/32".parse::<IpNet>().unwrap()),
-            Some(NatProtocol::Tcp),
-            Some(80),
-            Some(8080),
-            NatAction::Dnat,
-        ),
-    ]);
+    let rules = NatRules::new(vec![NatRule::new(
+        "dnat-portfwd-8080-to-h1-80".to_string(),
+        20,
+        Some("eth2".to_string()),
+        None,
+        None,
+        None,
+        None,
+        Some("192.168.10.10/32".parse::<IpNet>().unwrap()),
+        Some(NatProtocol::Tcp),
+        Some(80),
+        Some(8080),
+        NatAction::Dnat,
+    )]);
 
     Arc::new(Mutex::new(NatEngine::new(
         &Some(Arc::new(rules)),

--- a/crates/raptorgate/src/pipeline/wrappers.rs
+++ b/crates/raptorgate/src/pipeline/wrappers.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use std::net::IpAddr;
+use std::sync::Arc;
 
 use etherparse::NetSlice;
 use tokio::sync::Mutex;
@@ -7,6 +7,7 @@ use tokio::sync::Mutex;
 use crate::{
     data_plane::{
         dns_inspection::dns_inspection::{BlocklistVerdict, DnsInspection},
+        ips::ips::{Ips, IpsVerdict},
         nat::NatEngine,
         packet_context::PacketContext,
         tcp_session_tracker::TcpSessionTracker,
@@ -18,10 +19,10 @@ use crate::{
     rule_tree::{ArrivalInfo, Verdict},
 };
 
-use crate::dpi::AppProto;
-use crate::policy::policy_evaluator::DnsEvalContext;
 use crate::data_plane::dns_inspection::dnssec::DnssecProvider;
 use crate::data_plane::dns_inspection::tunneling_detector::DnsInspectionVerdict;
+use crate::dpi::AppProto;
+use crate::policy::policy_evaluator::DnsEvalContext;
 
 #[derive(Clone)]
 pub struct ValidationStage;
@@ -251,6 +252,38 @@ impl Stage for DnsTunnelingStage {
     }
 }
 
+#[derive(Clone)]
+pub struct IpsStage {
+    pub inspection: Arc<Ips>,
+}
+
+impl Stage for IpsStage {
+    fn is_applicable(&self, ctx: &PacketContext) -> bool {
+        use etherparse::TransportSlice;
+
+        matches!(
+            &ctx.borrow_sliced_packet().transport,
+            Some(TransportSlice::Tcp(_) | TransportSlice::Udp(_))
+        )
+    }
+
+    async fn process(&self, ctx: &mut PacketContext) -> StageOutcome {
+        match self.inspection.inspect_packet(ctx) {
+            IpsVerdict::Allow => StageOutcome::Continue,
+            IpsVerdict::Alert(msg) => {
+                tracing::debug!(reason = %msg, "IPS alert");
+                ctx.with_warnings_mut(|warnings| warnings.push(msg));
+                StageOutcome::Continue
+            }
+            IpsVerdict::Block(msg) => {
+                tracing::debug!(reason = %msg, "IPS block");
+                ctx.with_warnings_mut(|warnings| warnings.push(msg));
+                StageOutcome::Halt
+            }
+        }
+    }
+}
+
 /// Stage ewaluacji polityk.
 ///
 /// Opcjonalnie przyjmuje dostawcę DNSSEC (`dnssec`) — jeśli jest obecny,
@@ -269,27 +302,25 @@ impl Stage for PolicyEvalStage {
 
         // Wyznacz status DNSSEC dla pakietów DNS (leniwie, przez spawn_blocking).
         let dnssec_status = if let Some(provider) = &self.dnssec {
-            let is_dns = ctx.borrow_dpi_ctx()
+            let is_dns = ctx
+                .borrow_dpi_ctx()
                 .as_ref()
                 .map_or(false, |d| d.app_proto == Some(AppProto::Dns));
 
             if is_dns {
-                let domain = ctx.borrow_dpi_ctx()
+                let domain = ctx
+                    .borrow_dpi_ctx()
                     .as_ref()
                     .and_then(|d| d.dns_query_name.clone());
-                let qtype = ctx.borrow_dpi_ctx()
-                    .as_ref()
-                    .and_then(|d| d.dns_query_type);
+                let qtype = ctx.borrow_dpi_ctx().as_ref().and_then(|d| d.dns_query_type);
 
                 if let Some(domain) = domain {
                     let p = Arc::clone(provider);
-                    tokio::task::spawn_blocking(move || {
-                        p.check_domain(&domain, qtype).status
-                    })
-                    .await
-                    .ok()
-                    .map(Some)
-                    .unwrap_or(None)
+                    tokio::task::spawn_blocking(move || p.check_domain(&domain, qtype).status)
+                        .await
+                        .ok()
+                        .map(Some)
+                        .unwrap_or(None)
                 } else {
                     None
                 }
@@ -304,9 +335,11 @@ impl Stage for PolicyEvalStage {
             dnssec_status: Some(status),
         });
 
-        let verdict = self.provider
-            .get_evaluator()
-            .evaluate(ctx.borrow_sliced_packet(), &arrival, dns_ctx.as_ref());
+        let verdict = self.provider.get_evaluator().evaluate(
+            ctx.borrow_sliced_packet(),
+            &arrival,
+            dns_ctx.as_ref(),
+        );
 
         match verdict {
             Verdict::Allow => StageOutcome::Continue,

--- a/crates/raptorgate/src/query_server.rs
+++ b/crates/raptorgate/src/query_server.rs
@@ -13,34 +13,44 @@ use crate::config_provider::AppConfigProvider;
 use crate::data_plane::dns_inspection::config::DnsInspectionConfig;
 use crate::data_plane::dns_inspection::dns_inspection::DnsInspection;
 use crate::data_plane::dns_inspection::provider::DnsInspectionConfigProvider;
+use crate::data_plane::ips::config::IpsConfig;
+use crate::data_plane::ips::ips::Ips;
+use crate::data_plane::ips::provider::IpsConfigProvider;
 use crate::data_plane::nat::NatEngine;
 use crate::data_plane::tcp_session_tracker::TcpSessionTracker;
-use crate::policy::{Policy, PolicyId};
 use crate::policy::provider::PolicyManager;
+use crate::policy::{Policy, PolicyId};
 use crate::proto::services::firewall_query_service_server::{
     FirewallQueryService, FirewallQueryServiceServer,
 };
 use crate::proto::services::{
-    GetConfigRequest, GetConfigResponse, GetDnsInspectionConfigRequest, GetDnsInspectionConfigResponse,
+    GetConfigRequest, GetConfigResponse, GetDnsInspectionConfigRequest,
+    GetDnsInspectionConfigResponse, GetIpsConfigRequest, GetIpsConfigResponse,
     GetNatBindingsRequest, GetNatBindingsResponse, GetPoliciesRequest, GetPoliciesResponse,
     GetPolicyRequest, GetPolicyResponse, GetTcpSessionsRequest, GetTcpSessionsResponse,
-    SwapConfigRequest, SwapConfigResponse, SwapDnsInspectionConfigRequest,
-    SwapDnsInspectionConfigResponse, SwapPoliciesRequest, SwapPoliciesResponse,
     GetZonePairRequest, GetZonePairResponse, GetZonePairsRequest, GetZonePairsResponse,
-    GetZoneRequest, GetZoneResponse, GetZonesRequest, GetZonesResponse,
+    GetZoneRequest, GetZoneResponse, GetZonesRequest, GetZonesResponse, SwapConfigRequest,
+    SwapConfigResponse, SwapDnsInspectionConfigRequest, SwapDnsInspectionConfigResponse,
+    SwapIpsConfigRequest, SwapIpsConfigResponse, SwapPoliciesRequest, SwapPoliciesResponse,
     SwapZonePairsRequest, SwapZonePairsResponse, SwapZonesRequest, SwapZonesResponse,
 };
+use crate::zones::Zone;
 use crate::zones::provider::{ZonePairProvider, ZoneProvider};
 use crate::zones::{ZoneId, ZoneInterfaceId, ZonePair, ZonePairId};
-use crate::zones::Zone;
 
-pub struct QueryServer<PolicySwap> where PolicySwap: PolicyManager + Send + Sync {
+pub struct QueryServer<PolicySwap>
+where
+    PolicySwap: PolicyManager + Send + Sync,
+{
     handler: QueryHandler<PolicySwap>,
     socket_path: String,
     shutdown: CancellationToken,
 }
 
-impl<PolicySwap> QueryServer<PolicySwap> where PolicySwap: PolicyManager + Send + Sync + 'static {
+impl<PolicySwap> QueryServer<PolicySwap>
+where
+    PolicySwap: PolicyManager + Send + Sync + 'static,
+{
     pub fn new(
         handler: QueryHandler<PolicySwap>,
         socket_path: impl Into<String>,
@@ -84,7 +94,10 @@ impl<PolicySwap> QueryServer<PolicySwap> where PolicySwap: PolicyManager + Send 
 }
 
 #[derive(Clone)]
-pub struct QueryHandler<PolicySwap> where PolicySwap: PolicyManager {
+pub struct QueryHandler<PolicySwap>
+where
+    PolicySwap: PolicyManager,
+{
     pub tcp_tracker: Arc<TcpSessionTracker>,
     pub nat_engine: Arc<Mutex<NatEngine>>,
     pub policy_store: Arc<PolicySwap>,
@@ -95,10 +108,15 @@ pub struct QueryHandler<PolicySwap> where PolicySwap: PolicyManager {
     pub dns_inspection_store: Arc<DnsInspectionConfigProvider>,
     /// Aktywna instancja agregatora inspekcji DNS — hot-swap przez `update_config`.
     pub dns_inspection: Arc<DnsInspection>,
+    pub ips_store: Arc<IpsConfigProvider>,
+    pub ips: Arc<Ips>,
 }
 
 #[tonic::async_trait]
-impl<Swapper> FirewallQueryService for QueryHandler<Swapper> where Swapper: PolicyManager + Send + Sync + 'static {
+impl<Swapper> FirewallQueryService for QueryHandler<Swapper>
+where
+    Swapper: PolicyManager + Send + Sync + 'static,
+{
     async fn get_tcp_sessions(
         &self,
         _request: Request<GetTcpSessionsRequest>,
@@ -108,7 +126,7 @@ impl<Swapper> FirewallQueryService for QueryHandler<Swapper> where Swapper: Poli
 
     async fn swap_policies(
         &self,
-        request: Request<SwapPoliciesRequest>
+        request: Request<SwapPoliciesRequest>,
     ) -> Result<Response<SwapPoliciesResponse>, Status> {
         let rules = request.into_inner().rules;
         let mut policies = Vec::with_capacity(rules.len());
@@ -118,13 +136,15 @@ impl<Swapper> FirewallQueryService for QueryHandler<Swapper> where Swapper: Poli
                 Ok(policy) => policies.push(policy),
                 Err(err) => {
                     tracing::warn!(error = %err, "failed to parse policy from SwapPoliciesRequest");
-                    return Err(Status::invalid_argument(format!("failed to parse policy: {err}")));
+                    return Err(Status::invalid_argument(format!(
+                        "failed to parse policy: {err}"
+                    )));
                 }
             }
         }
-        
+
         let response = match self.policy_store.swap_policies(policies).await {
-            Ok(()) => SwapPoliciesResponse { },
+            Ok(()) => SwapPoliciesResponse {},
             Err(err) => {
                 tracing::error!(error = %err, "failed to swap policies");
                 return Err(Status::internal(format!("failed to swap policies: {err}")));
@@ -136,16 +156,16 @@ impl<Swapper> FirewallQueryService for QueryHandler<Swapper> where Swapper: Poli
 
     async fn get_policies(
         &self,
-        _request: Request<GetPoliciesRequest>
+        _request: Request<GetPoliciesRequest>,
     ) -> Result<Response<GetPoliciesResponse>, Status> {
-        let rules = self.policy_store.get_policies()
+        let rules = self
+            .policy_store
+            .get_policies()
             .iter()
             .map(|(id, pol)| pol.clone().into_rule(id.clone()))
             .collect::<Vec<_>>();
 
-        Ok(Response::new(GetPoliciesResponse {
-            rules,
-        }))
+        Ok(Response::new(GetPoliciesResponse { rules }))
     }
 
     async fn get_policy(
@@ -182,13 +202,15 @@ impl<Swapper> FirewallQueryService for QueryHandler<Swapper> where Swapper: Poli
                 Ok(pair) => zones_domain.push(pair),
                 Err(err) => {
                     tracing::warn!(error = %err, "failed to parse zone from SwapZonesRequest");
-                    return Err(Status::invalid_argument(format!("failed to parse zone: {err}")));
+                    return Err(Status::invalid_argument(format!(
+                        "failed to parse zone: {err}"
+                    )));
                 }
             }
         }
-        
+
         let response = match self.zone_store.swap_zones(zones_domain).await {
-            Ok(()) => SwapZonesResponse { },
+            Ok(()) => SwapZonesResponse {},
             Err(err) => {
                 tracing::error!(error = %err, "failed to swap zones");
                 return Err(Status::internal(format!("failed to swap zones: {err}")));
@@ -200,16 +222,16 @@ impl<Swapper> FirewallQueryService for QueryHandler<Swapper> where Swapper: Poli
 
     async fn get_zones(
         &self,
-        _request: Request<GetZonesRequest>
+        _request: Request<GetZonesRequest>,
     ) -> Result<Response<GetZonesResponse>, Status> {
-        let zones = self.zone_store.get_zones()
+        let zones = self
+            .zone_store
+            .get_zones()
             .iter()
             .map(|(id, pol)| pol.clone().into_proto(id.clone()))
             .collect::<Vec<_>>();
 
-        Ok(Response::new(GetZonesResponse {
-            zones,
-        }))
+        Ok(Response::new(GetZonesResponse { zones }))
     }
 
     async fn get_zone(
@@ -239,16 +261,24 @@ impl<Swapper> FirewallQueryService for QueryHandler<Swapper> where Swapper: Poli
                 Ok(pair) => zone_pairs_domain.push(pair),
                 Err(err) => {
                     tracing::warn!(error = %err, "failed to parse zone pair from SwapZonePairsRequest");
-                    return Err(Status::invalid_argument(format!("failed to parse zone pair: {err}")));
+                    return Err(Status::invalid_argument(format!(
+                        "failed to parse zone pair: {err}"
+                    )));
                 }
             }
         }
 
-        let response = match self.zone_pair_store.swap_zone_pairs(zone_pairs_domain).await {
+        let response = match self
+            .zone_pair_store
+            .swap_zone_pairs(zone_pairs_domain)
+            .await
+        {
             Ok(()) => SwapZonePairsResponse {},
             Err(err) => {
                 tracing::error!(error = %err, "failed to swap zone pairs");
-                return Err(Status::internal(format!("failed to swap zone pairs: {err}")));
+                return Err(Status::internal(format!(
+                    "failed to swap zone pairs: {err}"
+                )));
             }
         };
 
@@ -259,14 +289,14 @@ impl<Swapper> FirewallQueryService for QueryHandler<Swapper> where Swapper: Poli
         &self,
         _request: Request<GetZonePairsRequest>,
     ) -> Result<Response<GetZonePairsResponse>, Status> {
-        let zone_pairs = self.zone_pair_store.get_zone_pairs()
+        let zone_pairs = self
+            .zone_pair_store
+            .get_zone_pairs()
             .iter()
             .map(|(id, pair)| pair.clone().into_proto(id.clone()))
             .collect::<Vec<_>>();
 
-        Ok(Response::new(GetZonePairsResponse {
-            zone_pairs,
-        }))
+        Ok(Response::new(GetZonePairsResponse { zone_pairs }))
     }
 
     async fn get_zone_pair(
@@ -280,7 +310,9 @@ impl<Swapper> FirewallQueryService for QueryHandler<Swapper> where Swapper: Poli
             Some(pair) => Ok(Response::new(GetZonePairResponse {
                 zone_pair: Some(pair.into_proto(id)),
             })),
-            None => Err(Status::not_found(format!("zone pair with id {id} not found"))),
+            None => Err(Status::not_found(format!(
+                "zone pair with id {id} not found"
+            ))),
         }
     }
 
@@ -288,13 +320,17 @@ impl<Swapper> FirewallQueryService for QueryHandler<Swapper> where Swapper: Poli
         &self,
         request: Request<SwapConfigRequest>,
     ) -> Result<Response<SwapConfigResponse>, Status> {
-        let proto_config = request.into_inner().config
+        let proto_config = request
+            .into_inner()
+            .config
             .ok_or_else(|| Status::invalid_argument("missing config field"))?;
 
         let new_config = AppConfig::from_proto(proto_config)
             .map_err(|e| Status::invalid_argument(format!("invalid config: {e}")))?;
 
-        self.config_provider.swap_config(new_config).await
+        self.config_provider
+            .swap_config(new_config)
+            .await
             .map_err(|e| Status::internal(format!("failed to swap config: {e}")))?;
 
         Ok(Response::new(SwapConfigResponse {}))
@@ -314,16 +350,21 @@ impl<Swapper> FirewallQueryService for QueryHandler<Swapper> where Swapper: Poli
         &self,
         request: Request<SwapDnsInspectionConfigRequest>,
     ) -> Result<Response<SwapDnsInspectionConfigResponse>, Status> {
-        let proto_config = request.into_inner().config
+        let proto_config = request
+            .into_inner()
+            .config
             .ok_or_else(|| Status::invalid_argument("missing config field in request"))?;
 
         let new_config = DnsInspectionConfig::from_proto(proto_config)
             .map_err(|e| Status::invalid_argument(format!("invalid dns inspection config: {e}")))?;
 
-        self.dns_inspection_store.swap_config(new_config.clone()).await
+        self.dns_inspection_store
+            .swap_config(new_config.clone())
+            .await
             .map_err(|e| Status::internal(format!("failed to save dns inspection config: {e}")))?;
 
-        self.dns_inspection.update_config(&new_config)
+        self.dns_inspection
+            .update_config(&new_config)
             .map_err(|e| Status::internal(format!("failed to apply dns inspection config: {e}")))?;
 
         Ok(Response::new(SwapDnsInspectionConfigResponse {}))
@@ -335,6 +376,40 @@ impl<Swapper> FirewallQueryService for QueryHandler<Swapper> where Swapper: Poli
     ) -> Result<Response<GetDnsInspectionConfigResponse>, Status> {
         let config = self.dns_inspection_store.get_config();
         Ok(Response::new(GetDnsInspectionConfigResponse {
+            config: Some(config.to_proto()),
+        }))
+    }
+
+    async fn swap_ips_config(
+        &self,
+        request: Request<SwapIpsConfigRequest>,
+    ) -> Result<Response<SwapIpsConfigResponse>, Status> {
+        let proto_config = request
+            .into_inner()
+            .config
+            .ok_or_else(|| Status::invalid_argument("missing config field in request"))?;
+
+        let new_config = IpsConfig::from_proto(proto_config)
+            .map_err(|e| Status::invalid_argument(format!("invalid ips config: {e}")))?;
+
+        self.ips_store
+            .swap_config(new_config.clone())
+            .await
+            .map_err(|e| Status::internal(format!("failed to save ips config: {e}")))?;
+
+        self.ips
+            .update_config(&new_config)
+            .map_err(|e| Status::internal(format!("failed to apply ips config: {e}")))?;
+
+        Ok(Response::new(SwapIpsConfigResponse {}))
+    }
+
+    async fn get_ips_config(
+        &self,
+        _request: Request<GetIpsConfigRequest>,
+    ) -> Result<Response<GetIpsConfigResponse>, Status> {
+        let config = self.ips_store.get_config();
+        Ok(Response::new(GetIpsConfigResponse {
             config: Some(config.to_proto()),
         }))
     }
@@ -354,7 +429,8 @@ fn prepare_socket(socket_path: &str) -> std::io::Result<()> {
 
 fn cleanup_socket(socket_path: &str) {
     if let Err(e) = std::fs::remove_file(socket_path)
-        && e.kind() != std::io::ErrorKind::NotFound {
-            tracing::warn!(socket = socket_path, error = %e, "failed to remove query socket");
-        }
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!(socket = socket_path, error = %e, "failed to remove query socket");
+    }
 }

--- a/crates/raptorgate/tests/test_query_server.rs
+++ b/crates/raptorgate/tests/test_query_server.rs
@@ -6,18 +6,23 @@ use std::sync::OnceLock;
 use ngfw::config_provider::AppConfigProvider;
 use ngfw::data_plane::dns_inspection::dns_inspection::DnsInspection;
 use ngfw::data_plane::dns_inspection::provider::DnsInspectionConfigProvider;
+use ngfw::data_plane::ips::ips::Ips;
+use ngfw::data_plane::ips::provider::IpsConfigProvider;
 use ngfw::data_plane::nat::NatEngine;
 use ngfw::data_plane::tcp_session_tracker::TcpSessionTracker;
 use ngfw::policy::provider::DiskPolicyProvider;
 use ngfw::proto::config::Rule;
-use ngfw::proto::services::{GetConfigRequest, GetPoliciesRequest, SwapConfigRequest, SwapPoliciesRequest};
 use ngfw::proto::services::firewall_query_service_client::FirewallQueryServiceClient;
+use ngfw::proto::services::{
+    GetConfigRequest, GetIpsConfigRequest, GetPoliciesRequest, SwapConfigRequest,
+    SwapIpsConfigRequest, SwapPoliciesRequest,
+};
 use ngfw::query_server::{QueryHandler, QueryServer};
 use ngfw::zones::provider::ZonePairProvider;
 use ngfw::zones::provider::ZoneProvider;
+use serial_test::serial;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
-use serial_test::serial;
 use uuid::Uuid;
 
 struct SharedServer {
@@ -39,19 +44,26 @@ fn shared_server() -> &'static SharedServer {
             // it is never dropped, so the server task is never killed.
             let rt = tokio::runtime::Runtime::new().expect("failed to build server runtime");
             rt.block_on(async move {
-                let config_provider = Arc::new(AppConfigProvider::from_env().await.expect("failed to load config"));
+                let config_provider = Arc::new(
+                    AppConfigProvider::from_env()
+                        .await
+                        .expect("failed to load config"),
+                );
                 let config = config_provider.get_config();
                 let policy = DiskPolicyProvider::from_loaded(&config)
                     .await
                     .expect("failed to load policy provider");
                 let zones = ZoneProvider::from_disk(&config).await;
                 let zone_pairs = ZonePairProvider::from_disk(&config).await;
-                let dns_inspection_store = Arc::new(
-                    DnsInspectionConfigProvider::from_disk(config.data_dir.clone()).await
-                );
+                let dns_inspection_store =
+                    Arc::new(DnsInspectionConfigProvider::from_disk(config.data_dir.clone()).await);
                 let dns_initial_config = dns_inspection_store.get_config().clone();
                 let dns_inspection = DnsInspection::new((*dns_initial_config).clone())
                     .expect("failed to init dns inspection");
+                let ips_store =
+                    Arc::new(IpsConfigProvider::from_disk(config.data_dir.clone()).await);
+                let ips_initial_config = ips_store.get_config().clone();
+                let ips = Ips::new((*ips_initial_config).clone()).expect("failed to init ips");
 
                 let handler = QueryHandler {
                     tcp_tracker: TcpSessionTracker::new(),
@@ -62,6 +74,8 @@ fn shared_server() -> &'static SharedServer {
                     config_provider: Arc::clone(&config_provider),
                     dns_inspection_store,
                     dns_inspection,
+                    ips_store,
+                    ips,
                 };
 
                 let socket = "/tmp/test-query-shared.sock".to_string();
@@ -98,7 +112,7 @@ async fn connect(socket: &str) -> FirewallQueryServiceClient<tonic::transport::C
 
 #[tokio::test]
 #[serial(policies)] // has to be serial or else there's a race condition where after one test saves a new
-          // config, a second test may load the config saved by the first one.
+// config, a second test may load the config saved by the first one.
 async fn swap_policies_happy_path_returns_no_error() {
     let mut client = connect(&shared_server().socket).await;
 
@@ -149,7 +163,9 @@ async fn fetch_policies_returns_ok() {
     };
 
     client
-        .swap_policies(SwapPoliciesRequest { rules: vec![rule.clone()] })
+        .swap_policies(SwapPoliciesRequest {
+            rules: vec![rule.clone()],
+        })
         .await
         .unwrap();
 
@@ -192,10 +208,15 @@ async fn fetch_zones_returns_ok() {
         interface_ids: vec![],
     };
     client
-        .swap_zones(ngfw::proto::services::SwapZonesRequest { zones: vec![zone.clone()] })
+        .swap_zones(ngfw::proto::services::SwapZonesRequest {
+            zones: vec![zone.clone()],
+        })
         .await
         .unwrap();
-    let resp = client.get_zones(ngfw::proto::services::GetZonesRequest {}).await.unwrap();
+    let resp = client
+        .get_zones(ngfw::proto::services::GetZonesRequest {})
+        .await
+        .unwrap();
     let inner = resp.into_inner();
     assert!(
         inner.zones.iter().any(|z| z.name == zone.name),
@@ -233,10 +254,15 @@ async fn fetch_zone_pairs_returns_ok() {
         default_policy: Default::default(),
     };
     client
-        .swap_zone_pairs(ngfw::proto::services::SwapZonePairsRequest { zone_pairs: vec![zone_pair.clone()] })
+        .swap_zone_pairs(ngfw::proto::services::SwapZonePairsRequest {
+            zone_pairs: vec![zone_pair.clone()],
+        })
         .await
         .unwrap();
-    let resp = client.get_zone_pairs(ngfw::proto::services::GetZonePairsRequest {}).await.unwrap();
+    let resp = client
+        .get_zone_pairs(ngfw::proto::services::GetZonePairsRequest {})
+        .await
+        .unwrap();
     let inner = resp.into_inner();
     assert!(
         inner.zone_pairs.iter().any(|zp| zp.id == zone_pair.id),
@@ -287,7 +313,9 @@ async fn get_config_returns_ok() {
     };
 
     client
-        .swap_config(SwapConfigRequest { config: Some(swapped.clone()) })
+        .swap_config(SwapConfigRequest {
+            config: Some(swapped.clone()),
+        })
         .await
         .unwrap();
 
@@ -301,4 +329,53 @@ async fn get_config_returns_ok() {
     assert_eq!(config.tun_address, "192.168.1.1");
     assert_eq!(config.tun_netmask, "255.255.0.0");
     assert_eq!(config.pki_dir, "/tmp/pki");
+}
+
+#[tokio::test]
+#[serial(ips_config)]
+async fn swap_and_get_ips_config_roundtrip() {
+    let mut client = connect(&shared_server().socket).await;
+
+    let swapped = ngfw::proto::config::IpsConfig {
+        general: Some(ngfw::proto::config::IpsGeneralConfig { enabled: true }),
+        detection: Some(ngfw::proto::config::IpsDetectionConfig {
+            enabled: true,
+            max_payload_bytes: 2048,
+            max_matches_per_packet: 2,
+        }),
+        signatures: vec![ngfw::proto::config::IpsSignatureConfig {
+            id: "sig-http-sqli".into(),
+            name: "HTTP SQLi".into(),
+            enabled: true,
+            category: "sqli".into(),
+            pattern: "(?i)union\\s+select".into(),
+            severity: ngfw::proto::common::Severity::High as i32,
+            action: ngfw::proto::config::IpsAction::Block as i32,
+            app_protocols: vec![ngfw::proto::config::IpsAppProtocol::Http as i32],
+            src_ports: vec![],
+            dst_ports: vec![80, 8080],
+        }],
+    };
+
+    client
+        .swap_ips_config(SwapIpsConfigRequest {
+            config: Some(swapped.clone()),
+        })
+        .await
+        .unwrap();
+
+    let response = client
+        .get_ips_config(GetIpsConfigRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    let config = response.config.expect("get_ips_config returned no config");
+
+    assert!(config.general.expect("general").enabled);
+    let detection = config.detection.expect("detection");
+    assert_eq!(detection.max_payload_bytes, 2048);
+    assert_eq!(detection.max_matches_per_packet, 2);
+    assert_eq!(config.signatures.len(), 1);
+    assert_eq!(config.signatures[0].id, "sig-http-sqli");
+    assert_eq!(config.signatures[0].dst_ports, vec![80, 8080]);
 }

--- a/proto/config/config_models.proto
+++ b/proto/config/config_models.proto
@@ -254,6 +254,57 @@ message DnsInspectionConfig {
   DnsInspectionDnssecConfig       dnssec        = 4;
 }
 
+// ── IPS ─────────────────────────────────────────────────────────────────────
+
+enum IpsAction {
+  IPS_ACTION_UNSPECIFIED = 0;
+  IPS_ACTION_ALERT       = 1;
+  IPS_ACTION_BLOCK       = 2;
+}
+
+enum IpsAppProtocol {
+  IPS_APP_PROTOCOL_UNSPECIFIED = 0;
+  IPS_APP_PROTOCOL_HTTP        = 1;
+  IPS_APP_PROTOCOL_TLS         = 2;
+  IPS_APP_PROTOCOL_DNS         = 3;
+  IPS_APP_PROTOCOL_SSH         = 4;
+  IPS_APP_PROTOCOL_FTP         = 5;
+  IPS_APP_PROTOCOL_SMTP        = 6;
+  IPS_APP_PROTOCOL_RDP         = 7;
+  IPS_APP_PROTOCOL_SMB         = 8;
+  IPS_APP_PROTOCOL_QUIC        = 9;
+  IPS_APP_PROTOCOL_UNKNOWN     = 10;
+}
+
+message IpsGeneralConfig {
+  bool enabled = 1;
+}
+
+message IpsDetectionConfig {
+  bool   enabled                = 1;
+  uint32 max_payload_bytes      = 2;
+  uint32 max_matches_per_packet = 3;
+}
+
+message IpsSignatureConfig {
+  string              id            = 1;
+  string              name          = 2;
+  bool                enabled       = 3;
+  string              category      = 4;
+  string              pattern       = 5;
+  common.Severity     severity      = 6;
+  IpsAction           action        = 7;
+  repeated IpsAppProtocol app_protocols = 8;
+  repeated uint32     src_ports     = 9;
+  repeated uint32     dst_ports     = 10;
+}
+
+message IpsConfig {
+  IpsGeneralConfig      general    = 1;
+  IpsDetectionConfig    detection  = 2;
+  repeated IpsSignatureConfig signatures = 3;
+}
+
 // ── AppConfig — runtime-swappable firewall configuration ─────────────────────
 
 message AppConfig {

--- a/proto/services/query_service.proto
+++ b/proto/services/query_service.proto
@@ -24,6 +24,8 @@ service FirewallQueryService {
 
   rpc SwapDnsInspectionConfig (SwapDnsInspectionConfigRequest) returns (SwapDnsInspectionConfigResponse);
   rpc GetDnsInspectionConfig  (GetDnsInspectionConfigRequest)  returns (GetDnsInspectionConfigResponse);
+  rpc SwapIpsConfig           (SwapIpsConfigRequest)           returns (SwapIpsConfigResponse);
+  rpc GetIpsConfig            (GetIpsConfigRequest)            returns (GetIpsConfigResponse);
 }
 
 message GetTcpSessionsRequest {}
@@ -121,4 +123,18 @@ message GetDnsInspectionConfigRequest {}
 
 message GetDnsInspectionConfigResponse {
   config.DnsInspectionConfig config = 1;
+}
+
+// ── IPS Config ───────────────────────────────────────────────────────────────
+
+message SwapIpsConfigRequest {
+  config.IpsConfig config = 1;
+}
+
+message SwapIpsConfigResponse {}
+
+message GetIpsConfigRequest {}
+
+message GetIpsConfigResponse {
+  config.IpsConfig config = 1;
 }

--- a/vagrant/deploy.sh
+++ b/vagrant/deploy.sh
@@ -27,8 +27,14 @@ cp -f ../bin/"$PROJECT_NAME" .router_sync/"$PROJECT_NAME"/"$PROJECT_NAME"
 cp -rf ../bin/backend/* .router_sync/backend/
 # cd "$SCRIPT_DIR/../backend" && bun run build || exit 1 // czm buildujemy to w deployu
 cd "$SCRIPT_DIR"
-rm -rf .router_sync/backend/dist && mkdir -p .router_sync/backend/dist
-cp -rf ../backend/dist/* .router_sync/backend/dist/
+# Lokalny build backendu jest opcjonalny. Jeśli nie istnieje `../backend/dist`,
+# zostawiamy artefakty skopiowane wcześniej z `../bin/backend/dist`.
+if [ -d ../backend/dist ]; then
+  rm -rf .router_sync/backend/dist && mkdir -p .router_sync/backend/dist
+  cp -rf ../backend/dist/* .router_sync/backend/dist/
+else
+  echo "backend/dist not found locally; using artifacts from ../bin/backend/dist"
+fi
 rm -rf .router_sync/backend/devCerts && mkdir -p .router_sync/backend/devCerts
 cp -rf ../backend/devCerts/* .router_sync/backend/devCerts/
 cp -rf ../proto/* .router_sync/proto/


### PR DESCRIPTION
Add the initial IPS module, config provider and pipeline stage modeled after DNS inspection so signatures can be swapped at runtime without restarting the firewall.
Expose IPS config over gRPC and cover the swap/get flow with query server tests.