### PR TITLE
feat(core): add daily service logs and vagrant management gateway

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,9 @@
 obj/
 bin/
+target/
+.git/
+.codex/
+**/node_modules/
+**/dist/
+vagrant/.vagrant/
+vagrant/.router_sync/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,6 +989,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,7 +1804,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,7 +1,8 @@
+import "module-alias/register";
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { cwd } from "node:process";
-import { BadRequestException, Logger, ValidationPipe } from "@nestjs/common";
+import { BadRequestException, ValidationPipe } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { NestFactory } from "@nestjs/core";
 import { type MicroserviceOptions, Transport } from "@nestjs/microservices";
@@ -11,9 +12,16 @@ import { apiReference } from "@scalar/nestjs-api-reference";
 import cookieParser from "cookie-parser";
 import { AppModule } from "./app.module.js";
 import type { Env } from "./shared/config/env.validation.js";
+import {
+  DailyFileLogger,
+  DEFAULT_BACKEND_LOG_DIR,
+} from "./shared/logging/daily-file.logger.js";
 
 async function bootstrap() {
-  const logger = new Logger("Bootstrap");
+  const appLogger = new DailyFileLogger({
+    logDir: process.env.BACKEND_LOG_DIR ?? DEFAULT_BACKEND_LOG_DIR,
+  });
+  const logger = appLogger.withContext("Bootstrap");
   const certsDir = join(cwd(), "devCerts");
 
   const httpsOptions = {
@@ -23,6 +31,7 @@ async function bootstrap() {
 
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     httpsOptions,
+    logger: appLogger,
   });
 
   app.set("query parser", "extended");

--- a/backend/src/presentation/controllers/auth.controller.spec.ts
+++ b/backend/src/presentation/controllers/auth.controller.spec.ts
@@ -26,6 +26,11 @@ describe("AuthController", () => {
 		configService = {
 			get: jest.fn(),
 		} as any;
+		configService.get.mockImplementation((key) => {
+			if (key === "NODE_ENV") return "development";
+			if (key === "AUTH_COOKIE_PATH") return "/auth/refresh";
+			return undefined;
+		});
 		const module: TestingModule = await Test.createTestingModule({
 			controllers: [AuthController],
 			providers: [
@@ -66,10 +71,6 @@ describe("AuthController", () => {
 			};
 			// Zachowanie mocków
 			loginUserUseCase.execute.mockResolvedValue(expectedResponse);
-			configService.get.mockImplementation((key) => {
-				if (key === "NODE_ENV") return "development";
-				return undefined;
-			});
 			// Wykonanie testowanej metody
 			const result = await controller.login(loginDto, mockResponse as Response);
 			// Asercje (sprawdzenia)
@@ -122,7 +123,6 @@ describe("AuthController", () => {
 				refreshToken: "rotated-refresh-token", // Use case zwrócił nowy RT
 			};
 			refreshTokenUseCase.execute.mockResolvedValue(expectedResponse);
-			configService.get.mockReturnValue("development");
 			const result = await controller.refresh(
 				accessToken,
 				refreshToken,

--- a/backend/src/presentation/controllers/auth.controller.ts
+++ b/backend/src/presentation/controllers/auth.controller.ts
@@ -10,7 +10,7 @@ import {
 import { ConfigService } from "@nestjs/config";
 import { ApiBody, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { Throttle } from "@nestjs/throttler";
-import type { Response } from "express";
+import type { CookieOptions, Response } from "express";
 import { LoginUserUseCase } from "../../application/use-cases/login-user.use-case";
 import { LogoutUserUseCase } from "../../application/use-cases/logout-user.use-case";
 import { RecoverPasswordUseCase } from "../../application/use-cases/recover-password.use-case";
@@ -52,6 +52,19 @@ export class AuthController {
     private readonly recoverPasswordUseCase: RecoverPasswordUseCase,
   ) {}
 
+  private getRefreshCookieOptions(): CookieOptions {
+    const nodeEnv = this.configService.get("NODE_ENV", { infer: true });
+    const path = this.configService.get("AUTH_COOKIE_PATH", { infer: true });
+
+    return {
+      httpOnly: true,
+      secure: nodeEnv === "development" || nodeEnv === "production",
+      sameSite: "strict",
+      maxAge: 60 * 60 * 1000,
+      path,
+    };
+  }
+
   @ApiOperation({
     summary: "User login",
     description:
@@ -79,15 +92,7 @@ export class AuthController {
     const { refreshToken, ...loginResponse } =
       await this.loginUserUseCase.execute(applicationDto);
 
-    res.cookie("refresh_token", refreshToken, {
-      httpOnly: true,
-      secure:
-        this.configService.get("NODE_ENV") === "development" ||
-        this.configService.get("NODE_ENV") === "production",
-      sameSite: "strict",
-      maxAge: 60 * 60 * 1000,
-      path: "/auth/refresh",
-    });
+    res.cookie("refresh_token", refreshToken, this.getRefreshCookieOptions());
 
     return loginResponse;
   }
@@ -116,15 +121,11 @@ export class AuthController {
     });
 
     if (useCase.refreshToken) {
-      res.cookie("refresh_token", useCase.refreshToken, {
-        httpOnly: true,
-        secure:
-          this.configService.get("NODE_ENV") === "development" ||
-          this.configService.get("NODE_ENV") === "production",
-        sameSite: "strict",
-        maxAge: 60 * 60 * 1000,
-        path: "/auth/refresh",
-      });
+      res.cookie(
+        "refresh_token",
+        useCase.refreshToken,
+        this.getRefreshCookieOptions(),
+      );
     }
 
     return {
@@ -151,15 +152,7 @@ export class AuthController {
   ): Promise<void> {
     await this.logoutUserUseCase.execute({ accessToken });
 
-    res.clearCookie("refresh_token", {
-      httpOnly: true,
-      secure:
-        this.configService.get("NODE_ENV") === "development" ||
-        this.configService.get("NODE_ENV") === "production",
-      sameSite: "strict",
-      maxAge: 60 * 60 * 1000,
-      path: "/auth/refresh",
-    });
+    res.clearCookie("refresh_token", this.getRefreshCookieOptions());
   }
 
   @IsPublic()

--- a/backend/src/shared/config/env.validation.ts
+++ b/backend/src/shared/config/env.validation.ts
@@ -15,6 +15,8 @@ const envSchema = z.object({
     .string()
     .default("../sockets/control-plane.sock"),
   FIREWALL_QUERY_GRPC_SOCKET_PATH: z.string().default("../sockets/query.sock"),
+  BACKEND_LOG_DIR: z.string().default("/var/log/raptorgate/backend"),
+  AUTH_COOKIE_PATH: z.string().min(1).default("/auth/refresh"),
   COOKIE_SECRET: z
     .string()
     .min(32, "COOKIE_SECRET must be at least 32 characters"),

--- a/backend/src/shared/logging/daily-file.logger.spec.ts
+++ b/backend/src/shared/logging/daily-file.logger.spec.ts
@@ -1,0 +1,58 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DailyFileLogger, formatLocalDate } from "./daily-file.logger.js";
+
+describe("DailyFileLogger", () => {
+  let logDir: string;
+
+  beforeEach(() => {
+    logDir = mkdtempSync(join(tmpdir(), "raptorgate-backend-logs-"));
+  });
+
+  afterEach(() => {
+    rmSync(logDir, { recursive: true, force: true });
+  });
+
+  it("writes logs to a file named with the local calendar date", () => {
+    const logger = new DailyFileLogger({
+      logDir,
+      context: "TestContext",
+      mirrorToConsole: false,
+      now: () => new Date(2026, 3, 14, 10, 30, 0),
+    });
+
+    logger.log("backend started");
+
+    const logPath = join(logDir, "2026-04-14.log");
+
+    expect(existsSync(logPath)).toBe(true);
+    expect(readFileSync(logPath, "utf8")).toContain(
+      "LOG [TestContext] backend started",
+    );
+  });
+
+  it("uses a new file after the local date changes", () => {
+    let now = new Date(2026, 3, 14, 23, 59, 59);
+    const logger = new DailyFileLogger({
+      logDir,
+      mirrorToConsole: false,
+      now: () => now,
+    });
+
+    logger.warn("before midnight", "Scheduler");
+    now = new Date(2026, 3, 15, 0, 0, 1);
+    logger.warn("after midnight", "Scheduler");
+
+    expect(readFileSync(join(logDir, "2026-04-14.log"), "utf8")).toContain(
+      "before midnight",
+    );
+    expect(readFileSync(join(logDir, "2026-04-15.log"), "utf8")).toContain(
+      "after midnight",
+    );
+  });
+
+  it("formats local dates without using utc conversion", () => {
+    expect(formatLocalDate(new Date(2026, 0, 5, 1, 2, 3))).toBe("2026-01-05");
+  });
+});

--- a/backend/src/shared/logging/daily-file.logger.ts
+++ b/backend/src/shared/logging/daily-file.logger.ts
@@ -1,0 +1,219 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { inspect } from "node:util";
+import type { LoggerService, LogLevel } from "@nestjs/common";
+
+export const DEFAULT_BACKEND_LOG_DIR = "/var/log/raptorgate/backend";
+
+interface DailyFileLoggerOptions {
+  logDir: string;
+  context?: string;
+  mirrorToConsole?: boolean;
+  now?: () => Date;
+}
+
+type DailyFileLogLevel = LogLevel | "fatal";
+
+interface ParsedLogParams {
+  context?: string;
+  extra: unknown[];
+  stack?: string;
+}
+
+export class DailyFileLogger implements LoggerService {
+  private readonly logDir: string;
+  private readonly context?: string;
+  private readonly mirrorToConsole: boolean;
+  private readonly now: () => Date;
+  private enabledLogLevels?: Set<string>;
+
+  constructor(options: DailyFileLoggerOptions) {
+    this.logDir = options.logDir;
+    this.context = options.context;
+    this.mirrorToConsole = options.mirrorToConsole ?? true;
+    this.now = options.now ?? (() => new Date());
+
+    mkdirSync(this.logDir, { recursive: true });
+  }
+
+  withContext(context: string): DailyFileLogger {
+    return new DailyFileLogger({
+      logDir: this.logDir,
+      context,
+      mirrorToConsole: this.mirrorToConsole,
+      now: this.now,
+    });
+  }
+
+  log(message: unknown, ...optionalParams: unknown[]) {
+    this.write("log", message, this.parseDefaultParams(optionalParams));
+  }
+
+  error(message: unknown, ...optionalParams: unknown[]) {
+    this.write("error", message, this.parseErrorParams(optionalParams));
+  }
+
+  warn(message: unknown, ...optionalParams: unknown[]) {
+    this.write("warn", message, this.parseDefaultParams(optionalParams));
+  }
+
+  debug(message: unknown, ...optionalParams: unknown[]) {
+    this.write("debug", message, this.parseDefaultParams(optionalParams));
+  }
+
+  verbose(message: unknown, ...optionalParams: unknown[]) {
+    this.write("verbose", message, this.parseDefaultParams(optionalParams));
+  }
+
+  fatal(message: unknown, ...optionalParams: unknown[]) {
+    this.write("fatal", message, this.parseErrorParams(optionalParams));
+  }
+
+  setLogLevels(levels: LogLevel[]) {
+    this.enabledLogLevels = new Set(levels);
+  }
+
+  private write(
+    level: DailyFileLogLevel,
+    message: unknown,
+    params: ParsedLogParams,
+  ) {
+    if (!this.isLevelEnabled(level)) {
+      return;
+    }
+
+    const now = this.now();
+    const logPath = join(this.logDir, `${formatLocalDate(now)}.log`);
+    const line = this.formatLine(now, level, message, params);
+
+    mkdirSync(this.logDir, { recursive: true });
+    appendFileSync(logPath, line, { encoding: "utf8", mode: 0o640 });
+
+    if (this.mirrorToConsole) {
+      this.writeConsole(level, line);
+    }
+  }
+
+  private formatLine(
+    now: Date,
+    level: DailyFileLogLevel,
+    message: unknown,
+    params: ParsedLogParams,
+  ): string {
+    const context = params.context ?? this.context;
+    const contextPart = context ? ` [${context}]` : "";
+    const extraPart =
+      params.extra.length > 0
+        ? ` ${params.extra.map(formatValue).join(" ")}`
+        : "";
+    const stackPart = params.stack ? `\n${params.stack}` : "";
+
+    return `${now.toISOString()} ${level.toUpperCase()}${contextPart} ${formatValue(
+      message,
+    )}${extraPart}${stackPart}\n`;
+  }
+
+  private writeConsole(level: DailyFileLogLevel, line: string) {
+    const stream =
+      level === "error" || level === "fatal" || level === "warn"
+        ? process.stderr
+        : process.stdout;
+
+    stream.write(line);
+  }
+
+  private isLevelEnabled(level: DailyFileLogLevel): boolean {
+    if (!this.enabledLogLevels) {
+      return true;
+    }
+
+    return this.enabledLogLevels.has(level);
+  }
+
+  private parseDefaultParams(optionalParams: unknown[]): ParsedLogParams {
+    if (optionalParams.length === 0) {
+      return { context: this.context, extra: [] };
+    }
+
+    const contextCandidate = optionalParams[optionalParams.length - 1];
+
+    if (typeof contextCandidate === "string") {
+      return {
+        context: contextCandidate,
+        extra: optionalParams.slice(0, -1),
+      };
+    }
+
+    return {
+      context: this.context,
+      extra: optionalParams,
+    };
+  }
+
+  private parseErrorParams(optionalParams: unknown[]): ParsedLogParams {
+    const [traceCandidate, contextCandidate, ...extra] = optionalParams;
+
+    if (typeof contextCandidate === "string") {
+      return {
+        context: contextCandidate,
+        stack: typeof traceCandidate === "string" ? traceCandidate : undefined,
+        extra,
+      };
+    }
+
+    if (
+      typeof traceCandidate === "string" &&
+      looksLikeStackTrace(traceCandidate)
+    ) {
+      return {
+        context: this.context,
+        stack: traceCandidate,
+        extra: optionalParams.slice(1),
+      };
+    }
+
+    if (typeof traceCandidate === "string") {
+      return {
+        context: traceCandidate,
+        extra: optionalParams.slice(1),
+      };
+    }
+
+    return {
+      context: this.context,
+      extra: optionalParams,
+    };
+  }
+}
+
+export function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value instanceof Error) {
+    return value.stack ?? value.message;
+  }
+
+  return inspect(value, {
+    depth: 8,
+    breakLength: Number.POSITIVE_INFINITY,
+    compact: true,
+  });
+}
+
+function looksLikeStackTrace(value: string): boolean {
+  return (
+    value.includes("\n") ||
+    /^\s*at\s+/u.test(value) ||
+    /^[A-Za-z]*Error:/u.test(value)
+  );
+}

--- a/crates/raptorgate/Cargo.toml
+++ b/crates/raptorgate/Cargo.toml
@@ -12,7 +12,7 @@ thiserror = "2.0.18"
 tokio = { version = "1.50.0", features = ["full"] }
 tun = {version = "0.8.5", features = ["async"] }
 serde = { version = "1.0.228", features = ["derive"] }
-time = { version = "0.3.47", features = ["serde"] }
+time = { version = "0.3.47", features = ["serde", "local-offset"] }
 prost = "0.14.3"
 tonic-prost = "0.14.5"
 prost-types = "0.14.3"

--- a/crates/raptorgate/src/logging.rs
+++ b/crates/raptorgate/src/logging.rs
@@ -1,0 +1,174 @@
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+use std::path::{Path, PathBuf};
+use time::{Date, OffsetDateTime};
+use std::fs::{self, File, OpenOptions};
+use tracing_subscriber::fmt::MakeWriter;
+
+const DEFAULT_FIREWALL_LOG_DIR: &str = "/var/log/raptorgate/firewall";
+const FIREWALL_LOG_DIR_ENV: &str = "RAPTORGATE_FIREWALL_LOG_DIR";
+
+pub fn init() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let log_dir = std::env::var(FIREWALL_LOG_DIR_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(DEFAULT_FIREWALL_LOG_DIR));
+
+    let writer = DailyLogMakeWriter::new(log_dir)?;
+
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::TRACE)
+        .with_target(false)
+        .with_thread_ids(false)
+        .with_thread_names(false)
+        .with_writer(writer)
+        .try_init()?;
+
+    Ok(())
+}
+
+#[derive(Clone)]
+struct DailyLogMakeWriter {
+    state: Arc<Mutex<DailyLogState>>,
+}
+
+impl DailyLogMakeWriter {
+    fn new(log_dir: PathBuf) -> io::Result<Self> {
+        fs::create_dir_all(&log_dir)?;
+
+        Ok(Self {
+            state: Arc::new(Mutex::new(DailyLogState::new(log_dir))),
+        })
+    }
+}
+
+impl<'a> MakeWriter<'a> for DailyLogMakeWriter {
+    type Writer = DailyLogWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        DailyLogWriter {
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+struct DailyLogWriter {
+    state: Arc<Mutex<DailyLogState>>,
+}
+
+impl Write for DailyLogWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let written = {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| io::Error::other("daily log writer lock poisoned"))?;
+            state.write(buf)?
+        };
+
+        let _ = io::stdout().write_all(&buf[..written]);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| io::Error::other("daily log writer lock poisoned"))?;
+            state.flush()?;
+        }
+
+        let _ = io::stdout().flush();
+        Ok(())
+    }
+}
+
+struct DailyLogState {
+    log_dir: PathBuf,
+    current_file_name: Option<String>,
+    file: Option<File>,
+}
+
+impl DailyLogState {
+    fn new(log_dir: PathBuf) -> Self {
+        Self {
+            log_dir,
+            current_file_name: None,
+            file: None,
+        }
+    }
+
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.ensure_current_file()?;
+        self.file
+            .as_mut()
+            .ok_or_else(|| io::Error::other("daily log file was not opened"))?
+            .write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if let Some(file) = self.file.as_mut() {
+            file.flush()?;
+        }
+
+        Ok(())
+    }
+
+    fn ensure_current_file(&mut self) -> io::Result<()> {
+        let file_name = current_log_file_name();
+
+        if self.current_file_name.as_deref() == Some(file_name.as_str()) {
+            return Ok(());
+        }
+
+        fs::create_dir_all(&self.log_dir)?;
+        self.file = Some(open_log_file(&self.log_dir, &file_name)?);
+        self.current_file_name = Some(file_name);
+
+        Ok(())
+    }
+}
+
+fn current_log_file_name() -> String {
+    let date = OffsetDateTime::now_local()
+        .unwrap_or_else(|_| OffsetDateTime::now_utc())
+        .date();
+
+    log_file_name_for_date(date)
+}
+
+fn open_log_file(log_dir: &Path, file_name: &str) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o640);
+    }
+
+    options.open(log_dir.join(file_name))
+}
+
+fn log_file_name_for_date(date: Date) -> String {
+    format!(
+        "{:04}-{:02}-{:02}.log",
+        date.year(),
+        u8::from(date.month()),
+        date.day()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::log_file_name_for_date;
+    use time::{Date, Month};
+
+    #[test]
+    fn names_log_file_with_iso_calendar_date() {
+        let date =
+            Date::from_calendar_date(2026, Month::April, 14).expect("test date should be valid");
+
+        assert_eq!(log_file_name_for_date(date), "2026-04-14.log");
+    }
+}

--- a/crates/raptorgate/src/main.rs
+++ b/crates/raptorgate/src/main.rs
@@ -5,6 +5,7 @@ mod disk_store;
 mod dpi;
 mod events;
 mod ip_defrag;
+mod logging;
 mod packet_validator;
 mod pipeline;
 mod policy;
@@ -71,12 +72,15 @@ async fn main() {
         >,
     >;
 
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::TRACE)
-        .with_target(false)
-        .with_thread_ids(false)
-        .with_thread_names(false)
-        .init();
+    if let Err(err) = logging::init() {
+        eprintln!("failed to initialize daily firewall logging: {err}");
+        tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::TRACE)
+            .with_target(false)
+            .with_thread_ids(false)
+            .with_thread_names(false)
+            .init();
+    }
 
     let config_provider = match AppConfigProvider::from_env().await {
         Ok(provider) => Arc::new(provider),
@@ -94,7 +98,7 @@ async fn main() {
             Some(ca.ca_info())
         }
         Err(err) => {
-            eprintln!("Warning: CA initialization failed: {err}");
+            tracing::warn!(error = %err, "CA initialization failed");
             None
         }
     };
@@ -119,7 +123,7 @@ async fn main() {
         .await;
 
     tokio::spawn(events::init_event_system(config.event_socket_path.clone()));
-    
+
     let nat_engine = build_test_nat();
 
     // Inicjalizacja providera konfiguracji DNS inspection.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,17 @@ services:
       - ./bin:/host/bin
     command: "cp -rf . /host/bin/"
 
-  # backend_build:
-  #   build:
-  #     context: .
-  #     dockerfile: ./docker/backend/dockerfile
-  #   volumes:
-  #     - ./bin/backend:/host/bin
-  #   command: "sh -lc 'rm -rf /host/bin/* && cp -R /app/backend/. /host/bin/'"
+  backend_build:
+    build:
+      context: .
+      dockerfile: ./docker/backend/dockerfile
+    volumes:
+      - ./bin/backend:/host/bin
+    command: "sh -lc 'rm -rf /host/bin/* && cp -R /app/backend/. /host/bin/'"
+
+  frontend_build:
+    build:
+      context: .
+      dockerfile: ./docker/frontend/dockerfile
+    volumes:
+      - ./bin/frontend:/host/bin

--- a/docker/frontend/dockerfile
+++ b/docker/frontend/dockerfile
@@ -1,0 +1,17 @@
+FROM oven/bun:1 AS build
+
+WORKDIR /usr/src/frontend
+
+COPY frontend/package.json frontend/bun.lock ./
+RUN bun install --frozen-lockfile
+
+COPY frontend ./
+
+ENV RAPTOR_GATE_API_URL=/api
+RUN bun run build
+
+FROM alpine:3.19 AS runtime
+
+COPY --from=build /usr/src/frontend/dist /app/frontend/dist
+
+CMD ["sh", "-lc", "mkdir -p /host/bin && rm -rf /host/bin/* && cp -R /app/frontend/dist /host/bin/dist"]

--- a/vagrant/deploy.sh
+++ b/vagrant/deploy.sh
@@ -24,27 +24,39 @@ cd "$SCRIPT_DIR/.."
 cd "$SCRIPT_DIR/.."
 docker compose up --build || exit 1
 
+test -d bin/backend/node_modules/@nestjs/websockets || {
+  echo "backend artifact is missing @nestjs/websockets; rebuild backend_build failed or produced stale bin/backend" >&2
+  exit 1
+}
+
+grep -q 'module-alias/register' bin/backend/dist/src/main.js || {
+  echo "backend artifact is missing module-alias/register; rebuild backend_build produced stale dist" >&2
+  exit 1
+}
+
+test -f bin/frontend/dist/index.html || {
+  echo "frontend artifact is missing dist/index.html; rebuild frontend_build failed or produced stale bin/frontend" >&2
+  exit 1
+}
+
 cd "$SCRIPT_DIR"
 mkdir -p .router_sync/"$PROJECT_NAME"
 rm -rf .router_sync/backend && mkdir -p .router_sync/backend
+rm -rf .router_sync/frontend && mkdir -p .router_sync/frontend
 rm -rf .router_sync/proto && mkdir -p .router_sync/proto
+rm -rf .router_sync/logrotate && mkdir -p .router_sync/logrotate
+rm -rf .router_sync/nginx && mkdir -p .router_sync/nginx
 cp -f ../bin/"$PROJECT_NAME" .router_sync/"$PROJECT_NAME"/"$PROJECT_NAME"
 cp -rf ../bin/backend/* .router_sync/backend/
-# cd "$SCRIPT_DIR/../backend" && bun run build || exit 1 // czm buildujemy to w deployu
+cp -rf ../bin/frontend/dist .router_sync/frontend/
 cd "$SCRIPT_DIR"
-# Lokalny build backendu jest opcjonalny. Jeśli nie istnieje `../backend/dist`,
-# zostawiamy artefakty skopiowane wcześniej z `../bin/backend/dist`.
-if [ -d ../backend/dist ]; then
-  rm -rf .router_sync/backend/dist && mkdir -p .router_sync/backend/dist
-  cp -rf ../backend/dist/* .router_sync/backend/dist/
-else
-  echo "backend/dist not found locally; using artifacts from ../bin/backend/dist"
-fi
 rm -rf .router_sync/backend/devCerts && mkdir -p .router_sync/backend/devCerts
 cp -rf ../backend/devCerts/* .router_sync/backend/devCerts/
 cp -rf ../proto/* .router_sync/proto/
 cp -rf ./configs/* .router_sync/ngfw
 cp -rf services .router_sync
+cp -rf nginx/* .router_sync/nginx/
+cp -rf logrotate/* .router_sync/logrotate/
 
 vagrant rsync r1 || true
 vagrant up --provision

--- a/vagrant/logrotate/raptorgate
+++ b/vagrant/logrotate/raptorgate
@@ -1,0 +1,16 @@
+/var/log/raptorgate/.logrotate-trigger {
+    daily
+    rotate 1
+    missingok
+    create 0644 root root
+    nocompress
+    sharedscripts
+    postrotate
+        today="$(date +%F)"
+        for dir in /var/log/raptorgate/firewall /var/log/raptorgate/backend; do
+            [ -d "$dir" ] || continue
+            find "$dir" -maxdepth 1 -type f -name "*.log" ! -name "$today.log" -exec gzip -n -f {} +
+            find "$dir" -maxdepth 1 -type f -name "*.log.gz" -mtime +14 -delete
+        done
+    endscript
+}

--- a/vagrant/nginx/raptorgate-frontend.conf
+++ b/vagrant/nginx/raptorgate-frontend.conf
@@ -1,0 +1,60 @@
+user www-data;
+worker_processes auto;
+pid /run/raptorgate-frontend-nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  sendfile on;
+  tcp_nopush on;
+  types_hash_max_size 2048;
+
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  access_log /var/log/raptorgate/frontend/access.log;
+  error_log /var/log/raptorgate/frontend/error.log warn;
+
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+  }
+
+  server {
+    listen 192.168.56.254:443 ssl;
+    server_name _;
+
+    ssl_certificate /resources/backend/devCerts/cert.pem;
+    ssl_certificate_key /resources/backend/devCerts/key.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    root /resources/frontend/dist;
+    index index.html;
+
+    location = /api {
+      return 308 /api/;
+    }
+
+    location /api/ {
+      proxy_pass https://127.0.0.1:3000/;
+      proxy_ssl_verify off;
+      proxy_http_version 1.1;
+
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Port 443;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+    }
+
+    location / {
+      try_files $uri $uri/ /index.html;
+    }
+  }
+}

--- a/vagrant/services/backend.service
+++ b/vagrant/services/backend.service
@@ -16,9 +16,12 @@ Environment=NODE_ENV=production
 Environment=PORT=3000
 Environment=GRPC_PORT=3001
 Environment=GRPC_SOCKET_PATH=../ngfw/sockets/firewall.sock
+Environment=FIREWALL_GRPC_SOCKET_PATH=../ngfw/sockets/control-plane.sock
+Environment=FIREWALL_QUERY_GRPC_SOCKET_PATH=../ngfw/sockets/query.sock
 Environment=JWT_SECRET=development-jwt-secret-change-me-1234567890
 Environment=REFRESH_TOKEN_SECRET=development-refresh-secret-change-me-1234567890
 Environment=COOKIE_SECRET=development-cookie-secret-change-me-1234567890
+Environment=AUTH_COOKIE_PATH=/api/auth/refresh
 User=root
 
 [Install]

--- a/vagrant/services/frontend.service
+++ b/vagrant/services/frontend.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=RaptorGate Frontend HTTPS Gateway
+After=network-online.target backend.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStartPre=/usr/sbin/nginx -t -c /etc/nginx/raptorgate-frontend.conf
+ExecStart=/usr/sbin/nginx -c /etc/nginx/raptorgate-frontend.conf -g 'daemon off;'
+ExecReload=/usr/sbin/nginx -s reload -c /etc/nginx/raptorgate-frontend.conf
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/vagrant/services/ngfw.service
+++ b/vagrant/services/ngfw.service
@@ -16,6 +16,8 @@ User=root
 AmbientCapabilities=CAP_NET_RAW
 Environment="CAPTURE_INTERFACES=eth1,eth2"
 EnvironmentFile=/etc/systemd/system/ngfw.env
+Environment="EVENT_SOCKET_PATH=/resources/ngfw/sockets/firewall.sock"
+Environment="QUERY_SOCKET_PATH=/resources/ngfw/sockets/query.sock"
 Environment="CONTROL_PLANE_GRPC_SOCKET_PATH=/resources/ngfw/sockets/control-plane.sock"
 Environment="DUMMY_NAT_ENABLED=true"
 Environment="DUMMY_NAT_ALLOW_ALL=true"

--- a/vagrant/vagrantfile
+++ b/vagrant/vagrantfile
@@ -28,7 +28,7 @@ end
 def setup_nftables
   <<-SHELL
     apt-get update
-    apt-get install -y nftables
+    apt-get install -y nftables logrotate
     systemctl enable nftables
     systemctl restart nftables
 
@@ -53,15 +53,38 @@ def setup_nftables
     nft add rule inet filter input ct state established,related accept
     nft add rule inet filter input tcp dport 22 ct state new accept
     nft add rule inet filter input tcp dport 2201 ct state new accept
+    nft add rule inet filter input iifname "eth3" ip daddr 192.168.56.254 tcp dport 443 ct state new accept
   SHELL
 end
+
 def setup_backend_service
   <<-SHELL
     chmod +x /resources/backend/bun
+    install -d -m 0755 /var/log/raptorgate/backend
+    touch /var/log/raptorgate/.logrotate-trigger
     cp -f /resources/services/backend.service /etc/systemd/system/backend.service
+    if [ -f /resources/logrotate/raptorgate ]; then
+      cp -f /resources/logrotate/raptorgate /etc/logrotate.d/raptorgate
+      chmod 0644 /etc/logrotate.d/raptorgate
+    fi
     systemctl daemon-reload
     systemctl enable backend
     systemctl restart backend
+  SHELL
+end
+
+def setup_frontend_service
+  <<-SHELL
+    apt-get update
+    apt-get install -y nginx
+    install -d -m 0755 /resources/frontend/dist
+    install -d -m 0755 /var/log/raptorgate/frontend
+    cp -f /resources/nginx/raptorgate-frontend.conf /etc/nginx/raptorgate-frontend.conf
+    cp -f /resources/services/frontend.service /etc/systemd/system/frontend.service
+    systemctl disable --now nginx 2>/dev/null || true
+    systemctl daemon-reload
+    systemctl enable frontend
+    systemctl restart frontend
   SHELL
 end
 
@@ -82,8 +105,15 @@ def setup_ngfw_service
     mkdir -p /resources/ngfw
     mkdir -p /resources/ngfw/.data
     mkdir -p /resources/ngfw/sockets
+    install -d -m 0755 /var/log/raptorgate/firewall
+    touch /var/log/raptorgate/.logrotate-trigger
     chmod +x /resources/ngfw/ngfw
-    cp -rf /resources/services/* /etc/systemd/system/
+    cp -f /resources/services/*.service /etc/systemd/system/
+    cp -f /resources/services/ngfw.env /etc/systemd/system/ngfw.env
+    if [ -f /resources/logrotate/raptorgate ]; then
+      cp -f /resources/logrotate/raptorgate /etc/logrotate.d/raptorgate
+      chmod 0644 /etc/logrotate.d/raptorgate
+    fi
     systemctl daemon-reload
     systemctl restart ngfw
     systemctl enable --now ngfw
@@ -122,6 +152,7 @@ Vagrant.configure("2") do |config|
   #   192.168.20.0/24  (intnet2) : h2  (.10)  — r1 (.254)
   #                                             ldap  (.20)
   #                                             radius (.30)
+  #   192.168.56.0/24  (mgmt)    : host       — r1 (.254)
   #   r1 also runs the backend API (internal only, port 3000)
   # ---------------------------------------------------------------
 
@@ -170,6 +201,10 @@ Vagrant.configure("2") do |config|
       ip: "192.168.20.254",
       netmask: "255.255.255.0",
       libvirt__network_name: "intnet2"
+    r1.vm.network "private_network",
+      ip: "192.168.56.254",
+      netmask: "255.255.255.0",
+      libvirt__network_name: "mgmt"
 
     # config.trigger.before :provision do |t|
     #   t.info = "rsyncing .router_sync -> /resources"
@@ -180,13 +215,16 @@ Vagrant.configure("2") do |config|
 
     r1_provision = configure_interface("eth1", "192.168.10.254", "24") +
       configure_interface("eth2", "192.168.20.254", "24") +
+      configure_interface("eth3", "192.168.56.254", "24") +
       setup_tun_device + setup_nftables + setup_ngfw_service
 
-    r1_provision += setup_backend_service unless ENV['NO_BACKEND'] == '1'
+    unless ENV['NO_BACKEND'] == '1'
+      r1_provision += setup_backend_service + setup_frontend_service
+    end
 
     r1.vm.provision "shell", inline: r1_provision
 
-    # r1 has two interfaces, no gateway needed since it IS the gateway
+    # r1 has routed test interfaces plus a host-only management interface.
   end
 
   config.vm.define "ldap" do |ldap|


### PR DESCRIPTION
Add daily file logging for the backend and firewall services under /var/log/raptorgate, including Vagrant provisioning and logrotate setup. Fix Vagrant backend deployment artifacts so production startup includes required runtime dependencies and module alias registration. Build the frontend as a deployable Docker artifact, sync it into r1, and serve it through a dedicated HTTPS frontend service. Expose r1 on the 192.168.56.254 management interface and route https://192.168.56.254/api through Nginx to the backend. Configure backend refresh cookie paths for the /api reverse proxy so authentication works from the hosted frontend.