### PR TITLE
feat(observability): add structured log pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,17 +2078,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/backend/src/application/use-cases/apply-config-snapshot.use-case.ts
+++ b/backend/src/application/use-cases/apply-config-snapshot.use-case.ts
@@ -1,5 +1,5 @@
 import { hash } from "node:crypto";
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { ConfigurationSnapshot } from "../../domain/entities/configuration-snapshot.entity.js";
 import { AccessTokenIsInvalidException } from "../../domain/exceptions/acces-token-is-invalid.exception.js";
 import type { IConfigSnapshotRepository } from "../../domain/repositories/config-snapshot.repository.js";
@@ -33,6 +33,8 @@ import { TOKEN_SERVICE_TOKEN } from "../ports/token-service.interface.js";
 
 @Injectable()
 export class ApplyConfigSnapshotUseCase {
+  private readonly logger = new Logger(ApplyConfigSnapshotUseCase.name);
+
   constructor(
     @Inject(CONFIG_SNAPSHOT_REPOSITORY_TOKEN)
     private readonly configSnapshotRepository: IConfigSnapshotRepository,
@@ -161,6 +163,23 @@ export class ApplyConfigSnapshotUseCase {
         "apply",
       );
     }
+
+    this.logger.log({
+      event: "config_snapshot.apply.succeeded",
+      message: "configuration snapshot applied",
+      actorId: claims.sub,
+      snapshotId: newConfigSnapshot.getId(),
+      versionNumber: newConfigSnapshot.getVersionNumber(),
+      checksum,
+      isActive: dto.isActive,
+      counts: {
+        rules: activeRules.length,
+        zones: activeZones.length,
+        zonePairs: allZonePairs.length,
+        natRules: activeNatRules.length,
+        users: allUsers.length,
+      },
+    });
 
     return {
       id: newConfigSnapshot.getId(),

--- a/backend/src/application/use-cases/create-nat-rule.use-case.ts
+++ b/backend/src/application/use-cases/create-nat-rule.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { NatRule } from "../../domain/entities/nat-rule.entity.js";
 import { AccessTokenIsInvalidException } from "../../domain/exceptions/acces-token-is-invalid.exception.js";
 import { NatConfigIsInvalidException } from "../../domain/exceptions/nat-config-is-invalid.exception.js";
@@ -13,6 +13,8 @@ import { TOKEN_SERVICE_TOKEN } from "../ports/token-service.interface.js";
 
 @Injectable()
 export class CreateNatRuleUseCase {
+  private readonly logger = new Logger(CreateNatRuleUseCase.name);
+
   constructor(
     @Inject(NAT_RULES_REPOSITORY_TOKEN)
     private readonly natRulesRepository: INatRulesRepository,
@@ -52,6 +54,16 @@ export class CreateNatRuleUseCase {
       newNatRule.setTranslatedPort(dto.translatedPort);
 
     await this.natRulesRepository.save(newNatRule, claims.sub);
+
+    this.logger.log({
+      event: "nat_rule.create.succeeded",
+      message: "NAT rule created",
+      actorId: claims.sub,
+      natRuleId: newNatRule.getId(),
+      type: newNatRule.getType().getValue(),
+      isActive: newNatRule.getIsActive(),
+      priority: newNatRule.getPriority().getValue(),
+    });
 
     return { natRule: newNatRule };
   }

--- a/backend/src/application/use-cases/create-rule.use-case.ts
+++ b/backend/src/application/use-cases/create-rule.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { FirewallRule } from "../../domain/entities/firewall-rule.entity.js";
 import { AccessTokenIsInvalidException } from "../../domain/exceptions/acces-token-is-invalid.exception.js";
 import { EntityAlreadyExistsException } from "../../domain/exceptions/entity-already-exists-exception.js";
@@ -18,6 +18,8 @@ import {
 
 @Injectable()
 export class CreateRuleUseCase {
+  private readonly logger = new Logger(CreateRuleUseCase.name);
+
   constructor(
     @Inject(RULES_REPOSITORY_TOKEN)
     private readonly rulesRepository: IRulesRepository,
@@ -51,6 +53,17 @@ export class CreateRuleUseCase {
     );
 
     await this.rulesRepository.save(newRule);
+
+    this.logger.log({
+      event: "rule.create.succeeded",
+      message: "firewall rule created",
+      actorId: claims.sub,
+      ruleId: newRule.getId(),
+      ruleName: newRule.getName(),
+      zonePairId: newRule.getZonePairId(),
+      isActive: newRule.getIsActive(),
+      priority: newRule.getPriority().getValue(),
+    });
 
     return { rule: newRule };
   }

--- a/backend/src/application/use-cases/create-user.use-case.ts
+++ b/backend/src/application/use-cases/create-user.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { User } from "src/domain/entities/user.entity";
 import { RoleIsInvalidException } from "src/domain/exceptions/role-is-invalid.exception";
 import { UserAlreadyExistsException } from "src/domain/exceptions/user-already-exitst.exception";
@@ -19,6 +19,8 @@ import {
 
 @Injectable()
 export class CreateUserUseCase {
+  private readonly logger = new Logger(CreateUserUseCase.name);
+
   constructor(
     @Inject(USER_REPOSITORY_TOKEN)
     private readonly userRepository: IUserRepository,
@@ -67,6 +69,14 @@ export class CreateUserUseCase {
 
     const userRoles = await this.roleRepository.findByUserId(newUser.getId());
     newUser.setRoles(userRoles);
+
+    this.logger.log({
+      event: "user.create.succeeded",
+      message: "user created",
+      userId: newUser.getId(),
+      username: newUser.getUsername(),
+      roles: userRoles.map((role) => role.getName()),
+    });
 
     return {
       user: newUser,

--- a/backend/src/application/use-cases/create-zone-pair.use-case.ts
+++ b/backend/src/application/use-cases/create-zone-pair.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { ZonePair } from "../../domain/entities/zone-pair.entity.js";
 import { AccessTokenIsInvalidException } from "../../domain/exceptions/acces-token-is-invalid.exception.js";
 import { EntityAlreadyExistsException } from "../../domain/exceptions/entity-already-exists-exception.js";
@@ -14,6 +14,8 @@ import { TOKEN_SERVICE_TOKEN } from "../ports/token-service.interface.js";
 
 @Injectable()
 export class CreateZonePairUseCase {
+  private readonly logger = new Logger(CreateZonePairUseCase.name);
+
   constructor(
     @Inject(ZONE_PAIR_REPOSITORY_TOKEN)
     private readonly zonePairRepository: IZonePairRepository,
@@ -56,6 +58,16 @@ export class CreateZonePairUseCase {
     );
 
     await this.zonePairRepository.save(newZonePair);
+
+    this.logger.log({
+      event: "zone_pair.create.succeeded",
+      message: "zone pair created",
+      actorId: claims.sub,
+      zonePairId: newZonePair.getId(),
+      srcZoneId: newZonePair.getSrcZoneId(),
+      dstZoneId: newZonePair.getDstZoneId(),
+      defaultPolicy: newZonePair.getDefaultPolicy(),
+    });
 
     return { zonePair: newZonePair };
   }

--- a/backend/src/application/use-cases/create-zone.use-case.ts
+++ b/backend/src/application/use-cases/create-zone.use-case.ts
@@ -7,10 +7,12 @@ import { CreateZoneResponseDto } from '../dtos/create-zone-response.dto.js';
 import type { ITokenService } from '../ports/token-service.interface.js';
 import { Zone } from '../../domain/entities/zone.entity.js';
 import { CreateZoneDto } from '../dtos/create-zone.dto.js';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 
 @Injectable()
 export class CreateZoneUseCase {
+  private readonly logger = new Logger(CreateZoneUseCase.name);
+
   constructor(
     @Inject(ZONE_REPOSITORY_TOKEN)
     private readonly zoneRepository: IZoneRepository,
@@ -35,6 +37,15 @@ export class CreateZoneUseCase {
     );
 
     await this.zoneRepository.save(newZone, claims.sub);
+
+    this.logger.log({
+      event: 'zone.create.succeeded',
+      message: 'zone created',
+      actorId: claims.sub,
+      zoneId: newZone.getId(),
+      zoneName: newZone.getName(),
+      isActive: newZone.getIsActive(),
+    });
 
     return { zone: newZone };
   }

--- a/backend/src/application/use-cases/delete-nat-rule.use-case.ts
+++ b/backend/src/application/use-cases/delete-nat-rule.use-case.ts
@@ -1,10 +1,12 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { EntityNotFoundException } from "../../domain/exceptions/entity-not-found-exception.js";
 import type { INatRulesRepository } from "../../domain/repositories/nat-rules.repository.js";
 import { NAT_RULES_REPOSITORY_TOKEN } from "../../domain/repositories/nat-rules.repository.js";
 
 @Injectable()
 export class DeleteNatRuleUseCase {
+  private readonly logger = new Logger(DeleteNatRuleUseCase.name);
+
   constructor(
     @Inject(NAT_RULES_REPOSITORY_TOKEN)
     private readonly natRulesRepository: INatRulesRepository,
@@ -15,5 +17,12 @@ export class DeleteNatRuleUseCase {
     if (!existingRule) throw new EntityNotFoundException("Nat rule", id);
 
     await this.natRulesRepository.delete(id);
+
+    this.logger.log({
+      event: "nat_rule.delete.succeeded",
+      message: "NAT rule deleted",
+      natRuleId: existingRule.getId(),
+      type: existingRule.getType().getValue(),
+    });
   }
 }

--- a/backend/src/application/use-cases/delete-rule.use-case.ts
+++ b/backend/src/application/use-cases/delete-rule.use-case.ts
@@ -1,10 +1,12 @@
 import { EntityNotFoundException } from '../../domain/exceptions/entity-not-found-exception.js';
 import { RULES_REPOSITORY_TOKEN } from '../../domain/repositories/rules-repository.js';
 import type { IRulesRepository } from '../../domain/repositories/rules-repository.js';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 
 @Injectable()
 export class DeleteRuleUseCase {
+  private readonly logger = new Logger(DeleteRuleUseCase.name);
+
   constructor(
     @Inject(RULES_REPOSITORY_TOKEN)
     private readonly rulesRepository: IRulesRepository,
@@ -15,5 +17,12 @@ export class DeleteRuleUseCase {
     if (!rule) throw new EntityNotFoundException('rule', id);
 
     await this.rulesRepository.delete(id);
+
+    this.logger.log({
+      event: 'rule.delete.succeeded',
+      message: 'firewall rule deleted',
+      ruleId: rule.getId(),
+      ruleName: rule.getName(),
+    });
   }
 }

--- a/backend/src/application/use-cases/delete-user.use-case.ts
+++ b/backend/src/application/use-cases/delete-user.use-case.ts
@@ -8,10 +8,12 @@ import {
 } from 'src/domain/repositories/user.repository';
 import { EntityNotFoundException } from 'src/domain/exceptions/entity-not-found-exception';
 import { DleteUserDto } from '../dtos/delete-user.dto';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 
 @Injectable()
 export class DeleteUserUseCase {
+  private readonly logger = new Logger(DeleteUserUseCase.name);
+
   constructor(
     @Inject(USER_REPOSITORY_TOKEN)
     private readonly userRepository: IUserRepository,
@@ -33,5 +35,13 @@ export class DeleteUserUseCase {
     );
 
     await this.userRepository.deleteById(user.getId());
+
+    this.logger.log({
+      event: 'user.delete.succeeded',
+      message: 'user deleted',
+      userId: user.getId(),
+      username: user.getUsername(),
+      removedRoles: userRoles.map((role) => role.getName()),
+    });
   }
 }

--- a/backend/src/application/use-cases/delete-zone-pair.use-case.ts
+++ b/backend/src/application/use-cases/delete-zone-pair.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { EntityNotFoundException } from "../../domain/exceptions/entity-not-found-exception.js";
 import type { IZonePairRepository } from "../../domain/repositories/zone-pair.repository.js";
 import { ZONE_PAIR_REPOSITORY_TOKEN } from "../../domain/repositories/zone-pair.repository.js";
@@ -6,6 +6,8 @@ import type { DeleteZonePairDto } from "../dtos/delete-zone-pair.dto.js";
 
 @Injectable()
 export class DeleteZonePairUseCase {
+  private readonly logger = new Logger(DeleteZonePairUseCase.name);
+
   constructor(
     @Inject(ZONE_PAIR_REPOSITORY_TOKEN)
     private readonly zonePairRepository: IZonePairRepository,
@@ -15,6 +17,15 @@ export class DeleteZonePairUseCase {
     const isExisting = await this.zonePairRepository.findById(dto.id);
     if (!isExisting) throw new EntityNotFoundException("Zone pair", dto.id);
 
-    await this.zonePairRepository.findById(dto.id);
+    await this.zonePairRepository.delete(dto.id);
+
+    this.logger.log({
+      event: "zone_pair.delete.succeeded",
+      message: "zone pair deleted",
+      zonePairId: isExisting.getId(),
+      srcZoneId: isExisting.getSrcZoneId(),
+      dstZoneId: isExisting.getDstZoneId(),
+      defaultPolicy: isExisting.getDefaultPolicy(),
+    });
   }
 }

--- a/backend/src/application/use-cases/delete-zone.use-case.ts
+++ b/backend/src/application/use-cases/delete-zone.use-case.ts
@@ -5,10 +5,12 @@ import {
 import { EntityNotFoundException } from '../../domain/exceptions/entity-not-found-exception.js';
 import { ZONE_PAIR_REPOSITORY_TOKEN } from '../../domain/repositories/zone-pair.repository.js';
 import type { IZonePairRepository } from '../../domain/repositories/zone-pair.repository.js';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 
 @Injectable()
 export class DeleteZoneUseCase {
+  private readonly logger = new Logger(DeleteZoneUseCase.name);
+
   constructor(
     @Inject(ZONE_REPOSITORY_TOKEN)
     private readonly zoneRepository: IZoneRepository,
@@ -34,5 +36,13 @@ export class DeleteZoneUseCase {
       );
 
     await this.zoneRepository.delete(id);
+
+    this.logger.log({
+      event: 'zone.delete.succeeded',
+      message: 'zone deleted',
+      zoneId: isExisting.getId(),
+      zoneName: isExisting.getName(),
+      deletedZonePairs: zonePairsByDst.length + zonePairsBySrc.length,
+    });
   }
 }

--- a/backend/src/application/use-cases/edit-nat-rule.use-case.ts
+++ b/backend/src/application/use-cases/edit-nat-rule.use-case.ts
@@ -4,10 +4,12 @@ import { NAT_RULES_REPOSITORY_TOKEN } from '../../domain/repositories/nat-rules.
 import type { INatRulesRepository } from '../../domain/repositories/nat-rules.repository.js';
 import { EditNatRuleResponseDto } from '../dtos/edit-nat-rule-response.dto.js';
 import { EditNatRuleDto } from '../dtos/edit-nat-rule.dto.js';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 
 @Injectable()
 export class EditNatRuleUseCase {
+  private readonly logger = new Logger(EditNatRuleUseCase.name);
+
   constructor(
     @Inject(NAT_RULES_REPOSITORY_TOKEN)
     private readonly natRulesRepository: INatRulesRepository,
@@ -34,6 +36,18 @@ export class EditNatRuleUseCase {
     natRule.setUpdatedAt(new Date());
 
     await this.natRulesRepository.save(natRule);
+
+    this.logger.log({
+      event: 'nat_rule.update.succeeded',
+      message: 'NAT rule updated',
+      natRuleId: natRule.getId(),
+      type: natRule.getType().getValue(),
+      isActive: natRule.getIsActive(),
+      priority: natRule.getPriority().getValue(),
+      changedFields: Object.entries(dto)
+        .filter(([key, value]) => key !== 'id' && value !== undefined)
+        .map(([key]) => key),
+    });
 
     return { natRule };
   }

--- a/backend/src/application/use-cases/edit-rule.use-case.ts
+++ b/backend/src/application/use-cases/edit-rule.use-case.ts
@@ -8,10 +8,12 @@ import { EditRuleResponseDto } from '../dtos/edit-rule-response.dto.js';
 import type { IRulesRepository } from '../../domain/repositories/rules-repository.js';
 import { Priority } from '../../domain/value-objects/priority.vo.js';
 import { EditRuleDto } from '../dtos/edit-rule.dto.js';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 
 @Injectable()
 export class EditRuleUseCase {
+  private readonly logger = new Logger(EditRuleUseCase.name);
+
   constructor(
     @Inject(RULES_REPOSITORY_TOKEN)
     private readonly rulesRepository: IRulesRepository,
@@ -53,6 +55,19 @@ export class EditRuleUseCase {
     rule.setUpdatedAt(new Date());
 
     await this.rulesRepository.save(rule);
+
+    this.logger.log({
+      event: 'rule.update.succeeded',
+      message: 'firewall rule updated',
+      ruleId: rule.getId(),
+      ruleName: rule.getName(),
+      zonePairId: rule.getZonePairId(),
+      isActive: rule.getIsActive(),
+      priority: rule.getPriority().getValue(),
+      changedFields: Object.entries(dto)
+        .filter(([key, value]) => key !== 'id' && value !== undefined)
+        .map(([key]) => key),
+    });
 
     return {
       id: rule.getId(),

--- a/backend/src/application/use-cases/edit-user.use-case.ts
+++ b/backend/src/application/use-cases/edit-user.use-case.ts
@@ -15,10 +15,12 @@ import { EntityNotFoundException } from 'src/domain/exceptions/entity-not-found-
 import { RoleIsInvalidException } from 'src/domain/exceptions/role-is-invalid.exception';
 import { EditUserResponseDto } from '../dtos/edit-user-response.dto';
 import { EditUserDto } from '../dtos/edit-user.dto';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 
 @Injectable()
 export class EditUserUseCase {
+  private readonly logger = new Logger(EditUserUseCase.name);
+
   constructor(
     @Inject(USER_REPOSITORY_TOKEN)
     private readonly userRepository: IUserRepository,
@@ -73,6 +75,17 @@ export class EditUserUseCase {
 
     const userRoles = await this.roleRepository.findByUserId(user.getId());
     user.setRoles(userRoles);
+
+    this.logger.log({
+      event: 'user.update.succeeded',
+      message: 'user updated',
+      userId: user.getId(),
+      username: user.getUsername(),
+      roles: userRoles.map((role) => role.getName()),
+      changedFields: Object.entries(dto)
+        .filter(([key, value]) => key !== 'id' && value !== undefined)
+        .map(([key]) => key),
+    });
 
     return { user };
   }

--- a/backend/src/application/use-cases/edit-zone-pair.use-case.ts
+++ b/backend/src/application/use-cases/edit-zone-pair.use-case.ts
@@ -6,10 +6,12 @@ import { EditZonePairResponseDto } from '../dtos/edit-zone-pair-response.dto.js'
 import { ZONE_REPOSITORY_TOKEN } from '../../domain/repositories/zone.repository.js';
 import type { IZoneRepository } from '../../domain/repositories/zone.repository.js';
 import { EditZonePairDto } from '../dtos/edit-zone-pair.dto.js';
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, Logger } from '@nestjs/common';
 
 @Injectable()
 export class EditZonePairUseCase {
+  private readonly logger = new Logger(EditZonePairUseCase.name);
+
   constructor(
     @Inject(ZONE_PAIR_REPOSITORY_TOKEN)
     private readonly zonePairRepository: IZonePairRepository,
@@ -49,6 +51,18 @@ export class EditZonePairUseCase {
       zonePairExists.setDefaultPolicy(dto.defaultPolicy);
 
     await this.zonePairRepository.save(zonePairExists);
+
+    this.logger.log({
+      event: 'zone_pair.update.succeeded',
+      message: 'zone pair updated',
+      zonePairId: zonePairExists.getId(),
+      srcZoneId: zonePairExists.getSrcZoneId(),
+      dstZoneId: zonePairExists.getDstZoneId(),
+      defaultPolicy: zonePairExists.getDefaultPolicy(),
+      changedFields: Object.entries(dto)
+        .filter(([key, value]) => key !== 'id' && value !== undefined)
+        .map(([key]) => key),
+    });
 
     return {
       zonePair: zonePairExists,

--- a/backend/src/application/use-cases/edit-zone.use-case.ts
+++ b/backend/src/application/use-cases/edit-zone.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { AccessTokenIsInvalidException } from "../../domain/exceptions/acces-token-is-invalid.exception.js";
 import { AtLeastOneFieldRequiredException } from "../../domain/exceptions/at-least-one-field-required.exception.js";
 import { EntityNotFoundException } from "../../domain/exceptions/entity-not-found-exception.js";
@@ -13,6 +13,8 @@ import { TOKEN_SERVICE_TOKEN } from "../ports/token-service.interface.js";
 
 @Injectable()
 export class EditZoneUseCase {
+  private readonly logger = new Logger(EditZoneUseCase.name);
+
   constructor(
     @Inject(ZONE_REPOSITORY_TOKEN)
     private readonly zoneRepository: IZoneRepository,
@@ -37,6 +39,17 @@ export class EditZoneUseCase {
     if (dto.isActive !== undefined) zone.setIsActive(dto.isActive);
 
     await this.zoneRepository.save(zone, zone.getCreatedBy());
+    this.logger.log({
+      event: "zone.update.succeeded",
+      message: "zone updated",
+      actorId: claims.sub,
+      zoneId: zone.getId(),
+      zoneName: zone.getName(),
+      isActive: zone.getIsActive(),
+      changedFields: Object.entries(dto)
+        .filter(([key, value]) => key !== "id" && key !== "accessToken" && value !== undefined)
+        .map(([key]) => key),
+    });
     return { zone };
   }
 }

--- a/backend/src/application/use-cases/import-config.use-case.ts
+++ b/backend/src/application/use-cases/import-config.use-case.ts
@@ -1,5 +1,5 @@
 import { hash } from "node:crypto";
-import { BadRequestException, Inject, Injectable } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable, Logger } from "@nestjs/common";
 import { ConfigurationSnapshot } from "src/domain/entities/configuration-snapshot.entity";
 import { FirewallRule } from "src/domain/entities/firewall-rule.entity";
 import { NatRule } from "src/domain/entities/nat-rule.entity";
@@ -49,6 +49,8 @@ import {
 
 @Injectable()
 export class ImportConfigUseCase {
+  private readonly logger = new Logger(ImportConfigUseCase.name);
+
   constructor(
     @Inject(CONFIG_SNAPSHOT_REPOSITORY_TOKEN)
     private readonly configSnapshotRepository: IConfigSnapshotRepository,
@@ -192,6 +194,22 @@ export class ImportConfigUseCase {
         "import",
       );
     }
+
+    this.logger.log({
+      event: "config_snapshot.import.succeeded",
+      message: "configuration snapshot imported",
+      actorId: claims.sub,
+      snapshotId: importedSnapshot.getId(),
+      versionNumber: importedSnapshot.getVersionNumber(),
+      checksum: calculatedChecksum,
+      isActive: dto.snapshotData.isActive,
+      counts: {
+        rules: payload.bundle.rules.items.length,
+        zones: payload.bundle.zones.items.length,
+        zonePairs: payload.bundle.zone_pairs.items.length,
+        natRules: payload.bundle.nat_rules.items.length,
+      },
+    });
 
     return {
       configSnapshot: importedSnapshot,

--- a/backend/src/application/use-cases/login-user.use-case.ts
+++ b/backend/src/application/use-cases/login-user.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { InvalidCredentialsException } from "../../domain/exceptions/invalid-credentials.exception.js";
 import type { IUserRepository } from "../../domain/repositories/user.repository.js";
 import { USER_REPOSITORY_TOKEN } from "../../domain/repositories/user.repository.js";
@@ -13,6 +13,8 @@ import { TOKEN_SERVICE_TOKEN } from "../ports/token-service.interface.js";
 
 @Injectable()
 export class LoginUserUseCase {
+  private readonly logger = new Logger(LoginUserUseCase.name);
+
   constructor(
     @Inject(USER_REPOSITORY_TOKEN)
     private readonly userRepository: IUserRepository,
@@ -26,14 +28,29 @@ export class LoginUserUseCase {
   async execute(dto: LoginDto): Promise<LoginResponseDto> {
     const user = await this.userRepository.findByUsername(dto.username);
 
-    if (!user) throw new InvalidCredentialsException();
+    if (!user) {
+      this.logger.warn({
+        event: "auth.login.failed",
+        message: "login failed for unknown user",
+        username: dto.username,
+      });
+      throw new InvalidCredentialsException();
+    }
 
     const isPasswordValid = await this.passwordHasher.compare(
       dto.password,
       user.getPasswordHash(),
     );
 
-    if (!isPasswordValid) throw new InvalidCredentialsException();
+    if (!isPasswordValid) {
+      this.logger.warn({
+        event: "auth.login.failed",
+        message: "login failed for invalid password",
+        userId: user.getId(),
+        username: user.getUsername(),
+      });
+      throw new InvalidCredentialsException();
+    }
 
     const toknenPair = await this.tokenService.generateTokenPair({
       sub: user.getId(),
@@ -79,6 +96,14 @@ export class LoginUserUseCase {
     if (!user.getShowRecoveryToken() && !user.getIsFirstLogin()) {
       await this.userRepository.save(user);
     }
+
+    this.logger.log({
+      event: "auth.login.succeeded",
+      message: "user logged in",
+      userId: user.getId(),
+      username: user.getUsername(),
+      recoveryTokenIssued: recoveryToken !== null,
+    });
 
     return loggedInUser;
   }

--- a/backend/src/application/use-cases/logout-user.use-case.ts
+++ b/backend/src/application/use-cases/logout-user.use-case.ts
@@ -5,10 +5,12 @@ import type { IUserRepository } from '../../domain/repositories/user.repository.
 import { TOKEN_SERVICE_TOKEN } from '../ports/token-service.interface.js';
 import type { ITokenService } from '../ports/token-service.interface.js';
 import { LogoutUserDto } from '../dtos/logout-user.dto.js';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 
 @Injectable()
 export class LogoutUserUseCase {
+  private readonly logger = new Logger(LogoutUserUseCase.name);
+
   constructor(
     @Inject(USER_REPOSITORY_TOKEN)
     private readonly userRepository: IUserRepository,
@@ -38,5 +40,12 @@ export class LogoutUserUseCase {
       user.getRefreshToken(),
       user.getRefreshTokenExpiry(),
     );
+
+    this.logger.log({
+      event: 'auth.logout.succeeded',
+      message: 'user logged out',
+      userId: user.getId(),
+      username: user.getUsername(),
+    });
   }
 }

--- a/backend/src/application/use-cases/recover-password.use-case.ts
+++ b/backend/src/application/use-cases/recover-password.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { EntityNotFoundException } from "src/domain/exceptions/entity-not-found-exception";
 import {
   type IUserRepository,
@@ -16,6 +16,8 @@ import {
 
 @Injectable()
 export class RecoverPasswordUseCase {
+  private readonly logger = new Logger(RecoverPasswordUseCase.name);
+
   constructor(
     @Inject(USER_REPOSITORY_TOKEN)
     private readonly userRepository: IUserRepository,
@@ -27,17 +29,39 @@ export class RecoverPasswordUseCase {
 
   async execute(dto: RecoveryPasswordDto): Promise<void> {
     const user = await this.userRepository.findByUsername(dto.username);
-    if (!user) throw new EntityNotFoundException("User", dto.username);
+    if (!user) {
+      this.logger.warn({
+        event: "auth.password_recovery.failed",
+        message: "password recovery failed for unknown user",
+        username: dto.username,
+      });
+      throw new EntityNotFoundException("User", dto.username);
+    }
 
-    if (user.getRecoveryToken() === null)
+    if (user.getRecoveryToken() === null) {
+      this.logger.warn({
+        event: "auth.password_recovery.failed",
+        message: "password recovery token is not set",
+        userId: user.getId(),
+        username: user.getUsername(),
+      });
       throw new Error("No recovery token found for user");
+    }
 
     const isValidToken = await this.passwordHasherService.compare(
       dto.recoveryToken,
       user.getRecoveryToken()!,
     );
 
-    if (!isValidToken) throw new Error("Invalid recovery token");
+    if (!isValidToken) {
+      this.logger.warn({
+        event: "auth.password_recovery.failed",
+        message: "invalid recovery token",
+        userId: user.getId(),
+        username: user.getUsername(),
+      });
+      throw new Error("Invalid recovery token");
+    }
 
     const hashedPassword = await this.passwordHasherService.hash(
       dto.newPassword,
@@ -47,5 +71,12 @@ export class RecoverPasswordUseCase {
     user.setShowRecoveryToken(true);
 
     await this.userRepository.save(user);
+
+    this.logger.log({
+      event: "auth.password_recovery.succeeded",
+      message: "password recovered",
+      userId: user.getId(),
+      username: user.getUsername(),
+    });
   }
 }

--- a/backend/src/application/use-cases/refresh-token.use-case.ts
+++ b/backend/src/application/use-cases/refresh-token.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { RefreshTokenIsInvalidException } from "../../domain/exceptions/refresh-token-is-invalid.exception.js";
 import { UserNotFoundException } from "../../domain/exceptions/user-not-found.exception.js";
 import type { IUserRepository } from "../../domain/repositories/user.repository.js";
@@ -10,6 +10,8 @@ import { TOKEN_SERVICE_TOKEN } from "../ports/token-service.interface.js";
 
 @Injectable()
 export class RefreshTokenUseCase {
+  private readonly logger = new Logger(RefreshTokenUseCase.name);
+
   constructor(
     @Inject(TOKEN_SERVICE_TOKEN) private readonly tokenService: ITokenService,
     @Inject(USER_REPOSITORY_TOKEN)
@@ -31,6 +33,12 @@ export class RefreshTokenUseCase {
     if (!user) throw new UserNotFoundException(payload.sub);
 
     if (user.getRefreshToken() !== dto.refreshToken) {
+      this.logger.warn({
+        event: "auth.refresh.failed",
+        message: "refresh token mismatch",
+        userId: user.getId(),
+        username: user.getUsername(),
+      });
       throw new RefreshTokenIsInvalidException();
     }
 
@@ -47,6 +55,12 @@ export class RefreshTokenUseCase {
       user.setRefreshToken(null);
 
       await this.userRepository.setRefreshToken(user.getId(), null, null);
+      this.logger.warn({
+        event: "auth.refresh.failed",
+        message: "refresh token expired outside grace period",
+        userId: user.getId(),
+        username: user.getUsername(),
+      });
       throw new RefreshTokenIsInvalidException();
     }
 
@@ -67,6 +81,13 @@ export class RefreshTokenUseCase {
         user.getRefreshTokenExpiry(),
       );
 
+      this.logger.log({
+        event: "auth.refresh.rotated",
+        message: "refresh token rotated",
+        userId: user.getId(),
+        username: user.getUsername(),
+      });
+
       return {
         accessToken: newTokenPair.accessToken,
         refreshToken: newTokenPair.refreshToken,
@@ -74,6 +95,13 @@ export class RefreshTokenUseCase {
     } else {
       const accessToken = await this.tokenService.generateAccessToken({
         sub: user.getId(),
+        username: user.getUsername(),
+      });
+
+      this.logger.log({
+        event: "auth.refresh.succeeded",
+        message: "access token refreshed",
+        userId: user.getId(),
         username: user.getUsername(),
       });
 

--- a/backend/src/application/use-cases/rollback-config.use-case.ts
+++ b/backend/src/application/use-cases/rollback-config.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { EntityNotFoundException } from "../../domain/exceptions/entity-not-found-exception.js";
 import {
   CONFIG_SNAPSHOT_REPOSITORY_TOKEN,
@@ -29,6 +29,8 @@ import {
 
 @Injectable()
 export class RollbackConfigUseCase {
+  private readonly logger = new Logger(RollbackConfigUseCase.name);
+
   constructor(
     @Inject(CONFIG_SNAPSHOT_REPOSITORY_TOKEN)
     private readonly configSnapshotRepository: IConfigSnapshotRepository,
@@ -65,6 +67,20 @@ export class RollbackConfigUseCase {
       configSnapshot,
       "rollback",
     );
+
+    this.logger.log({
+      event: "config_snapshot.rollback.succeeded",
+      message: "configuration snapshot rolled back",
+      snapshotId: configSnapshot.getId(),
+      versionNumber: configSnapshot.getVersionNumber(),
+      checksum: configSnapshot.getChecksum().getValue(),
+      counts: {
+        rules: configBundle.bundle.rules.items.length,
+        zones: configBundle.bundle.zones.items.length,
+        zonePairs: configBundle.bundle.zone_pairs.items.length,
+        natRules: configBundle.bundle.nat_rules.items.length,
+      },
+    });
 
     return {
       id: configSnapshot.getId(),

--- a/backend/src/application/use-cases/update-dns-inspection-config.use-case.ts
+++ b/backend/src/application/use-cases/update-dns-inspection-config.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { DnsInspectionConfig } from "../../domain/entities/dns-inspection-config.entity.js";
 import {
   DNS_INSPECTION_REPOSITORY_TOKEN,
@@ -15,6 +15,8 @@ import {
 
 @Injectable()
 export class UpdateDnsInspectionConfigUseCase {
+  private readonly logger = new Logger(UpdateDnsInspectionConfigUseCase.name);
+
   constructor(
     @Inject(DNS_INSPECTION_REPOSITORY_TOKEN)
     private readonly repository: IDnsInspectionRepository,
@@ -56,6 +58,15 @@ export class UpdateDnsInspectionConfigUseCase {
     await this.firewallDnsInspectionQueryService.swapDnsInspectionConfig(
       dnsInspection,
     );
+
+    this.logger.log({
+      event: "dns_inspection.update.succeeded",
+      message: "DNS inspection config updated",
+      enabled: dnsInspection.getGeneral().enabled,
+      blocklistDomains: dnsInspection.getBlocklist().domains.length,
+      dnsTunnelingEnabled: dnsInspection.getDnsTunneling().enabled,
+      dnssecEnabled: dnsInspection.getDnssec().enabled,
+    });
 
     return { dnsInspection };
   }

--- a/backend/src/application/use-cases/update-ips-config.use-case.ts
+++ b/backend/src/application/use-cases/update-ips-config.use-case.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { IpsConfig } from "src/domain/entities/ips-config.entity";
 import { IpsSignature } from "src/domain/entities/ips-signature.entity";
 import {
@@ -20,6 +20,8 @@ import {
 
 @Injectable()
 export class UpdateIpsConfigUseCase {
+  private readonly logger = new Logger(UpdateIpsConfigUseCase.name);
+
   constructor(
     @Inject(IPS_CONFIG_REPOSITORY_TOKEN)
     private readonly ipsConfigRepository: IIpsConfigRepository,
@@ -54,6 +56,14 @@ export class UpdateIpsConfigUseCase {
     await this.ipsConfigRepository.save(newIpsConfig);
 
     await this.firewallIpsConfigQueryService.swapIpsConfig(newIpsConfig);
+
+    this.logger.log({
+      event: "ips.update.succeeded",
+      message: "IPS config updated",
+      enabled: newIpsConfig.getGeneral().enabled,
+      detectionEnabled: newIpsConfig.getDetection().enabled,
+      signatures: newIpsConfig.getSignatures().length,
+    });
 
     return { ipsConfig: newIpsConfig };
   }

--- a/backend/src/infrastructure/adapters/grpc-config-snapshot-push.service.ts
+++ b/backend/src/infrastructure/adapters/grpc-config-snapshot-push.service.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import {
   Inject,
   Injectable,
+  Logger,
   OnModuleInit,
   ServiceUnavailableException,
 } from "@nestjs/common";
@@ -34,6 +35,7 @@ export const CONFIG_SNAPSHOT_PUSH_GRPC_CLIENT_TOKEN =
 export class GrpcConfigSnapshotPushService
   implements IConfigSnapshotPushService, OnModuleInit
 {
+  private readonly logger = new Logger(GrpcConfigSnapshotPushService.name);
   private configSnapshotPushClient: FirewallConfigSnapshotServiceClient;
 
   constructor(
@@ -53,9 +55,10 @@ export class GrpcConfigSnapshotPushService
     reason: ConfigSnapshotPushReason,
   ): Promise<void> {
     const payload = snapshot.deserializePayload();
+    const correlationId = randomUUID();
 
     const request: PushActiveConfigSnapshotRequest = {
-      correlationId: randomUUID(),
+      correlationId,
       reason,
       snapshot: {
         id: snapshot.getId(),
@@ -70,19 +73,57 @@ export class GrpcConfigSnapshotPushService
       },
     };
 
+    this.logger.log({
+      event: "firewall.snapshot.push.started",
+      message: "pushing active config snapshot to firewall",
+      correlationId,
+      reason,
+      snapshotId: snapshot.getId(),
+      versionNumber: snapshot.getVersionNumber(),
+      counts: bundleCounts(payload),
+    });
+
     try {
       const response = await firstValueFrom(
         this.configSnapshotPushClient.pushActiveConfigSnapshot(request),
       );
 
       if (!response.accepted) {
+        this.logger.warn({
+          event: "firewall.snapshot.push.rejected",
+          message: response.message || "firewall rejected active snapshot push",
+          correlationId,
+          reason,
+          snapshotId: snapshot.getId(),
+        });
         throw new Error(
           `Firewall rejected active snapshot push: ${response.message || "unknown reason"}`,
         );
       }
+
+      this.logger.log({
+        event: "firewall.snapshot.push.succeeded",
+        message: "firewall accepted active config snapshot",
+        correlationId,
+        reason,
+        snapshotId: snapshot.getId(),
+        appliedSnapshotId: response.appliedSnapshotId,
+      });
     } catch (error) {
       const reasonText =
         error instanceof Error ? error.message : "Unknown gRPC error";
+
+      this.logger.error(
+        {
+          event: "firewall.snapshot.push.failed",
+          message: "failed to push active config snapshot to firewall",
+          correlationId,
+          reason,
+          snapshotId: snapshot.getId(),
+          error: reasonText,
+        },
+        error instanceof Error ? error.stack : undefined,
+      );
 
       throw new ServiceUnavailableException(
         `Firewall config snapshot push service is unavailable. ${reasonText}`,
@@ -226,4 +267,17 @@ export class GrpcConfigSnapshotPushService
         return CertificateType.CERTIFICATE_TYPE_UNSPECIFIED;
     }
   }
+}
+
+function bundleCounts(payload: ConfigSnapshotPayload) {
+  const bundle = payload.bundle;
+
+  return {
+    rules: bundle.rules.items.length,
+    zones: bundle.zones.items.length,
+    zonePairs: bundle.zone_pairs.items.length,
+    natRules: bundle.nat_rules.items.length,
+    dnsBlacklist: bundle.dns_blacklist.items.length,
+    ipsSignatures: bundle.ips_signatures.items.length,
+  };
 }

--- a/backend/src/infrastructure/adapters/grpc-firewall-dns-inspection-query.service.ts
+++ b/backend/src/infrastructure/adapters/grpc-firewall-dns-inspection-query.service.ts
@@ -1,6 +1,7 @@
 import {
   Inject,
   Injectable,
+  Logger,
   OnModuleInit,
   ServiceUnavailableException,
 } from "@nestjs/common";
@@ -31,6 +32,7 @@ export const FIREWALL_QUERY_GRPC_CLIENT_TOKEN =
 export class GrpcFirewallDnsInspectionQueryService
   implements IFirewallDnsInspectionQueryService, OnModuleInit
 {
+  private readonly logger = new Logger(GrpcFirewallDnsInspectionQueryService.name);
   private firewallQueryClient: FirewallQueryServiceClient;
 
   constructor(
@@ -47,18 +49,46 @@ export class GrpcFirewallDnsInspectionQueryService
 
   async swapDnsInspectionConfig(config: DnsInspectionConfig): Promise<void> {
     try {
+      this.logger.log({
+        event: "firewall.dns_inspection.swap.started",
+        message: "swapping DNS inspection config on firewall",
+        enabled: config.getGeneral().enabled,
+        blocklistDomains: config.getBlocklist().domains.length,
+        dnsTunnelingEnabled: config.getDnsTunneling().enabled,
+        dnssecEnabled: config.getDnssec().enabled,
+      });
+
       await firstValueFrom(
         this.firewallQueryClient.swapDnsInspectionConfig({
           config: this.toProto(config),
         }),
       );
+
+      this.logger.log({
+        event: "firewall.dns_inspection.swap.succeeded",
+        message: "DNS inspection config swapped on firewall",
+        enabled: config.getGeneral().enabled,
+      });
     } catch (error) {
+      this.logger.error(
+        {
+          event: "firewall.dns_inspection.swap.failed",
+          message: "failed to swap DNS inspection config on firewall",
+          error: error instanceof Error ? error.message : "Unknown gRPC error",
+        },
+        error instanceof Error ? error.stack : undefined,
+      );
       throw this.toTransportException("swap DNS inspection config", error);
     }
   }
 
   async getDnsInspectionConfig(): Promise<DnsInspectionConfig> {
     try {
+      this.logger.log({
+        event: "firewall.dns_inspection.get.started",
+        message: "loading DNS inspection config from firewall",
+      });
+
       const response = await firstValueFrom(
         this.firewallQueryClient.getDnsInspectionConfig({}),
       );
@@ -69,12 +99,29 @@ export class GrpcFirewallDnsInspectionQueryService
         );
       }
 
-      return this.toDomain(response.config);
+      const config = this.toDomain(response.config);
+
+      this.logger.log({
+        event: "firewall.dns_inspection.get.succeeded",
+        message: "loaded DNS inspection config from firewall",
+        enabled: config.getGeneral().enabled,
+        blocklistDomains: config.getBlocklist().domains.length,
+      });
+
+      return config;
     } catch (error) {
       if (error instanceof ServiceUnavailableException) {
         throw error;
       }
 
+      this.logger.error(
+        {
+          event: "firewall.dns_inspection.get.failed",
+          message: "failed to load DNS inspection config from firewall",
+          error: error instanceof Error ? error.message : "Unknown gRPC error",
+        },
+        error instanceof Error ? error.stack : undefined,
+      );
       throw this.toTransportException("get DNS inspection config", error);
     }
   }

--- a/backend/src/infrastructure/adapters/grpc-firewall-ips-config-query.service.ts
+++ b/backend/src/infrastructure/adapters/grpc-firewall-ips-config-query.service.ts
@@ -1,6 +1,7 @@
 import {
   Inject,
   Injectable,
+  Logger,
   OnModuleInit,
   ServiceUnavailableException,
 } from "@nestjs/common";
@@ -19,6 +20,8 @@ import { Severity } from "../grpc/generated/common/common";
 import {
   IpsAction,
   IpsAppProtocol,
+  IpsMatchType,
+  IpsPatternEncoding,
 } from "../grpc/generated/config/config_models";
 import {
   FIREWALL_QUERY_SERVICE_NAME,
@@ -30,6 +33,7 @@ import { FIREWALL_QUERY_GRPC_CLIENT_TOKEN } from "./grpc-firewall-dns-inspection
 export class GrpcFirewallIpsConfigQueryService
   implements IFirewallIpsConfigQueryService, OnModuleInit
 {
+  private readonly logger = new Logger(GrpcFirewallIpsConfigQueryService.name);
   private firewallQueryClient: FirewallQueryServiceClient;
 
   constructor(
@@ -46,6 +50,14 @@ export class GrpcFirewallIpsConfigQueryService
 
   async swapIpsConfig(config: IpsConfig): Promise<void> {
     try {
+      this.logger.log({
+        event: "firewall.ips.swap.started",
+        message: "swapping IPS config on firewall",
+        enabled: config.getGeneral().enabled,
+        detectionEnabled: config.getDetection().enabled,
+        signatures: config.getSignatures().length,
+      });
+
       await firstValueFrom(
         this.firewallQueryClient.swapIpsConfig({
           config: {
@@ -65,18 +77,47 @@ export class GrpcFirewallIpsConfigQueryService
                   .map((appProtocol) => IpsAppProtocol[appProtocol.getValue()]),
                 srcPorts: signature.getSrcPorts().map((port) => port.getValue),
                 dstPorts: signature.getDstPorts().map((port) => port.getValue),
+                matchType: IpsMatchType.IPS_MATCH_TYPE_REGEX,
+                patternEncoding: IpsPatternEncoding.IPS_PATTERN_ENCODING_TEXT,
+                caseInsensitive: false,
               };
             }),
           },
         }),
       );
+
+      this.logger.log({
+        event: "firewall.ips.swap.succeeded",
+        message: "IPS config swapped on firewall",
+        enabled: config.getGeneral().enabled,
+        signatures: config.getSignatures().length,
+      });
     } catch (error) {
-      throw new ServiceUnavailableException(error);
+      const reason =
+        error instanceof Error ? error.message : "Unknown gRPC error";
+
+      this.logger.error(
+        {
+          event: "firewall.ips.swap.failed",
+          message: "failed to swap IPS config on firewall",
+          error: reason,
+        },
+        error instanceof Error ? error.stack : undefined,
+      );
+
+      throw new ServiceUnavailableException(
+        `Firewall query service failed to swap IPS config. ${reason}`,
+      );
     }
   }
 
   async getIpsConfig(): Promise<IpsConfig> {
     try {
+      this.logger.log({
+        event: "firewall.ips.get.started",
+        message: "loading IPS config from firewall",
+      });
+
       const response = await firstValueFrom(
         this.firewallQueryClient.getIpsConfig({}),
       );
@@ -87,7 +128,7 @@ export class GrpcFirewallIpsConfigQueryService
         );
       }
 
-      return IpsConfig.create(
+      const config = IpsConfig.create(
         response.config.general || {
           enabled: false,
         },
@@ -117,8 +158,31 @@ export class GrpcFirewallIpsConfigQueryService
           return newSignature;
         }),
       );
+
+      this.logger.log({
+        event: "firewall.ips.get.succeeded",
+        message: "loaded IPS config from firewall",
+        enabled: config.getGeneral().enabled,
+        signatures: config.getSignatures().length,
+      });
+
+      return config;
     } catch (error) {
-      throw new ServiceUnavailableException(error);
+      const reason =
+        error instanceof Error ? error.message : "Unknown gRPC error";
+
+      this.logger.error(
+        {
+          event: "firewall.ips.get.failed",
+          message: "failed to load IPS config from firewall",
+          error: reason,
+        },
+        error instanceof Error ? error.stack : undefined,
+      );
+
+      throw new ServiceUnavailableException(
+        `Firewall query service failed to get IPS config. ${reason}`,
+      );
     }
   }
 }

--- a/backend/src/infrastructure/adapters/grpc-raptor-lang-validation.service.ts
+++ b/backend/src/infrastructure/adapters/grpc-raptor-lang-validation.service.ts
@@ -1,6 +1,7 @@
 import {
   Inject,
   Injectable,
+  Logger,
   OnModuleInit,
   ServiceUnavailableException,
 } from "@nestjs/common";
@@ -20,6 +21,7 @@ export const RAPTOR_LANG_VALIDATION_GRPC_CLIENT_TOKEN =
 export class GrpcRaptorLangValidationService
   implements IRaptorLangValidationService, OnModuleInit
 {
+  private readonly logger = new Logger(GrpcRaptorLangValidationService.name);
   private raptorLangValidationClient: RaptorLangValidationServiceClient;
 
   constructor(
@@ -36,15 +38,33 @@ export class GrpcRaptorLangValidationService
 
   async validateRaptorLang(content: string): Promise<void> {
     try {
+      this.logger.log({
+        event: "firewall.raptorlang.validation.started",
+        message: "validating RaptorLang content through firewall",
+        contentLength: content.length,
+      });
+
       const response = await firstValueFrom(
         this.raptorLangValidationClient.validateRaptorLang({ dsl: content }),
       );
 
       if (!response.isValid) {
+        this.logger.warn({
+          event: "firewall.raptorlang.validation.rejected",
+          message: response.errorMessage || "RaptorLang content is invalid",
+          contentLength: content.length,
+        });
+
         throw new RaptorLangValidationException(
           response.errorMessage || "RaptorLang rule content is invalid.",
         );
       }
+
+      this.logger.log({
+        event: "firewall.raptorlang.validation.succeeded",
+        message: "RaptorLang content accepted by firewall",
+        contentLength: content.length,
+      });
     } catch (error) {
       if (error instanceof RaptorLangValidationException) {
         throw error;
@@ -52,6 +72,16 @@ export class GrpcRaptorLangValidationService
 
       const reason =
         error instanceof Error ? error.message : "Unknown gRPC error";
+
+      this.logger.error(
+        {
+          event: "firewall.raptorlang.validation.failed",
+          message: "RaptorLang validation service call failed",
+          contentLength: content.length,
+          error: reason,
+        },
+        error instanceof Error ? error.stack : undefined,
+      );
 
       throw new ServiceUnavailableException(
         `RaptorLang validation service is unavailable. ${reason}`,

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -2,7 +2,7 @@ import "module-alias/register";
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { cwd } from "node:process";
-import { BadRequestException, ValidationPipe } from "@nestjs/common";
+import { BadRequestException, type LogLevel, ValidationPipe } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { NestFactory } from "@nestjs/core";
 import { type MicroserviceOptions, Transport } from "@nestjs/microservices";
@@ -21,6 +21,7 @@ async function bootstrap() {
   const appLogger = new DailyFileLogger({
     logDir: process.env.BACKEND_LOG_DIR ?? DEFAULT_BACKEND_LOG_DIR,
   });
+  appLogger.setLogLevels(parseBackendLogLevels(process.env.BACKEND_LOG_LEVELS));
   const logger = appLogger.withContext("Bootstrap");
   const certsDir = join(cwd(), "devCerts");
 
@@ -169,3 +170,20 @@ async function bootstrap() {
 }
 
 bootstrap();
+
+function parseBackendLogLevels(raw: string | undefined): LogLevel[] {
+  const allowed = new Set<LogLevel>([
+    "log",
+    "error",
+    "warn",
+    "debug",
+    "verbose",
+  ]);
+
+  const levels = (raw ?? "log,error,warn")
+    .split(",")
+    .map((level) => level.trim())
+    .filter((level): level is LogLevel => allowed.has(level as LogLevel));
+
+  return levels.length > 0 ? levels : ["log", "error", "warn"];
+}

--- a/backend/src/presentation/controllers/ips-config.controller.ts
+++ b/backend/src/presentation/controllers/ips-config.controller.ts
@@ -5,7 +5,6 @@ import {
   HttpCode,
   HttpStatus,
   Inject,
-  Logger,
   Put,
 } from "@nestjs/common";
 import { ApiBody, ApiOperation } from "@nestjs/swagger";
@@ -37,7 +36,6 @@ import {
 
 @Controller("ips-config")
 export class IpsConfigController {
-  private readonly logger = new Logger(IpsConfigController.name);
   constructor(
     @Inject(GetIpsConfigurationUseCase)
     private readonly getIpsConfigurationUseCase: GetIpsConfigurationUseCase,
@@ -61,7 +59,6 @@ export class IpsConfigController {
   @ApiError500("Internal server error while retrieving IPS config")
   async getIpsConfig(): Promise<GetIpsConfigResponseDto> {
     const result = await this.getIpsConfigurationUseCase.execute();
-    this.logger.debug(result);
 
     const ipsConfig = IpsConfigResponseMapper.toDto(result.ipsConfig);
 

--- a/backend/src/presentation/filters/http-exception-envelope.filter.ts
+++ b/backend/src/presentation/filters/http-exception-envelope.filter.ts
@@ -6,10 +6,11 @@ import {
   ExceptionFilter,
   HttpException,
   HttpStatus,
+  Logger,
   NotFoundException,
   UnauthorizedException,
 } from "@nestjs/common";
-import type { Response } from "express";
+import type { Request, Response } from "express";
 import { IpsActionIsInvalidException } from "src/domain/exceptions/ips-action-is-invalid.exception.js";
 import { IpsAppProtocolIsInvalidException } from "src/domain/exceptions/ips-app-protocol-is-invalid.exception.js";
 import { SignatureSeverityIsInvalidException } from "src/domain/exceptions/signature-severity-is-invalid.exception.js";
@@ -39,8 +40,11 @@ import { UserSourceIsInvalidException } from "../../domain/exceptions/user-sourc
 
 @Catch()
 export class HttpExceptionEnvelopeFilter implements ExceptionFilter {
+  private readonly logger = new Logger(HttpExceptionEnvelopeFilter.name);
+
   catch(exception: unknown, host: ArgumentsHost) {
     const context = host.switchToHttp();
+    const req = context.getRequest<Request>();
     const res = context.getResponse<Response>();
 
     const mapped = this.mapDomainToHttpException(exception);
@@ -59,6 +63,8 @@ export class HttpExceptionEnvelopeFilter implements ExceptionFilter {
     const message = this.extractMessage(response); // normalizacja
 
     const error = this.extractError(response, status);
+
+    this.logException(exception, req, status, message, error);
 
     res.status(status).json({ statusCode: status, message, error });
   }
@@ -133,5 +139,33 @@ export class HttpExceptionEnvelopeFilter implements ExceptionFilter {
       if (typeof err === "string") return err;
     }
     return HttpStatus[status] ?? "Error";
+  }
+
+  private logException(
+    exception: unknown,
+    req: Request,
+    statusCode: number,
+    message: string,
+    error: string,
+  ) {
+    const payload = {
+      event: "http.request.failed",
+      message,
+      method: req.method,
+      path: req.originalUrl ?? req.url,
+      statusCode,
+      error,
+    };
+
+    if (statusCode >= 500) {
+      if (exception instanceof Error && exception.stack) {
+        this.logger.error(payload, exception.stack);
+      } else {
+        this.logger.error(payload);
+      }
+      return;
+    }
+
+    this.logger.warn(payload);
   }
 }

--- a/backend/src/presentation/interceptors/success-envelope.interceptor.ts
+++ b/backend/src/presentation/interceptors/success-envelope.interceptor.ts
@@ -2,6 +2,7 @@ import {
   CallHandler,
   ExecutionContext,
   Injectable,
+  Logger,
   NestInterceptor,
 } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
@@ -11,6 +12,8 @@ import { RESPONSE_MESSAGE_KEY } from "../decorators/response-message.decorator.j
 
 @Injectable()
 export class SuccessEnvelopeInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(SuccessEnvelopeInterceptor.name);
+
   constructor(private readonly reflector: Reflector) {}
 
   intercept(context: ExecutionContext, next: CallHandler) {
@@ -19,6 +22,7 @@ export class SuccessEnvelopeInterceptor implements NestInterceptor {
     const http = context.switchToHttp();
     const req = http.getRequest<Request>();
     const res = http.getResponse<Response>();
+    const startedAt = Date.now();
 
     const customMessage = this.reflector.getAllAndOverride<string>(
       RESPONSE_MESSAGE_KEY,
@@ -26,12 +30,26 @@ export class SuccessEnvelopeInterceptor implements NestInterceptor {
     );
 
     return next.handle().pipe(
-      map((data: unknown) => ({
-        statusCode: res.statusCode,
-        message:
-          customMessage ?? this.defaultMessage(req.method, res.statusCode),
-        data: data ?? null,
-      })),
+      map((data: unknown) => {
+        const message =
+          customMessage ?? this.defaultMessage(req.method, res.statusCode);
+
+        this.logger.log({
+          event: "http.request.completed",
+          message,
+          method: req.method,
+          path: req.originalUrl ?? req.url,
+          statusCode: res.statusCode,
+          durationMs: Date.now() - startedAt,
+          userId: getRequestUserId(req),
+        });
+
+        return {
+          statusCode: res.statusCode,
+          message,
+          data: data ?? null,
+        };
+      }),
     );
   }
 
@@ -41,4 +59,11 @@ export class SuccessEnvelopeInterceptor implements NestInterceptor {
     if (method === "PUT" || method === "PATCH") return "Resource updated";
     return "Success";
   }
+}
+
+function getRequestUserId(req: Request): string | undefined {
+  const user = (req as Request & { user?: { id?: unknown; sub?: unknown } }).user;
+  if (typeof user?.id === "string") return user.id;
+  if (typeof user?.sub === "string") return user.sub;
+  return undefined;
 }

--- a/backend/src/shared/config/env.validation.ts
+++ b/backend/src/shared/config/env.validation.ts
@@ -16,6 +16,7 @@ const envSchema = z.object({
     .default("../sockets/control-plane.sock"),
   FIREWALL_QUERY_GRPC_SOCKET_PATH: z.string().default("../sockets/query.sock"),
   BACKEND_LOG_DIR: z.string().default("/var/log/raptorgate/backend"),
+  BACKEND_LOG_LEVELS: z.string().default("log,error,warn"),
   AUTH_COOKIE_PATH: z.string().min(1).default("/auth/refresh"),
   COOKIE_SECRET: z
     .string()

--- a/backend/src/shared/logging/daily-file.logger.spec.ts
+++ b/backend/src/shared/logging/daily-file.logger.spec.ts
@@ -19,17 +19,22 @@ describe("DailyFileLogger", () => {
       logDir,
       context: "TestContext",
       mirrorToConsole: false,
-      now: () => new Date(2026, 3, 14, 10, 30, 0),
+      now: () => new Date(Date.UTC(2026, 3, 14, 10, 30, 0)),
     });
 
     logger.log("backend started");
 
     const logPath = join(logDir, "2026-04-14.log");
+    const record = JSON.parse(readFileSync(logPath, "utf8"));
 
     expect(existsSync(logPath)).toBe(true);
-    expect(readFileSync(logPath, "utf8")).toContain(
-      "LOG [TestContext] backend started",
-    );
+    expect(record).toMatchObject({
+      context: "TestContext",
+      level: "info",
+      message: "backend started",
+      service: "backend",
+      timestamp: "2026-04-14T10:30:00.000Z",
+    });
   });
 
   it("uses a new file after the local date changes", () => {
@@ -54,5 +59,28 @@ describe("DailyFileLogger", () => {
 
   it("formats local dates without using utc conversion", () => {
     expect(formatLocalDate(new Date(2026, 0, 5, 1, 2, 3))).toBe("2026-01-05");
+  });
+
+  it("writes structured metadata and redacts secrets", () => {
+    const logger = new DailyFileLogger({
+      logDir,
+      mirrorToConsole: false,
+      now: () => new Date(Date.UTC(2026, 3, 14, 10, 30, 0)),
+    });
+
+    logger.log({
+      event: "auth.login.succeeded",
+      message: "user logged in",
+      refreshToken: "secret-refresh-token",
+      userId: "user-1",
+    });
+
+    const record = JSON.parse(
+      readFileSync(join(logDir, "2026-04-14.log"), "utf8"),
+    );
+
+    expect(record.event).toBe("auth.login.succeeded");
+    expect(record.metadata.userId).toBe("user-1");
+    expect(record.metadata.refreshToken).toBe("[REDACTED]");
   });
 });

--- a/backend/src/shared/logging/daily-file.logger.ts
+++ b/backend/src/shared/logging/daily-file.logger.ts
@@ -20,6 +20,14 @@ interface ParsedLogParams {
   stack?: string;
 }
 
+interface NormalizedLogMessage {
+  event?: string;
+  error?: string;
+  message: string;
+  metadata?: unknown;
+  stack?: string;
+}
+
 export class DailyFileLogger implements LoggerService {
   private readonly logDir: string;
   private readonly context?: string;
@@ -101,16 +109,21 @@ export class DailyFileLogger implements LoggerService {
     params: ParsedLogParams,
   ): string {
     const context = params.context ?? this.context;
-    const contextPart = context ? ` [${context}]` : "";
-    const extraPart =
-      params.extra.length > 0
-        ? ` ${params.extra.map(formatValue).join(" ")}`
-        : "";
-    const stackPart = params.stack ? `\n${params.stack}` : "";
+    const normalized = normalizeMessage(message);
+    const metadata = mergeMetadata(normalized.metadata, params.extra);
+    const record = compactRecord({
+      timestamp: now.toISOString(),
+      level: normalizeLevel(level),
+      service: "backend",
+      context,
+      event: normalized.event,
+      message: normalized.message,
+      metadata,
+      error: normalized.error,
+      stack: normalized.stack ?? params.stack,
+    });
 
-    return `${now.toISOString()} ${level.toUpperCase()}${contextPart} ${formatValue(
-      message,
-    )}${extraPart}${stackPart}\n`;
+    return `${JSON.stringify(redact(record))}\n`;
   }
 
   private writeConsole(level: DailyFileLogLevel, line: string) {
@@ -127,7 +140,10 @@ export class DailyFileLogger implements LoggerService {
       return true;
     }
 
-    return this.enabledLogLevels.has(level);
+    return (
+      this.enabledLogLevels.has(level) ||
+      this.enabledLogLevels.has(normalizeLevel(level))
+    );
   }
 
   private parseDefaultParams(optionalParams: unknown[]): ParsedLogParams {
@@ -186,6 +202,10 @@ export class DailyFileLogger implements LoggerService {
   }
 }
 
+function normalizeLevel(level: DailyFileLogLevel): string {
+  return level === "log" ? "info" : level;
+}
+
 export function formatLocalDate(date: Date): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
@@ -194,20 +214,129 @@ export function formatLocalDate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-function formatValue(value: unknown): string {
+function normalizeMessage(value: unknown): NormalizedLogMessage {
+  if (value instanceof Error) {
+    return {
+      error: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+  }
+
   if (typeof value === "string") {
+    return { message: value };
+  }
+
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    const metadata = { ...record };
+    const message =
+      typeof record.message === "string"
+        ? record.message
+        : inspect(redact(record), {
+            depth: 8,
+            breakLength: Number.POSITIVE_INFINITY,
+            compact: true,
+          });
+    const error = normalizeError(record.error);
+
+    delete metadata.message;
+    delete metadata.event;
+    delete metadata.error;
+    delete metadata.stack;
+
+    return {
+      event: typeof record.event === "string" ? record.event : undefined,
+      error: error.error,
+      message,
+      metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+      stack: typeof record.stack === "string" ? record.stack : error.stack,
+    };
+  }
+
+  return { message: inspect(value, { depth: 8, compact: true }) };
+}
+
+function normalizeError(value: unknown): { error?: string; stack?: string } {
+  if (value instanceof Error) {
+    return { error: value.name, stack: value.stack };
+  }
+
+  if (typeof value === "string") {
+    return { error: value };
+  }
+
+  return {};
+}
+
+function mergeMetadata(metadata: unknown, extra: unknown[]): unknown {
+  if (extra.length === 0) {
+    return metadata;
+  }
+
+  return {
+    ...(metadata && typeof metadata === "object" && !Array.isArray(metadata)
+      ? (metadata as Record<string, unknown>)
+      : metadata === undefined
+        ? {}
+        : { value: metadata }),
+    extra,
+  };
+}
+
+function compactRecord(record: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(record).filter(([, value]) => value !== undefined),
+  );
+}
+
+function redact(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (value === null || value === undefined) {
     return value;
   }
 
   if (value instanceof Error) {
-    return value.stack ?? value.message;
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
   }
 
-  return inspect(value, {
-    depth: 8,
-    breakLength: Number.POSITIVE_INFINITY,
-    compact: true,
-  });
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+
+  if (typeof value !== "object") {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redact(item, seen));
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+      key,
+      isSecretKey(key) ? "[REDACTED]" : redact(item, seen),
+    ]),
+  );
+}
+
+function isSecretKey(key: string): boolean {
+  return /password|authorization|cookie|secret|token|privateKey|certificatePem/iu.test(
+    key,
+  );
 }
 
 function looksLikeStackTrace(value: string): boolean {

--- a/crates/raptorgate/Cargo.toml
+++ b/crates/raptorgate/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0.149"
 arc-swap = "1.8.2"
 paste = "1.0.15"
 visibility = "0.1.1"
-tracing-subscriber = "0.3.23"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 ipnet = "2.12.0"
 rcgen = { version = "0.13", features = ["pem"] }
 ring = "0.17"

--- a/crates/raptorgate/src/data_plane/interface_sniffer.rs
+++ b/crates/raptorgate/src/data_plane/interface_sniffer.rs
@@ -47,7 +47,11 @@ impl InterfaceSniffer {
 
     pub fn sniff_new(&self, iface: String) -> Result<(), SnifferError> {
         if self.handles.contains_key(&iface) {
-            tracing::warn!(iface = %iface, "already sniffing interface, ignoring");
+            tracing::warn!(
+                event = "sniffer.start.skipped",
+                iface = %iface,
+                "already sniffing interface, ignoring"
+            );
             return Ok(());
         }
 
@@ -60,17 +64,33 @@ impl InterfaceSniffer {
         let mut cap = match Self::open_capture(&name, timeout) {
             Ok(c) => c,
             Err(e) => {
-                tracing::error!(iface = %name, error = %e, "failed to open capture");
+                tracing::error!(
+                    event = "sniffer.capture.open_failed",
+                    iface = %name,
+                    error = %e,
+                    "failed to open capture"
+                );
                 return Err(e.into());
             }
         };
+
+        tracing::info!(
+            event = "sniffer.capture.started",
+            iface = %name,
+            timeout_ms = timeout,
+            "packet capture started"
+        );
 
         tokio::task::spawn_blocking(move || {
             let iface_arc: Arc<str> = Arc::from(name.as_str());
 
             loop {
                 if child.is_cancelled() {
-                    tracing::info!(iface = %name, "capture cancelled");
+                    tracing::info!(
+                        event = "sniffer.capture.cancelled",
+                        iface = %name,
+                        "capture cancelled"
+                    );
                     break;
                 }
 
@@ -81,14 +101,24 @@ impl InterfaceSniffer {
                             iface: Arc::clone(&iface_arc),
                         };
                         if tx.blocking_send(packet).is_err() {
-                            tracing::info!(iface = %name, "channel closed, stopping capture");
+                            tracing::info!(
+                                event = "sniffer.capture.stopped",
+                                iface = %name,
+                                reason = "channel_closed",
+                                "channel closed, stopping capture"
+                            );
                             break;
                         }
                     }
                     // TODO: check if there's a way to cancel immediately without waiting for timeout
                     Err(pcap::Error::TimeoutExpired) => {}
                     Err(e) => {
-                        tracing::error!(iface = %name, error = %e, "capture error, stopping");
+                        tracing::error!(
+                            event = "sniffer.capture.failed",
+                            iface = %name,
+                            error = %e,
+                            "capture error, stopping"
+                        );
                         break;
                     }
                 }
@@ -103,10 +133,18 @@ impl InterfaceSniffer {
         match self.handles.remove(iface) {
             Some((_, token)) => {
                 token.cancel();
-                tracing::info!(iface = %iface, "capture cancellation requested");
+                tracing::info!(
+                    event = "sniffer.capture.cancel_requested",
+                    iface = %iface,
+                    "capture cancellation requested"
+                );
             }
             None => {
-                tracing::warn!(iface = %iface, "cancel_sniffing called for unknown interface");
+                tracing::warn!(
+                    event = "sniffer.capture.cancel_skipped",
+                    iface = %iface,
+                    "cancel_sniffing called for unknown interface"
+                );
             }
         }
     }
@@ -114,7 +152,11 @@ impl InterfaceSniffer {
     pub fn cancel_all(&self) {
         for entry in &self.handles {
             entry.value().cancel();
-            tracing::info!(iface = %entry.key(), "capture cancellation requested");
+            tracing::info!(
+                event = "sniffer.capture.cancel_requested",
+                iface = %entry.key(),
+                "capture cancellation requested"
+            );
         }
     }
 
@@ -130,7 +172,12 @@ impl InterfaceSniffer {
             .timeout(timeout_ms)
             .open()?;
         if let Err(e) = cap.direction(Direction::In) {
-            tracing::warn!(iface = %iface, error = %e, "could not set capture direction, capturing all");
+            tracing::warn!(
+                event = "sniffer.capture.direction_failed",
+                iface = %iface,
+                error = %e,
+                "could not set capture direction, capturing all"
+            );
         }
 
         Ok(cap)
@@ -152,7 +199,6 @@ impl ConfigObserver for InterfaceSniffer {
         let new_interfaces = &new_config.capture_interfaces;
 
         let old_timeout = Duration::from_millis(self.pcap_timeout_ms.load(Ordering::Relaxed) as u64);
-        let new_timeout = Duration::from_millis(new_config.pcap_timeout_ms as u64);
 
         for iface in &old_interfaces {
             if !new_interfaces.contains(iface) {
@@ -173,11 +219,20 @@ impl ConfigObserver for InterfaceSniffer {
         let new_timeout = Duration::from_millis(self.pcap_timeout_ms.load(Ordering::Relaxed) as u64);
 
         emit(Event::new(EventKind::SnifferConfigChanged {
-            old_interfaces,
-            new_interfaces,
+            old_interfaces: old_interfaces.clone(),
+            new_interfaces: new_interfaces.clone(),
             old_timeout,
             new_timeout,
         }));
+
+        tracing::info!(
+            event = "sniffer.config.changed",
+            old_interfaces = ?old_interfaces,
+            new_interfaces = ?new_interfaces,
+            old_timeout_ms = old_timeout.as_millis(),
+            new_timeout_ms = new_timeout.as_millis(),
+            "sniffer config changed"
+        );
 
         Ok(())
     }

--- a/crates/raptorgate/src/data_plane/tun_forwarder.rs
+++ b/crates/raptorgate/src/data_plane/tun_forwarder.rs
@@ -46,7 +46,9 @@ impl TunForwarder {
         let raw = ctx.borrow_raw();
         if raw.len() <= ETH_HDR {
             tracing::warn!(
+                event = "tun.forward.drop",
                 iface = %ctx.borrow_src_interface(),
+                packet_len = raw.len(),
                 "packet too short to strip ethernet header, dropping"
             );
             return;
@@ -56,13 +58,18 @@ impl TunForwarder {
             Some(dev) => {
                 if let Err(e) = dev.send(&raw[ETH_HDR..]).await {
                     tracing::error!(
+                        event = "tun.forward.failed",
                         iface = %ctx.borrow_src_interface(),
                         error = %e,
                         "failed to forward packet to TUN"
                     );
                 }
             },
-            None => tracing::warn!("Tried forwarding packet, but TUN device not available"),
+            None => tracing::warn!(
+                event = "tun.forward.skipped",
+                iface = %ctx.borrow_src_interface(),
+                "TUN device not available"
+            ),
         }
     }
 }
@@ -96,6 +103,7 @@ impl ConfigObserver for TunForwarder {
         }));
 
         tracing::info!(
+            event = "tun.device.swapped",
             tun_device = %new_config.tun_device_name,
             tun_address = %new_config.tun_address,
             tun_netmask = %new_config.tun_netmask,

--- a/crates/raptorgate/src/events.rs
+++ b/crates/raptorgate/src/events.rs
@@ -28,7 +28,11 @@ struct BackendConnection {
 impl BackendConnection {
     /// Returns false if the gRPC task has died (receiver dropped).
     async fn send(&self, event: proto::Event) -> bool {
-        tracing::trace!(kind = ?event.kind, "Sending out event...");
+        tracing::trace!(
+            event = "event_bus.dispatch.started",
+            kind = ?event.kind,
+            "sending event to backend stream"
+        );
 
         self.tx.send(event).await.is_ok()
     }
@@ -52,7 +56,11 @@ async fn try_connect(socket_path: &str) -> Result<BackendConnection, tonic::tran
 
     tokio::spawn(async move {
         if let Err(e) = client.push_events(ReceiverStream::new(rx)).await {
-            tracing::warn!(error = %e, "BackendEventService stream ended");
+            tracing::warn!(
+                event = "event_bus.backend_stream.ended",
+                error = %e,
+                "BackendEventService stream ended"
+            );
         }
         // when this task returns, `rx` is dropped → `tx.send()` will fail
         // → the event loop detects it and sets backend = None
@@ -123,7 +131,11 @@ async fn dispatch(event: Event, backend: &mut Option<BackendConnection>, buffer:
     match backend {
         Some(conn) => {
             if !conn.send(event.into()).await {
-                tracing::warn!("backend connection lost, will reconnect");
+                tracing::warn!(
+                    event = "event_bus.backend_connection.lost",
+                    dropped_events = DROPPED_EVENTS.load(Ordering::Relaxed),
+                    "backend connection lost, will reconnect"
+                );
                 *backend = None;
                 DROPPED_EVENTS.fetch_add(1, Ordering::Relaxed);
             }
@@ -131,11 +143,22 @@ async fn dispatch(event: Event, backend: &mut Option<BackendConnection>, buffer:
 
         None => {
             if buffer.len() < OVERFLOW_CAPACITY {
-                tracing::trace!(kind = ?event.kind, "no backend connection, buffering event");
+                tracing::trace!(
+                    event = "event_bus.buffered",
+                    kind = ?event.kind,
+                    buffered_events = buffer.len(),
+                    "no backend connection, buffering event"
+                );
                 buffer.push(event);
             } else {
-                DROPPED_EVENTS.fetch_add(1, Ordering::Relaxed);
-                tracing::warn!(kind = ?event.kind, "overflow buffer full, event dropped");
+                let dropped_events = DROPPED_EVENTS.fetch_add(1, Ordering::Relaxed) + 1;
+                tracing::warn!(
+                    event = "event_bus.event_dropped",
+                    kind = ?event.kind,
+                    buffered_events = buffer.len(),
+                    dropped_events,
+                    "overflow buffer full, event dropped"
+                );
             }
         }
     }
@@ -148,14 +171,25 @@ async fn attempt_reconnect(
 ) {
     match try_connect(socket_path).await {
         Ok(conn) => {
-            tracing::info!("reconnected to backend");
+            tracing::info!(
+                event = "event_bus.backend_connected",
+                socket_path,
+                buffered_events = buffer.len(),
+                dropped_events = DROPPED_EVENTS.load(Ordering::Relaxed),
+                "reconnected to backend"
+            );
             *backend = Some(conn);
 
             emit(Event::new(EventKind::EventBusConnectedEvent {}));
             flush_batch(buffer, backend).await;
         }
         Err(e) => {
-            tracing::warn!(error = ?e, "reconnect attempt failed");
+            tracing::warn!(
+                event = "event_bus.backend_reconnect.failed",
+                socket_path,
+                error = ?e,
+                "reconnect attempt failed"
+            );
         }
     }
 }

--- a/crates/raptorgate/src/logging.rs
+++ b/crates/raptorgate/src/logging.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use std::path::{Path, PathBuf};
 use time::{Date, OffsetDateTime};
 use std::fs::{self, File, OpenOptions};
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt::MakeWriter;
 
 const DEFAULT_FIREWALL_LOG_DIR: &str = "/var/log/raptorgate/firewall";
@@ -16,14 +17,21 @@ pub fn init() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let writer = DailyLogMakeWriter::new(log_dir)?;
 
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::TRACE)
+        .with_env_filter(log_filter())
         .with_target(false)
         .with_thread_ids(false)
         .with_thread_names(false)
         .with_writer(writer)
+        .json()
+        .flatten_event(true)
         .try_init()?;
 
     Ok(())
+}
+
+fn log_filter() -> EnvFilter {
+    EnvFilter::try_from_env("RAPTORGATE_LOG_LEVEL")
+        .unwrap_or_else(|_| EnvFilter::new("info"))
 }
 
 #[derive(Clone)]

--- a/crates/raptorgate/src/main.rs
+++ b/crates/raptorgate/src/main.rs
@@ -75,30 +75,55 @@ async fn main() {
     if let Err(err) = logging::init() {
         eprintln!("failed to initialize daily firewall logging: {err}");
         tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::TRACE)
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_env("RAPTORGATE_LOG_LEVEL")
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+            )
             .with_target(false)
             .with_thread_ids(false)
             .with_thread_names(false)
+            .json()
+            .flatten_event(true)
             .init();
     }
 
     let config_provider = match AppConfigProvider::from_env().await {
         Ok(provider) => Arc::new(provider),
         Err(err) => {
-            tracing::error!("Configuration error: {err}");
+            tracing::error!(
+                event = "startup.config.failed",
+                error = %err,
+                "configuration error"
+            );
             return;
         }
     };
 
     let config = config_provider.get_config();
+    tracing::info!(
+        event = "startup.config.loaded",
+        capture_interfaces = ?config.capture_interfaces,
+        data_dir = %config.data_dir.display(),
+        query_socket_path = %config.query_socket_path,
+        event_socket_path = %config.event_socket_path,
+        "firewall config loaded"
+    );
 
     let ca_info = match CaManager::init(&config.pki_dir) {
         Ok(ca) => {
-            tracing::info!(fingerprint = %ca.ca_info().fingerprint, "CA initialized");
+            tracing::info!(
+                event = "startup.ca.initialized",
+                fingerprint = %ca.ca_info().fingerprint,
+                "CA initialized"
+            );
             Some(ca.ca_info())
         }
         Err(err) => {
-            tracing::warn!(error = %err, "CA initialization failed");
+            tracing::warn!(
+                event = "startup.ca.failed",
+                error = %err,
+                "CA initialization failed"
+            );
             None
         }
     };
@@ -138,7 +163,11 @@ async fn main() {
     let dns_inspection = match DnsInspection::new((*dns_initial_config).clone()) {
         Ok(inspection) => inspection,
         Err(err) => {
-            tracing::error!(error = %err, "failed to initialize DNS inspection");
+            tracing::error!(
+                event = "startup.dns_inspection.failed",
+                error = %err,
+                "failed to initialize DNS inspection"
+            );
             return;
         }
     };
@@ -148,7 +177,11 @@ async fn main() {
     let ips = match Ips::new((*ips_initial_config).clone()) {
         Ok(inspection) => inspection,
         Err(err) => {
-            tracing::error!(error = %err, "failed to initialize IPS");
+            tracing::error!(
+                event = "startup.ips.failed",
+                error = %err,
+                "failed to initialize IPS"
+            );
             return;
         }
     };
@@ -187,7 +220,11 @@ async fn main() {
         .register(Arc::clone(&sniffer), "InterfaceSniffer")
         .await;
     for e in errs {
-        tracing::error!(error = %e, "interface sniffer error");
+        tracing::error!(
+            event = "startup.sniffer.failed",
+            error = %e,
+            "interface sniffer error"
+        );
     }
 
     // Rzutujemy DnsInspection na DnssecProvider i wstrzykujemy do PolicyEvalStage.

--- a/crates/raptorgate/src/pipeline/wrappers.rs
+++ b/crates/raptorgate/src/pipeline/wrappers.rs
@@ -1,7 +1,7 @@
 use std::net::IpAddr;
 use std::sync::Arc;
 
-use etherparse::NetSlice;
+use etherparse::{NetSlice, TransportSlice};
 use tokio::sync::Mutex;
 
 use crate::{
@@ -40,7 +40,13 @@ impl Stage for ValidationStage {
         match validate(ctx.borrow_sliced_packet()) {
             Ok(()) => StageOutcome::Continue,
             Err(e) => {
-                tracing::debug!(reason = %e, "packet failed validation");
+                log_packet_decision(
+                    ctx,
+                    "packet.validation.failed",
+                    "validation",
+                    "drop",
+                    &e.to_string(),
+                );
                 StageOutcome::Halt
             }
         }
@@ -143,7 +149,16 @@ impl Stage for FtpAlgStage {
                 dpi_ctx,
             ) {
                 Ok(new_ctx) => *ctx = new_ctx,
-                Err(_) => return StageOutcome::Halt,
+                Err(err) => {
+                    tracing::warn!(
+                        event = "ftp_alg.reparse.failed",
+                        stage = "ftp_alg",
+                        verdict = "drop",
+                        error = %err,
+                        "FTP ALG rewrite produced an invalid packet"
+                    );
+                    return StageOutcome::Halt;
+                }
             }
         } else {
             // Safety: the backing allocation and length stay unchanged here.
@@ -201,7 +216,13 @@ impl Stage for DnsBlockListStage {
         match self.inspection.check_blocklist(&domain) {
             BlocklistVerdict::Allow => StageOutcome::Continue,
             BlocklistVerdict::Block(msg) => {
-                tracing::debug!(reason = %msg, "DNS blocklist block");
+                log_packet_decision(
+                    ctx,
+                    "dns.blocklist.blocked",
+                    "dns_blocklist",
+                    "drop",
+                    &msg,
+                );
                 ctx.with_warnings_mut(|w| w.push(msg));
                 StageOutcome::Halt
             }
@@ -240,12 +261,24 @@ impl Stage for DnsTunnelingStage {
         match self.inspection.inspect_tunneling(&domain, &qtype) {
             DnsInspectionVerdict::Allow => StageOutcome::Continue,
             DnsInspectionVerdict::Alert(msg) => {
-                tracing::debug!(reason = %msg, "DNS tunneling alert");
+                log_packet_decision(
+                    ctx,
+                    "dns.tunneling.alert",
+                    "dns_tunneling",
+                    "allow_warn",
+                    &msg,
+                );
                 ctx.with_warnings_mut(|w| w.push(msg));
                 StageOutcome::Continue
             }
             DnsInspectionVerdict::Block(msg) => {
-                tracing::debug!(reason = %msg, "DNS tunneling block");
+                log_packet_decision(
+                    ctx,
+                    "dns.tunneling.blocked",
+                    "dns_tunneling",
+                    "drop",
+                    &msg,
+                );
                 ctx.with_warnings_mut(|w| w.push(msg));
                 StageOutcome::Halt
             }
@@ -280,14 +313,14 @@ impl Stage for IpsStage {
                 for matched in matches {
                     emit_ips_signature_matched(ctx, &matched);
                 }
-                tracing::debug!(reason = %msg, "IPS alert");
+                log_packet_decision(ctx, "ips.signature.alert", "ips", "allow_warn", &msg);
                 ctx.with_warnings_mut(|warnings| warnings.push(msg));
                 StageOutcome::Continue
             }
             IpsVerdict::Block(matched) => {
                 let msg = matched.message();
                 emit_ips_signature_matched(ctx, &matched);
-                tracing::debug!(reason = %msg, "IPS block");
+                log_packet_decision(ctx, "ips.signature.blocked", "ips", "drop", &msg);
                 ctx.with_warnings_mut(|warnings| warnings.push(msg));
                 StageOutcome::Halt
             }
@@ -409,12 +442,35 @@ impl Stage for PolicyEvalStage {
 
         match verdict {
             Verdict::Allow => StageOutcome::Continue,
-            Verdict::Drop => StageOutcome::Halt,
+            Verdict::Drop => {
+                log_packet_decision(
+                    ctx,
+                    "policy.packet.dropped",
+                    "policy_eval",
+                    "drop",
+                    "policy returned drop verdict",
+                );
+                StageOutcome::Halt
+            }
             Verdict::AllowWarn(msg) => {
+                log_packet_decision(
+                    ctx,
+                    "policy.packet.allowed_with_warning",
+                    "policy_eval",
+                    "allow_warn",
+                    &msg,
+                );
                 ctx.with_warnings_mut(|w| w.push(msg));
                 StageOutcome::Continue
             }
             Verdict::DropWarn(msg) => {
+                log_packet_decision(
+                    ctx,
+                    "policy.packet.dropped_with_warning",
+                    "policy_eval",
+                    "drop_warn",
+                    &msg,
+                );
                 ctx.with_warnings_mut(|w| w.push(msg));
                 StageOutcome::Halt
             }
@@ -432,7 +488,13 @@ impl Stage for TcpClassificationStage {
         match self.tracker.process_packet(ctx.borrow_sliced_packet()) {
             Ok(_) => StageOutcome::Continue,
             Err(e) => {
-                tracing::error!(error = %e, "TCP session tracking error");
+                log_packet_decision(
+                    ctx,
+                    "tcp_session.tracking.failed",
+                    "tcp_classification",
+                    "drop",
+                    &e.to_string(),
+                );
                 StageOutcome::Halt
             }
         }
@@ -457,12 +519,100 @@ impl Stage for DpiStage {
     async fn process(&self, ctx: &mut PacketContext) -> StageOutcome {
         match self.classifier.inspect_packet(ctx.borrow_sliced_packet()) {
             InspectResult::Done(dpi_ctx) => {
-                tracing::debug!("DPI: classification done ctx={dpi_ctx:?}");
+                tracing::debug!(
+                    event = "dpi.classification.completed",
+                    stage = "dpi",
+                    app_proto = ?dpi_ctx.app_proto,
+                    "DPI classification completed"
+                );
                 ctx.with_dpi_ctx_mut(|c| *c = Some(dpi_ctx));
             }
             InspectResult::NeedMore => {}
             InspectResult::Skipped => {}
         }
         StageOutcome::Continue
+    }
+}
+
+fn log_packet_decision(
+    ctx: &PacketContext,
+    event: &'static str,
+    stage: &'static str,
+    verdict: &'static str,
+    reason: &str,
+) {
+    let fields = packet_log_fields(ctx);
+
+    tracing::warn!(
+        event,
+        stage,
+        verdict,
+        reason,
+        iface = %ctx.borrow_src_interface(),
+        packet_len = fields.packet_len,
+        src_ip = fields.src_ip.as_deref().unwrap_or(""),
+        dst_ip = fields.dst_ip.as_deref().unwrap_or(""),
+        src_port = fields.src_port.unwrap_or_default(),
+        dst_port = fields.dst_port.unwrap_or_default(),
+        protocol = fields.protocol.unwrap_or(""),
+        app_proto = fields.app_proto.as_deref().unwrap_or(""),
+        "packet decision"
+    );
+}
+
+struct PacketLogFields {
+    packet_len: usize,
+    src_ip: Option<String>,
+    dst_ip: Option<String>,
+    src_port: Option<u16>,
+    dst_port: Option<u16>,
+    protocol: Option<&'static str>,
+    app_proto: Option<String>,
+}
+
+fn packet_log_fields(ctx: &PacketContext) -> PacketLogFields {
+    let sliced = ctx.borrow_sliced_packet();
+    let (src_ip, dst_ip) = match &sliced.net {
+        Some(NetSlice::Ipv4(ipv4)) => (
+            Some(ipv4.header().source_addr().to_string()),
+            Some(ipv4.header().destination_addr().to_string()),
+        ),
+        Some(NetSlice::Ipv6(ipv6)) => (
+            Some(ipv6.header().source_addr().to_string()),
+            Some(ipv6.header().destination_addr().to_string()),
+        ),
+        _ => (None, None),
+    };
+
+    let (src_port, dst_port, protocol) = match &sliced.transport {
+        Some(TransportSlice::Tcp(tcp)) => (
+            Some(tcp.source_port()),
+            Some(tcp.destination_port()),
+            Some("tcp"),
+        ),
+        Some(TransportSlice::Udp(udp)) => (
+            Some(udp.source_port()),
+            Some(udp.destination_port()),
+            Some("udp"),
+        ),
+        Some(TransportSlice::Icmpv4(_)) => (None, None, Some("icmpv4")),
+        Some(TransportSlice::Icmpv6(_)) => (None, None, Some("icmpv6")),
+        _ => (None, None, None),
+    };
+
+    let app_proto = ctx
+        .borrow_dpi_ctx()
+        .as_ref()
+        .and_then(|dpi_ctx| dpi_ctx.app_proto)
+        .map(|proto| proto.to_string().to_lowercase());
+
+    PacketLogFields {
+        packet_len: ctx.borrow_raw().len(),
+        src_ip,
+        dst_ip,
+        src_port,
+        dst_port,
+        protocol,
+        app_proto,
     }
 }

--- a/crates/raptorgate/src/query_server.rs
+++ b/crates/raptorgate/src/query_server.rs
@@ -82,7 +82,11 @@ where
             }
         };
 
-        tracing::info!(socket = self.socket_path, "FirewallQueryService listening");
+        tracing::info!(
+            event = "grpc.query_service.listening",
+            socket = self.socket_path,
+            "FirewallQueryService listening"
+        );
 
         let incoming = UnixListenerStream::new(listener);
 
@@ -275,10 +279,23 @@ where
         let new_config = AppConfig::from_proto(proto_config)
             .map_err(|e| Status::invalid_argument(format!("invalid config: {e}")))?;
 
+        tracing::info!(
+            event = "config.swap.started",
+            capture_interfaces = ?new_config.capture_interfaces,
+            query_socket_path = %new_config.query_socket_path,
+            event_socket_path = %new_config.event_socket_path,
+            "received AppConfig swap request"
+        );
+
         self.config_provider
             .swap_config(new_config)
             .await
             .map_err(|e| Status::internal(format!("failed to swap config: {e}")))?;
+
+        tracing::info!(
+            event = "config.swap.succeeded",
+            "AppConfig swap request applied"
+        );
 
         Ok(Response::new(SwapConfigResponse {}))
     }
@@ -314,6 +331,15 @@ where
         let new_config = DnsInspectionConfig::from_proto(proto_config)
             .map_err(|e| Status::invalid_argument(format!("invalid dns inspection config: {e}")))?;
 
+        tracing::info!(
+            event = "dns_inspection.swap.started",
+            enabled = new_config.general.enabled,
+            blocklist_domains = new_config.blocklist.domains.len(),
+            dns_tunneling_enabled = new_config.dns_tunneling.enabled,
+            dnssec_enabled = new_config.dnssec.enabled,
+            "received DNS inspection config swap request"
+        );
+
         self.dns_inspection_store
             .swap_config(new_config.clone())
             .await
@@ -322,6 +348,12 @@ where
         self.dns_inspection
             .update_config(&new_config)
             .map_err(|e| Status::internal(format!("failed to apply dns inspection config: {e}")))?;
+
+        tracing::info!(
+            event = "dns_inspection.swap.succeeded",
+            enabled = new_config.general.enabled,
+            "DNS inspection config applied"
+        );
 
         Ok(Response::new(SwapDnsInspectionConfigResponse {}))
     }
@@ -348,6 +380,14 @@ where
         let new_config = IpsConfig::from_proto(proto_config)
             .map_err(|e| Status::invalid_argument(format!("invalid ips config: {e}")))?;
 
+        tracing::info!(
+            event = "ips.swap.started",
+            enabled = new_config.general.enabled,
+            detection_enabled = new_config.detection.enabled,
+            signatures = new_config.signatures.len(),
+            "received IPS config swap request"
+        );
+
         self.ips_store
             .swap_config(new_config.clone())
             .await
@@ -356,6 +396,13 @@ where
         self.ips
             .update_config(&new_config)
             .map_err(|e| Status::internal(format!("failed to apply ips config: {e}")))?;
+
+        tracing::info!(
+            event = "ips.swap.succeeded",
+            enabled = new_config.general.enabled,
+            signatures = new_config.signatures.len(),
+            "IPS config applied"
+        );
 
         Ok(Response::new(SwapIpsConfigResponse {}))
     }
@@ -392,6 +439,17 @@ where
             .bundle
             .ok_or_else(|| Status::invalid_argument("missing bundle in snapshot"))?;
 
+        tracing::info!(
+            event = "config_snapshot.push.started",
+            correlation_id,
+            snapshot_id,
+            rules = bundle.rules.len(),
+            zones = bundle.zones.len(),
+            zone_pairs = bundle.zone_pairs.len(),
+            zone_interfaces = bundle.zone_interfaces.len(),
+            "received active config snapshot push"
+        );
+
         // 1. Parse all proto types into domain-type HashMaps
         let policies = parse_proto_collection(bundle.rules, Policy::try_from_rule, "rule")?;
         let zones = parse_proto_collection(bundle.zones, Zone::try_from_proto, "zone")?;
@@ -409,6 +467,14 @@ where
 
         if !errors.is_empty() {
             let messages: Vec<String> = errors.iter().map(std::string::ToString::to_string).collect();
+            tracing::warn!(
+                event = "config_snapshot.push.rejected",
+                correlation_id,
+                snapshot_id,
+                error_count = messages.len(),
+                message = %messages.join("; "),
+                "active config snapshot rejected by integrity validation"
+            );
             return Ok(Response::new(PushActiveConfigSnapshotResponse {
                 correlation_id,
                 accepted: false,
@@ -438,6 +504,13 @@ where
             .swap_policies(policies.into_iter().collect())
             .await
             .map_err(|e| Status::internal(format!("failed to swap policies: {e}")))?;
+
+        tracing::info!(
+            event = "config_snapshot.push.succeeded",
+            correlation_id,
+            snapshot_id,
+            "active config snapshot applied"
+        );
 
         Ok(Response::new(PushActiveConfigSnapshotResponse {
             correlation_id,

--- a/vagrant/deploy.sh
+++ b/vagrant/deploy.sh
@@ -46,6 +46,7 @@ rm -rf .router_sync/frontend && mkdir -p .router_sync/frontend
 rm -rf .router_sync/proto && mkdir -p .router_sync/proto
 rm -rf .router_sync/logrotate && mkdir -p .router_sync/logrotate
 rm -rf .router_sync/nginx && mkdir -p .router_sync/nginx
+rm -rf .router_sync/vector && mkdir -p .router_sync/vector
 cp -f ../bin/"$PROJECT_NAME" .router_sync/"$PROJECT_NAME"/"$PROJECT_NAME"
 cp -rf ../bin/backend/* .router_sync/backend/
 cp -rf ../bin/frontend/dist .router_sync/frontend/
@@ -57,6 +58,7 @@ cp -rf ./configs/* .router_sync/ngfw
 cp -rf services .router_sync
 cp -rf nginx/* .router_sync/nginx/
 cp -rf logrotate/* .router_sync/logrotate/
+cp -rf vector/* .router_sync/vector/
 
 vagrant rsync r1 || true
 vagrant up --provision

--- a/vagrant/services/backend.service
+++ b/vagrant/services/backend.service
@@ -22,6 +22,7 @@ Environment=JWT_SECRET=development-jwt-secret-change-me-1234567890
 Environment=REFRESH_TOKEN_SECRET=development-refresh-secret-change-me-1234567890
 Environment=COOKIE_SECRET=development-cookie-secret-change-me-1234567890
 Environment=AUTH_COOKIE_PATH=/api/auth/refresh
+Environment=BACKEND_LOG_LEVELS=log,error,warn
 User=root
 
 [Install]

--- a/vagrant/services/ngfw.service
+++ b/vagrant/services/ngfw.service
@@ -21,6 +21,7 @@ Environment="QUERY_SOCKET_PATH=/resources/ngfw/sockets/query.sock"
 Environment="CONTROL_PLANE_GRPC_SOCKET_PATH=/resources/ngfw/sockets/control-plane.sock"
 Environment="DUMMY_NAT_ENABLED=true"
 Environment="DUMMY_NAT_ALLOW_ALL=true"
+Environment="RAPTORGATE_LOG_LEVEL=info"
 
 [Install]
 WantedBy=multi-user.target

--- a/vagrant/services/victorialogs.service
+++ b/vagrant/services/victorialogs.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=VictoriaLogs
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=victorialogs
+Group=victorialogs
+ExecStart=/usr/local/bin/victoria-logs-prod -storageDataPath=/var/lib/victorialogs -retentionPeriod=14d -httpListenAddr=:9428
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/vagrant/vagrantfile
+++ b/vagrant/vagrantfile
@@ -54,13 +54,18 @@ def setup_nftables
     nft add rule inet filter input tcp dport 22 ct state new accept
     nft add rule inet filter input tcp dport 2201 ct state new accept
     nft add rule inet filter input iifname "eth3" ip daddr 192.168.56.254 tcp dport 443 ct state new accept
+    nft add rule inet filter input iifname "eth3" ip daddr 192.168.56.254 tcp dport 9428 ct state new accept
   SHELL
 end
 
 def setup_backend_service
   <<-SHELL
     chmod +x /resources/backend/bun
-    install -d -m 0755 /var/log/raptorgate/backend
+    if getent group raptorgate-logs >/dev/null 2>&1; then
+      install -d -m 2750 -o root -g raptorgate-logs /var/log/raptorgate/backend
+    else
+      install -d -m 0755 /var/log/raptorgate/backend
+    fi
     touch /var/log/raptorgate/.logrotate-trigger
     cp -f /resources/services/backend.service /etc/systemd/system/backend.service
     if [ -f /resources/logrotate/raptorgate ]; then
@@ -88,6 +93,76 @@ def setup_frontend_service
   SHELL
 end
 
+def setup_observability
+  <<-SHELL
+    set -e
+
+    apt-get update
+    apt-get install -y ca-certificates curl gnupg tar gzip
+
+    if ! command -v vector >/dev/null 2>&1; then
+      vector_setup="$(mktemp)"
+      curl -fsSL -o "$vector_setup" https://setup.vector.dev
+      bash "$vector_setup"
+      rm -f "$vector_setup"
+      apt-get install -y vector
+    fi
+
+    if ! id -u victorialogs >/dev/null 2>&1; then
+      useradd --system --home /var/lib/victorialogs --shell /usr/sbin/nologin victorialogs
+    fi
+
+    if ! getent group raptorgate-logs >/dev/null 2>&1; then
+      groupadd --system raptorgate-logs
+    fi
+
+    if id -u vector >/dev/null 2>&1; then
+      usermod -a -G raptorgate-logs vector
+    fi
+
+    install -d -m 0755 /etc/vector
+    install -d -m 0755 -o victorialogs -g victorialogs /var/lib/victorialogs
+    install -d -m 2750 -o root -g raptorgate-logs /var/log/raptorgate /var/log/raptorgate/backend /var/log/raptorgate/firewall
+    chgrp -R raptorgate-logs /var/log/raptorgate
+    find /var/log/raptorgate -type d -exec chmod 2750 {} +
+    find /var/log/raptorgate -type f -name "*.log" -exec chmod 0640 {} +
+    if id -u vector >/dev/null 2>&1; then
+      install -d -m 0755 -o vector -g vector /var/lib/vector
+      chown -R vector:vector /var/lib/vector
+      chmod -R u+rwX /var/lib/vector
+    else
+      install -d -m 0755 /var/lib/vector
+    fi
+
+    VICTORIALOGS_VERSION="${VICTORIALOGS_VERSION:-v1.50.0}"
+    if [ ! -x /usr/local/bin/victoria-logs-prod ] || ! /usr/local/bin/victoria-logs-prod --version 2>/dev/null | grep -q "$VICTORIALOGS_VERSION"; then
+      tmp_dir="$(mktemp -d)"
+      curl -fL -o "$tmp_dir/victoria-logs.tar.gz" "https://github.com/VictoriaMetrics/VictoriaLogs/releases/download/$VICTORIALOGS_VERSION/victoria-logs-linux-amd64-$VICTORIALOGS_VERSION.tar.gz"
+      tar -xzf "$tmp_dir/victoria-logs.tar.gz" -C "$tmp_dir"
+      victorialogs_bin="$tmp_dir/victoria-logs-prod"
+      if [ ! -f "$victorialogs_bin" ]; then
+        victorialogs_bin="$(find "$tmp_dir" -type f -name victoria-logs-prod -print -quit)"
+      fi
+      if [ -z "$victorialogs_bin" ] || [ ! -f "$victorialogs_bin" ]; then
+        echo "victoria-logs-prod not found in downloaded archive"
+        find "$tmp_dir" -maxdepth 2 -type f -print
+        exit 1
+      fi
+      install -m 0755 "$victorialogs_bin" /usr/local/bin/victoria-logs-prod
+      rm -rf "$tmp_dir"
+    fi
+
+    cp -f /resources/services/victorialogs.service /etc/systemd/system/victorialogs.service
+    cp -f /resources/vector/vector.yaml /etc/vector/vector.yaml
+
+    systemctl daemon-reload
+    systemctl enable victorialogs
+    systemctl restart victorialogs
+    systemctl enable vector
+    systemctl restart vector
+  SHELL
+end
+
 def setup_ngfw_service
   <<-SHELL
     sysctl -w net.ipv4.ip_forward=1
@@ -105,7 +180,11 @@ def setup_ngfw_service
     mkdir -p /resources/ngfw
     mkdir -p /resources/ngfw/.data
     mkdir -p /resources/ngfw/sockets
-    install -d -m 0755 /var/log/raptorgate/firewall
+    if getent group raptorgate-logs >/dev/null 2>&1; then
+      install -d -m 2750 -o root -g raptorgate-logs /var/log/raptorgate/firewall
+    else
+      install -d -m 0755 /var/log/raptorgate/firewall
+    fi
     touch /var/log/raptorgate/.logrotate-trigger
     chmod +x /resources/ngfw/ngfw
     cp -f /resources/services/*.service /etc/systemd/system/
@@ -217,7 +296,7 @@ Vagrant.configure("2") do |config|
     r1_provision = configure_interface("eth1", "192.168.10.254", "24") +
       configure_interface("eth2", "192.168.20.254", "24") +
       configure_interface("eth3", "192.168.56.254", "24") +
-      setup_tun_device + setup_nftables + setup_ngfw_service
+      setup_tun_device + setup_nftables + setup_ngfw_service + setup_observability
 
     unless ENV['NO_BACKEND'] == '1'
       r1_provision += setup_backend_service + setup_frontend_service 

--- a/vagrant/vector/vector.yaml
+++ b/vagrant/vector/vector.yaml
@@ -1,0 +1,73 @@
+data_dir: /var/lib/vector
+
+sources:
+  backend_logs:
+    type: file
+    include:
+      - /var/log/raptorgate/backend/*.log
+    read_from: beginning
+
+  firewall_logs:
+    type: file
+    include:
+      - /var/log/raptorgate/firewall/*.log
+    read_from: beginning
+
+transforms:
+  backend_normalized:
+    type: remap
+    inputs:
+      - backend_logs
+    source: |
+      raw_message = .message
+      parsed, err = parse_json(raw_message)
+      if err == null && is_object(parsed) {
+        . = merge!(., parsed)
+      } else {
+        .message = raw_message
+        .timestamp = now()
+        .level = "info"
+        .parse_error = true
+      }
+      level = to_string(.level) ?? "info"
+      .level = downcase(level)
+      .service = "backend"
+      .component = "raptorgate"
+      .source_file = .file
+      del(.source_type)
+
+  firewall_normalized:
+    type: remap
+    inputs:
+      - firewall_logs
+    source: |
+      raw_message = .message
+      parsed, err = parse_json(raw_message)
+      if err == null && is_object(parsed) {
+        . = merge!(., parsed)
+      } else {
+        .message = raw_message
+        .timestamp = now()
+        .level = "info"
+        .parse_error = true
+      }
+      level = to_string(.level) ?? "info"
+      .level = downcase(level)
+      .service = "firewall"
+      .component = "raptorgate"
+      .source_file = .file
+      del(.source_type)
+
+sinks:
+  victorialogs:
+    type: http
+    inputs:
+      - backend_normalized
+      - firewall_normalized
+    uri: "http://127.0.0.1:9428/insert/jsonline?_stream_fields=host,service,level,context,event&_msg_field=message&_time_field=timestamp"
+    method: post
+    compression: gzip
+    encoding:
+      codec: json
+    framing:
+      method: newline_delimited


### PR DESCRIPTION
Add a lightweight observability path for backend and firewall logs.

Backend logging is changed to JSON lines with stable fields for timestamp, level, service, context, event, message, metadata, error, and stack. Secret-like metadata keys are redacted before write. Log levels are configurable through BACKEND_LOG_LEVELS, and the logger keeps console mirroring for systemd.

Add audit logs around backend HTTP requests, exception handling, auth flows, config import/apply/rollback, CRUD use cases, DNS inspection updates, IPS updates, and gRPC firewall adapters. Remove the noisy IPS controller debug output so structured audit records become the primary signal.

Firewall logging now uses tracing-subscriber JSON output with EnvFilter from RAPTORGATE_LOG_LEVEL. Add structured events across startup, query services, event buffering, packet wrappers, interface sniffing, TUN forwarding, DPI, IPS, and selected failure paths so firewall logs can be filtered by event and level.

Add Vector and VictoriaLogs provisioning for the Vagrant router VM. Vector tails backend and firewall log directories, normalizes service and level fields, and writes JSON lines into VictoriaLogs. VictoriaLogs runs under systemd with local retention and the management interface opens port 9428.

Harden Vagrant observability setup by fixing the VictoriaLogs release archive URL, validating the downloaded binary, creating the Vector state directory with the right owner, and adding a shared raptorgate-logs group so Vector can read root-owned 0640 backend and firewall logs without making them world-readable.

Set backend and firewall service environment variables for production log levels. Sync Vector config during deploy and add the VictoriaLogs unit file.

Fix the IPS gRPC config mapper for regenerated proto types by sending matchType, patternEncoding, and caseInsensitive fields expected by the firewall contracts