### PR TITLE
feat(firewall): add app_proto policy match

### DIFF
--- a/crates/raptorgate/src/dpi/proto.rs
+++ b/crates/raptorgate/src/dpi/proto.rs
@@ -1,7 +1,5 @@
-use derive_more::Display;
-
 // Protokół warstwy aplikacji rozpoznany przez DPI, niezależnie od portu.
-#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AppProto {
     Http,
     Tls,
@@ -13,4 +11,22 @@ pub enum AppProto {
     Smb,
     Quic,
     Unknown,
+}
+
+impl std::fmt::Display for AppProto {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            AppProto::Http => "http",
+            AppProto::Tls => "tls",
+            AppProto::Dns => "dns",
+            AppProto::Ssh => "ssh",
+            AppProto::Ftp => "ftp",
+            AppProto::Smtp => "smtp",
+            AppProto::Rdp => "rdp",
+            AppProto::Smb => "smb",
+            AppProto::Quic => "quic",
+            AppProto::Unknown => "unknown",
+        };
+        write!(f, "{s}")
+    }
 }

--- a/crates/raptorgate/src/pipeline/wrappers.rs
+++ b/crates/raptorgate/src/pipeline/wrappers.rs
@@ -23,7 +23,7 @@ use crate::{
 use crate::data_plane::dns_inspection::dnssec::DnssecProvider;
 use crate::data_plane::dns_inspection::tunneling_detector::DnsInspectionVerdict;
 use crate::dpi::AppProto;
-use crate::policy::policy_evaluator::DnsEvalContext;
+use crate::policy::policy_evaluator::{DnsEvalContext, PolicyEvalContext};
 
 #[derive(Clone)]
 pub struct ValidationStage;
@@ -434,11 +434,12 @@ impl Stage for PolicyEvalStage {
             dnssec_status: Some(status),
         });
 
-        let verdict = self.provider.get_evaluator().evaluate(
-            ctx.borrow_sliced_packet(),
-            &arrival,
-            dns_ctx.as_ref(),
-        );
+        let verdict = self.provider.get_evaluator().evaluate(PolicyEvalContext {
+            packet: ctx.borrow_sliced_packet(),
+            arrival: &arrival,
+            dns: dns_ctx.as_ref(),
+            dpi: ctx.borrow_dpi_ctx().as_ref(),
+        });
 
         match verdict {
             Verdict::Allow => StageOutcome::Continue,

--- a/crates/raptorgate/src/policy/policy_evaluator.rs
+++ b/crates/raptorgate/src/policy/policy_evaluator.rs
@@ -4,19 +4,24 @@ use std::net::IpAddr;
 use etherparse::{NetSlice, SlicedPacket, TransportSlice};
 
 use crate::data_plane::dns_inspection::types::DnssecStatus;
+use crate::dpi::DpiContext;
 use crate::rule_tree::{
     ArrivalInfo, FieldValue, IpVer, MatchKind, Operation, Pattern, Port, Protocol, RuleTree, Step,
     TreeWalker, Verdict,
 };
 
 /// Kontekst DNS przekazywany do ewaluatora polityk — zawiera wyniki inspekcji DNS.
-///
-/// Przekazywany opcjonalnie do [`PolicyEvaluator::evaluate`]. Dla pakietów nieDNS
-/// należy przekazać `None`.
 pub struct DnsEvalContext {
     /// Status walidacji DNSSEC dla domeny z zapytania DNS (wyznaczany leniwie przez
     /// [`DnssecProvider`][crate::data_plane::dns_inspection::dnssec::DnssecProvider]).
     pub dnssec_status: Option<DnssecStatus>,
+}
+
+pub(crate) struct PolicyEvalContext<'a, 'p> {
+    pub packet: &'a SlicedPacket<'p>,
+    pub arrival: &'a ArrivalInfo,
+    pub dns: Option<&'a DnsEvalContext>,
+    pub dpi: Option<&'a DpiContext>,
 }
 
 pub struct PolicyEvaluator {
@@ -32,26 +37,16 @@ impl PolicyEvaluator {
         }
     }
 
-    /// Ewaluuje polityki dla podanego pakietu i opcjonalnego kontekstu DNS.
-    ///
-    /// Dla pakietów DNS należy przekazać `Some(&DnsEvalContext)` z wypełnionym
-    /// statusem DNSSEC. Dla pozostałych pakietów — `None`.
-    pub(crate) fn evaluate(
-        &self,
-        packet: &SlicedPacket,
-        arrival: &ArrivalInfo,
-        dns: Option<&DnsEvalContext>,
-    ) -> Verdict {
+    pub(crate) fn evaluate(&self, ctx: PolicyEvalContext<'_, '_>) -> Verdict {
         let mut walker = TreeWalker::new(&self.rules);
 
         loop {
             match walker.current_step() {
                 Step::NeedsMatch { kind, pattern } => {
-                    let Some(value) = Self::extract(*kind, packet, arrival, dns) else {
-                        walker.advance(false);
-                        continue;
+                    let matched = match Self::extract(*kind, &ctx) {
+                        Some(value) => Self::pattern_matches(pattern, value),
+                        None => Self::missing_value_matches(*kind, pattern),
                     };
-                    let matched = Self::pattern_matches(pattern, value);
                     if let Step::Verdict(v) = walker.advance(matched) {
                         return v.clone();
                     }
@@ -62,27 +57,22 @@ impl PolicyEvaluator {
         }
     }
 
-    fn extract(
-        kind: MatchKind,
-        packet: &SlicedPacket,
-        arrival: &ArrivalInfo,
-        dns: Option<&DnsEvalContext>,
-    ) -> Option<FieldValue> {
+    fn extract(kind: MatchKind, ctx: &PolicyEvalContext<'_, '_>) -> Option<FieldValue> {
         match kind {
             MatchKind::SrcIp => {
-                let ipv4 = packet.net.as_ref()?.ipv4_ref()?;
+                let ipv4 = ctx.packet.net.as_ref()?.ipv4_ref()?;
                 Some(FieldValue::Ip(
                     IpAddr::V4(ipv4.header().source_addr()).into(),
                 ))
             }
             MatchKind::DstIp => {
-                let ipv4 = packet.net.as_ref()?.ipv4_ref()?;
+                let ipv4 = ctx.packet.net.as_ref()?.ipv4_ref()?;
                 Some(FieldValue::Ip(
                     IpAddr::V4(ipv4.header().destination_addr()).into(),
                 ))
             }
             MatchKind::IpVer => {
-                let ver = match &packet.net {
+                let ver = match &ctx.packet.net {
                     Some(NetSlice::Ipv4(_)) => IpVer::V4,
                     Some(NetSlice::Ipv6(_)) => IpVer::V6,
                     _ => return None,
@@ -90,7 +80,7 @@ impl PolicyEvaluator {
                 Some(FieldValue::IpVer(ver))
             }
             MatchKind::Protocol => {
-                let proto = match &packet.transport {
+                let proto = match &ctx.packet.transport {
                     Some(TransportSlice::Tcp(_)) => Protocol::Tcp,
                     Some(TransportSlice::Udp(_)) => Protocol::Udp,
                     Some(TransportSlice::Icmpv4(_)) => Protocol::Icmp,
@@ -98,7 +88,11 @@ impl PolicyEvaluator {
                 };
                 Some(FieldValue::Protocol(proto))
             }
-            MatchKind::SrcPort => match &packet.transport {
+            MatchKind::AppProto => {
+                let proto = ctx.dpi?.app_proto?;
+                Some(FieldValue::AppProto(proto))
+            }
+            MatchKind::SrcPort => match &ctx.packet.transport {
                 Some(TransportSlice::Tcp(tcp)) => {
                     Some(FieldValue::Port(Port::from(tcp.source_port())))
                 }
@@ -107,7 +101,7 @@ impl PolicyEvaluator {
                 }
                 _ => None,
             },
-            MatchKind::DstPort => match &packet.transport {
+            MatchKind::DstPort => match &ctx.packet.transport {
                 Some(TransportSlice::Tcp(tcp)) => {
                     Some(FieldValue::Port(Port::from(tcp.destination_port())))
                 }
@@ -116,12 +110,28 @@ impl PolicyEvaluator {
                 }
                 _ => None,
             },
-            MatchKind::Hour => Some(FieldValue::Hour(arrival.hour)),
-            MatchKind::DayOfWeek => Some(FieldValue::DayOfWeek(arrival.day_of_week)),
+            MatchKind::Hour => Some(FieldValue::Hour(ctx.arrival.hour)),
+            MatchKind::DayOfWeek => Some(FieldValue::DayOfWeek(ctx.arrival.day_of_week)),
             MatchKind::DnssecStatus => {
-                let status = dns?.dnssec_status?;
+                let status = ctx.dns?.dnssec_status?;
                 Some(FieldValue::DnssecStatus(status))
             }
+        }
+    }
+
+    fn missing_value_matches(kind: MatchKind, pattern: &Pattern) -> bool {
+        match kind {
+            MatchKind::AppProto => Self::pattern_accepts_missing(pattern),
+            _ => false,
+        }
+    }
+
+    fn pattern_accepts_missing(pattern: &Pattern) -> bool {
+        match pattern {
+            Pattern::Wildcard => true,
+            Pattern::Or(patterns) => patterns.iter().any(Self::pattern_accepts_missing),
+            Pattern::And(patterns) => patterns.iter().all(Self::pattern_accepts_missing),
+            _ => false,
         }
     }
 
@@ -155,9 +165,6 @@ impl PolicyEvaluator {
 
             (Pattern::Or(patterns), _) => patterns.iter().any(|p| Self::pattern_matches(p, value)),
             (Pattern::And(patterns), _) => patterns.iter().all(|p| Self::pattern_matches(p, value)),
-
-            // DnssecStatus obsługuje wyłącznie Equal (comparisons odrzucane przez validate_for).
-            (_, FieldValue::DnssecStatus(_)) => false,
         }
     }
 }
@@ -177,6 +184,7 @@ mod tests {
     use etherparse::{PacketBuilder, SlicedPacket};
 
     use super::*;
+    use crate::dpi::{AppProto, DpiContext};
     use crate::rule_tree::{
         ArmEnd, ArrivalInfo, Hour, IpGlobbable, IpVer, MatchBuilder, Octet, Port, Protocol, Weekday,
     };
@@ -235,9 +243,23 @@ mod tests {
     }
 
     fn eval(tree: RuleTree, raw: &[u8], arrival: &ArrivalInfo) -> Verdict {
+        eval_with_dpi(tree, raw, arrival, None)
+    }
+
+    fn eval_with_dpi(
+        tree: RuleTree,
+        raw: &[u8],
+        arrival: &ArrivalInfo,
+        dpi: Option<&DpiContext>,
+    ) -> Verdict {
         let sliced = SlicedPacket::from_ethernet(raw).unwrap();
         let evaluator = PolicyEvaluator::new(tree, Verdict::Drop);
-        evaluator.evaluate(&sliced, arrival, None)
+        evaluator.evaluate(PolicyEvalContext {
+            packet: &sliced,
+            arrival,
+            dns: None,
+            dpi,
+        })
     }
 
     // ── Wildcard ──────────────────────────────────────────────
@@ -328,6 +350,82 @@ mod tests {
         assert_eq!(
             eval(tree, &default_packet(), &default_arrival()),
             Verdict::Drop
+        );
+    }
+
+    #[test]
+    fn equal_app_proto_match() {
+        let tree = RuleTree::new(
+            MatchBuilder::with_arm(
+                MatchKind::AppProto,
+                Pattern::Equal(FieldValue::AppProto(AppProto::Http)),
+                ArmEnd::Verdict(Verdict::Allow),
+            )
+            .build()
+            .unwrap(),
+        );
+        let dpi = DpiContext {
+            app_proto: Some(AppProto::Http),
+            ..Default::default()
+        };
+        assert_eq!(
+            eval_with_dpi(tree, &default_packet(), &default_arrival(), Some(&dpi)),
+            Verdict::Allow
+        );
+    }
+
+    #[test]
+    fn equal_app_proto_no_match() {
+        let tree = RuleTree::new(
+            MatchBuilder::with_arm(
+                MatchKind::AppProto,
+                Pattern::Equal(FieldValue::AppProto(AppProto::Http)),
+                ArmEnd::Verdict(Verdict::Allow),
+            )
+            .build()
+            .unwrap(),
+        );
+        let dpi = DpiContext {
+            app_proto: Some(AppProto::Tls),
+            ..Default::default()
+        };
+        assert_eq!(
+            eval_with_dpi(tree, &default_packet(), &default_arrival(), Some(&dpi)),
+            Verdict::Drop
+        );
+    }
+
+    #[test]
+    fn equal_app_proto_without_dpi_no_match() {
+        let tree = RuleTree::new(
+            MatchBuilder::with_arm(
+                MatchKind::AppProto,
+                Pattern::Equal(FieldValue::AppProto(AppProto::Http)),
+                ArmEnd::Verdict(Verdict::Allow),
+            )
+            .build()
+            .unwrap(),
+        );
+        assert_eq!(
+            eval_with_dpi(tree, &default_packet(), &default_arrival(), None),
+            Verdict::Drop
+        );
+    }
+
+    #[test]
+    fn wildcard_app_proto_without_dpi_matches() {
+        let tree = RuleTree::new(
+            MatchBuilder::with_arm(
+                MatchKind::AppProto,
+                Pattern::Wildcard,
+                ArmEnd::Verdict(Verdict::Allow),
+            )
+            .build()
+            .unwrap(),
+        );
+        assert_eq!(
+            eval_with_dpi(tree, &default_packet(), &default_arrival(), None),
+            Verdict::Allow
         );
     }
 

--- a/crates/raptorgate/src/rule_tree.rs
+++ b/crates/raptorgate/src/rule_tree.rs
@@ -12,7 +12,7 @@ use serde::ser::SerializeStruct;
 
 use derive_more::{Debug, Display, Error, PartialEq};
 
-use crate::{policy::parse_rule_tree, rule_tree::matcher::Match};
+use crate::{dpi::AppProto, policy::parse_rule_tree, rule_tree::matcher::Match};
 pub use matcher::MatchBuilder;
 
 #[derive(Clone, Debug, Display)]
@@ -137,6 +137,7 @@ pub enum FieldValue {
     DayOfWeek(Weekday),
     Hour(Hour),
     Protocol(Protocol),
+    AppProto(AppProto),
     Port(Port),
     /// Status walidacji DNSSEC — dopasowywany przez `match dns_dnssec_status { = secure : ... }`.
     #[display("{_0}")]
@@ -151,6 +152,7 @@ pub enum MatchKind {
     DayOfWeek,
     Hour,
     Protocol,
+    AppProto,
     SrcPort,
     DstPort,
     /// Status walidacji DNSSEC — pasuje do wartości `FieldValue::DnssecStatus`.
@@ -166,6 +168,7 @@ impl std::fmt::Display for MatchKind {
             MatchKind::DayOfWeek   => "day_of_week",
             MatchKind::Hour        => "hour",
             MatchKind::Protocol    => "protocol",
+            MatchKind::AppProto    => "app_proto",
             MatchKind::SrcPort     => "src_port",
             MatchKind::DstPort     => "dst_port",
             MatchKind::DnssecStatus => "dns_dnssec_status",
@@ -291,6 +294,7 @@ mod tests {
             MatchKind::DstIp,
             MatchKind::IpVer,
             MatchKind::Protocol,
+            MatchKind::AppProto,
         ];
         for kind in invalid {
             assert!(

--- a/crates/raptorgate/src/rule_tree/parsing/lower.rs
+++ b/crates/raptorgate/src/rule_tree/parsing/lower.rs
@@ -1,10 +1,12 @@
-use derive_more::Display;
 use thiserror::Error;
+use derive_more::Display;
 
 use crate::rule_tree::matcher::Match;
 use crate::rule_tree::parsing::ast::{
     AstBody, AstMatch, AstPattern, AstValue, Spanned, Verdict as AstVerdict,
 };
+
+use crate::dpi::AppProto;
 use crate::rule_tree::parsing::lexer::Position;
 use crate::data_plane::dns_inspection::types::DnssecStatus;
 use crate::rule_tree::types::{Hour, IpGlobbable, IpVer, Port, Protocol, Weekday};
@@ -52,6 +54,7 @@ fn lower_kind(s: &Spanned<String>) -> Result<MatchKind, LowerError> {
         "day_of_week" => Ok(MatchKind::DayOfWeek),
         "hour" => Ok(MatchKind::Hour),
         "protocol" => Ok(MatchKind::Protocol),
+        "app_proto" => Ok(MatchKind::AppProto),
         "src_port" => Ok(MatchKind::SrcPort),
         "dst_port" => Ok(MatchKind::DstPort),
         "dns_dnssec_status" => Ok(MatchKind::DnssecStatus),
@@ -89,6 +92,23 @@ fn lower_value(kind: MatchKind, v: Spanned<AstValue>) -> Result<FieldValue, Lowe
                 "tcp" => Ok(FieldValue::Protocol(Protocol::Tcp)),
                 "udp" => Ok(FieldValue::Protocol(Protocol::Udp)),
                 "icmp" => Ok(FieldValue::Protocol(Protocol::Icmp)),
+                other => Err(LowerError::UnknownValue {
+                    kind,
+                    value: other.to_string(),
+                    pos,
+                }),
+            },
+            MatchKind::AppProto => match s.val.as_str() {
+                "http" => Ok(FieldValue::AppProto(AppProto::Http)),
+                "tls" => Ok(FieldValue::AppProto(AppProto::Tls)),
+                "dns" => Ok(FieldValue::AppProto(AppProto::Dns)),
+                "ssh" => Ok(FieldValue::AppProto(AppProto::Ssh)),
+                "ftp" => Ok(FieldValue::AppProto(AppProto::Ftp)),
+                "smtp" => Ok(FieldValue::AppProto(AppProto::Smtp)),
+                "rdp" => Ok(FieldValue::AppProto(AppProto::Rdp)),
+                "smb" => Ok(FieldValue::AppProto(AppProto::Smb)),
+                "quic" => Ok(FieldValue::AppProto(AppProto::Quic)),
+                "unknown" => Ok(FieldValue::AppProto(AppProto::Unknown)),
                 other => Err(LowerError::UnknownValue {
                     kind,
                     value: other.to_string(),
@@ -273,6 +293,7 @@ mod tests {
     use super::*;
     use crate::rule_tree::parsing::ast::AstArm;
     use crate::rule_tree::parsing::lexer::Position;
+    use crate::dpi::AppProto;
     use crate::rule_tree::types::{Hour, IpGlobbable, IpVer, Octet, Port, Protocol, Weekday};
     use crate::rule_tree::{
         ArmEnd, FieldValue, MatchBuilder, MatchKind, Operation, Pattern, Verdict,
@@ -386,6 +407,14 @@ mod tests {
     }
 
     #[test]
+    fn lower_kind_app_proto() {
+        assert_eq!(
+            lower_kind(&sp("app_proto".into())).unwrap(),
+            MatchKind::AppProto
+        );
+    }
+
+    #[test]
     fn lower_kind_src_port() {
         assert_eq!(
             lower_kind(&sp("src_port".into())).unwrap(),
@@ -489,6 +518,28 @@ mod tests {
             err,
             LowerError::UnknownValue {
                 kind: MatchKind::Protocol,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn lower_value_app_proto_http() {
+        let fv = lower_value(MatchKind::AppProto, sp(AstValue::Ident(sp("http".into())))).unwrap();
+        assert_eq!(fv, FieldValue::AppProto(AppProto::Http));
+    }
+
+    #[test]
+    fn lower_value_app_proto_unknown_ident() {
+        let err = lower_value(
+            MatchKind::AppProto,
+            sp(AstValue::Ident(sp("websocket".into()))),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            LowerError::UnknownValue {
+                kind: MatchKind::AppProto,
                 ..
             }
         ));
@@ -1336,5 +1387,15 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn lower_app_proto_comparison_returns_error() {
+        let ast = ast_match(
+            "app_proto",
+            vec![arm(greater_ident("http"), verdict_body(AstVerdict::Allow))],
+        );
+        let err = lower(ast).unwrap_err();
+        assert!(matches!(err, LowerError::Rule(RuleError::InvalidPattern(_))));
     }
 }

--- a/crates/raptorgate/tests/test_raptorlang.rs
+++ b/crates/raptorgate/tests/test_raptorlang.rs
@@ -1,10 +1,11 @@
 // ── Equal: IpVer ──────────────────────────────────────────
 // Mirrors: equal_ip_ver_match / equal_ip_ver_no_match
 
+use ngfw::dpi::AppProto;
 use ngfw::rule_tree::{
     matcher::{Match, MatchBuilder},
     parsing::parse_rule_tree,
-    ArmEnd, ArrivalInfo, FieldValue, Hour, IpGlobbable as IP, IpVer, MatchKind, Octet, Operation,
+    ArmEnd, FieldValue, Hour, IpGlobbable as IP, IpVer, MatchKind, Octet, Operation,
     Pattern, Port, Protocol, Verdict, Weekday,
 };
 
@@ -74,6 +75,29 @@ test_parse_and_stringify!(
         MatchKind::Protocol,
         Pattern::Equal(FieldValue::Protocol(Protocol::Udp)),
         ArmEnd::Verdict(Verdict::Drop),
+    )
+);
+
+test_parse_and_stringify!(
+    lower_equal_app_proto_http,
+    "match app_proto { = http : verdict drop }",
+    MatchBuilder::with_arm(
+        MatchKind::AppProto,
+        Pattern::Equal(FieldValue::AppProto(AppProto::Http)),
+        ArmEnd::Verdict(Verdict::Drop),
+    )
+);
+
+test_parse_and_stringify!(
+    lower_or_app_proto_http_tls,
+    "match app_proto { |(= http = tls) : verdict allow }",
+    MatchBuilder::with_arm(
+        MatchKind::AppProto,
+        Pattern::Or(vec![
+            Pattern::Equal(FieldValue::AppProto(AppProto::Http)),
+            Pattern::Equal(FieldValue::AppProto(AppProto::Tls)),
+        ]),
+        ArmEnd::Verdict(Verdict::Allow),
     )
 );
 


### PR DESCRIPTION
RaptorLang rules can now filter traffic by DPI application protocol through the new app_proto match kind.

RealFrame is no longer part of the current data path, so policy evaluation now receives DPI metadata through PolicyEvalContext. The context carries the sliced packet, arrival metadata, optional DNSSEC data, and optional DpiContext from PacketContext.

The rule tree now supports FieldValue::AppProto and MatchKind::AppProto. The lowerer accepts lowercase DPI protocol identifiers: http, tls, dns, ssh, ftp, smtp, rdp, smb, quic, and unknown. Numeric comparisons are rejected for app_proto like other non-ordered match kinds.

PolicyEvaluator extracts app_proto from DpiContext when DPI has already classified the packet. A concrete app_proto arm does not match when DPI context is missing, while wildcard app_proto arms still match missing DPI data.

PolicyEvalStage now passes ctx.borrow_dpi_ctx() into evaluation, so the existing pipeline order of DpiStage before PolicyEvalStage enables RaptorLang policy decisions based on DPI results.

Tests cover app_proto parsing, stringify roundtrips, known and unknown protocol values, invalid comparison lowering, evaluator match/no-match cases, missing DPI context, and wildcard behavior.