### PR TITLE
feat(config): add NAT config hotswap

### DIFF
--- a/crates/raptorgate/src/data_plane/nat/engine.rs
+++ b/crates/raptorgate/src/data_plane/nat/engine.rs
@@ -66,6 +66,17 @@ impl NatEngine {
         self.bindings.insert(binding);
     }
 
+    pub fn replace_rules(&mut self, nat_rules: NatRules) {
+        let nat_rule_count = nat_rules.rules().len();
+        self.nat_rules = (!nat_rules.is_empty()).then(|| Arc::new(nat_rules));
+
+        tracing::info!(nat_rule_count, "nat rules swapped");
+    }
+
+    pub fn nat_rules(&self) -> Option<Arc<NatRules>> {
+        self.nat_rules.clone()
+    }
+
     /// Zwraca kolejny dostępny identyfikator powiązania
     pub fn next_binding_id(&mut self) -> u64 {
         let binding_id = self.bindings.next_binding_id();
@@ -302,28 +313,27 @@ impl NatEngine {
                     }
                 }
                 
-                if rule.action() != NatAction::Dnat {
-                    if let Some(cidr) = rule.dst_cidr() {
-                        if !cidr.contains(&flow.dst_ip) {
-                            return false;
-                        }
-                    }
+                if (rule.action() != NatAction::Dnat || rule.translated_ip().is_some())
+                    && let Some(cidr) = rule.dst_cidr()
+                    && !cidr.contains(&flow.dst_ip)
+                {
+                    return false;
                 }
-                
+
                 if let Some(rule_proto) = rule.protocol() {
                     if flow_nat_protocol(flow.proto) != rule_proto {
                         return false;
                     }
                 }
-                
-                if rule.action() != NatAction::Dnat {
-                    if let Some(src_port) = rule.src_port() {
-                        if flow.src_port != src_port {
-                            return false;
-                        }
+
+                if (rule.action() != NatAction::Dnat || rule.translated_port().is_some())
+                    && let Some(src_port) = rule.src_port()
+                {
+                    if flow.src_port != src_port {
+                        return false;
                     }
                 }
-                
+
                 if let Some(dst_port) = rule.dst_port() {
                     if flow.dst_port != dst_port {
                         return false;
@@ -361,16 +371,29 @@ impl NatEngine {
 
         let (translated_forward, allocated_port) = match rule.action() {
             NatAction::Snat | NatAction::Pat | NatAction::Masquerade => {
-                let public_ip = self.interface_ip_for(
-                    rule.out_interface()?,
-                    original_forward.src_ip,
-                )?;
+                let public_ip = match rule.translated_ip() {
+                    Some(ip) if same_ip_family(ip, original_forward.src_ip) => ip,
+                    Some(ip) => {
+                        tracing::debug!(
+                            rule_id = %rule.id(),
+                            original_src = %original_forward.src_ip,
+                            translated_src = %ip,
+                            "nat rejected source binding due to mixed address families"
+                        );
+
+                        return None;
+                    }
+                    None => self.interface_ip_for(
+                        rule.out_interface()?,
+                        original_forward.src_ip,
+                    )?,
+                };
                 
                 let port = self.port_store.add(
                     public_ip,
                     original_forward.proto,
                     original_forward.src_port,
-                    rule.src_port().map(|port| PortRange::new(port, port)),
+                    rule.translated_port().map(|port| PortRange::new(port, port)),
                 )?;
 
                 (
@@ -385,7 +408,9 @@ impl NatEngine {
                 )
             }
             NatAction::Dnat => {
-                let dst_ip = rule.dst_cidr()?.addr();
+                let dst_ip = rule
+                    .translated_ip()
+                    .or_else(|| rule.dst_cidr().map(|cidr| cidr.addr()))?;
                 
                 if !same_ip_family(dst_ip, original_forward.dst_ip) {
                     tracing::debug!(
@@ -403,7 +428,7 @@ impl NatEngine {
                         src_ip: original_forward.src_ip,
                         src_port: original_forward.src_port,
                         dst_ip,
-                        dst_port: rule.src_port().unwrap_or(original_forward.dst_port),
+                        dst_port: rule.translated_port().unwrap_or(original_forward.dst_port),
                         proto: original_forward.proto,
                     },
                     None,

--- a/crates/raptorgate/src/main.rs
+++ b/crates/raptorgate/src/main.rs
@@ -33,15 +33,12 @@ use crate::pipeline::wrappers::{
     NatPreroutingStage, PolicyEvalStage, TcpClassificationStage, ValidationStage,
 };
 use crate::pipeline::{Chain, Stage, StageOutcome};
-use crate::policy::nat::nat_rule::{NatAction, NatProtocol, NatRule};
 use crate::policy::nat::nat_rules::NatRules;
 use crate::policy::provider::DiskPolicyProvider;
 use crate::query_server::{QueryHandler, QueryServer};
 use crate::tls::CaManager;
 use etherparse::NetSlice;
-use ipnet::IpNet;
 use std::collections::HashMap;
-use std::net::IpAddr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
@@ -153,7 +150,33 @@ async fn main() {
 
     tokio::spawn(events::init_event_system(config.event_socket_path.clone()));
 
-    let nat_engine = build_test_nat();
+    let nat_rules = match NatRules::from_disk(&config.data_dir).await {
+        Ok(rules) if !rules.is_empty() => {
+            tracing::info!(
+                event = "startup.nat.loaded",
+                rules = rules.rules().len(),
+                "loaded NAT rules from config"
+            );
+            Some(Arc::new(rules))
+        }
+        Ok(_) => {
+            tracing::info!(
+                event = "startup.nat.empty",
+                "NAT rules config is empty"
+            );
+            None
+        }
+        Err(err) => {
+            tracing::warn!(
+                event = "startup.nat.load_failed",
+                error = %err,
+                data_dir = %config.data_dir.display(),
+                "failed to load NAT rules config, starting without NAT rules"
+            );
+            None
+        }
+    };
+    let nat_engine = Arc::new(Mutex::new(NatEngine::new(&nat_rules, HashMap::new())));
 
     // Inicjalizacja providera konfiguracji DNS inspection.
     let dns_inspection_store =
@@ -298,43 +321,4 @@ async fn main() {
             });
         }
     }
-}
-
-fn build_test_nat() -> Arc<Mutex<NatEngine>> {
-    let interface_ips = HashMap::from([
-        (
-            "eth1".to_string(),
-            vec![
-                "192.168.10.254".parse::<IpAddr>().unwrap(),
-                "fd10::fe".parse::<IpAddr>().unwrap(),
-            ],
-        ),
-        (
-            "eth2".to_string(),
-            vec![
-                "192.168.20.254".parse::<IpAddr>().unwrap(),
-                "fd20::fe".parse::<IpAddr>().unwrap(),
-            ],
-        ),
-    ]);
-
-    let rules = NatRules::new(vec![NatRule::new(
-        "dnat-portfwd-8080-to-h1-80".to_string(),
-        20,
-        Some("eth2".to_string()),
-        None,
-        None,
-        None,
-        None,
-        Some("192.168.10.10/32".parse::<IpNet>().unwrap()),
-        Some(NatProtocol::Tcp),
-        Some(80),
-        Some(8080),
-        NatAction::Dnat,
-    )]);
-
-    Arc::new(Mutex::new(NatEngine::new(
-        &Some(Arc::new(rules)),
-        interface_ips,
-    )))
 }

--- a/crates/raptorgate/src/policy/nat/nat_rule.rs
+++ b/crates/raptorgate/src/policy/nat/nat_rule.rs
@@ -1,6 +1,9 @@
+use std::net::IpAddr;
+
+use anyhow::{Context, Result, bail};
 use ipnet::IpNet;
 
-use crate::policy::nat::port_range::PortRange;
+use crate::proto::{common, config};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum NatProtocol {
@@ -30,6 +33,8 @@ pub struct NatRule {
     protocol: Option<NatProtocol>,
     src_port: Option<u16>,
     dst_port: Option<u16>,
+    translated_ip: Option<IpAddr>,
+    translated_port: Option<u16>,
     action: NatAction,
 }
 
@@ -46,6 +51,8 @@ impl NatRule {
         protocol: Option<NatProtocol>,
         src_port: Option<u16>,
         dst_port: Option<u16>,
+        translated_ip: Option<IpAddr>,
+        translated_port: Option<u16>,
         action: NatAction,
     ) -> Self {
         Self {
@@ -60,7 +67,64 @@ impl NatRule {
             protocol,
             src_port,
             dst_port,
+            translated_ip,
+            translated_port,
             action,
+        }
+    }
+
+    pub fn try_from_proto(value: config::NatRule) -> Result<Self> {
+        let action = match common::NatRuleType::try_from(value.r#type)
+            .context("invalid nat rule type")?
+        {
+            common::NatRuleType::Snat => NatAction::Snat,
+            common::NatRuleType::Dnat => NatAction::Dnat,
+            common::NatRuleType::Pat => NatAction::Pat,
+            common::NatRuleType::Unspecified => bail!("nat rule type is unspecified"),
+        };
+
+        let translated_ip = parse_optional_ip(&value.translated_ip, "translated_ip")?;
+        if translated_ip.is_none() {
+            bail!("translated_ip is required");
+        }
+
+        Ok(Self::new(
+            value.id,
+            value.priority,
+            None,
+            None,
+            None,
+            None,
+            parse_optional_net(&value.src_ip, "src_ip")?,
+            parse_optional_net(&value.dst_ip, "dst_ip")?,
+            None,
+            parse_optional_port(value.src_port, "src_port")?,
+            parse_optional_port(value.dst_port, "dst_port")?,
+            translated_ip,
+            parse_optional_port(value.translated_port, "translated_port")?,
+            action,
+        ))
+    }
+
+    pub fn into_proto(&self) -> config::NatRule {
+        config::NatRule {
+            id: self.id.clone(),
+            r#type: match self.action {
+                NatAction::Snat => common::NatRuleType::Snat,
+                NatAction::Dnat => common::NatRuleType::Dnat,
+                NatAction::Pat => common::NatRuleType::Pat,
+                NatAction::Masquerade => common::NatRuleType::Unspecified,
+            } as i32,
+            src_ip: net_to_string(self.src_cidr),
+            dst_ip: net_to_string(self.dst_cidr),
+            src_port: self.src_port.map(u32::from),
+            dst_port: self.dst_port.map(u32::from),
+            translated_ip: self
+                .translated_ip
+                .map(|ip| ip.to_string())
+                .unwrap_or_default(),
+            translated_port: self.translated_port.map(u32::from),
+            priority: self.priority,
         }
     }
 
@@ -97,7 +161,72 @@ impl NatRule {
     pub fn dst_port(&self) -> Option<u16> {
         self.dst_port
     }
+    pub fn translated_ip(&self) -> Option<IpAddr> {
+        self.translated_ip
+    }
+    pub fn translated_port(&self) -> Option<u16> {
+        self.translated_port
+    }
     pub fn action(&self) -> NatAction {
         self.action.clone()
+    }
+}
+
+fn parse_optional_net(value: &str, field: &str) -> Result<Option<IpNet>> {
+    if value.is_empty() {
+        return Ok(None);
+    }
+
+    if value.contains('/') {
+        return value
+            .parse::<IpNet>()
+            .with_context(|| format!("invalid {field}"))
+            .map(Some);
+    }
+
+    let ip = value
+        .parse::<IpAddr>()
+        .with_context(|| format!("invalid {field}"))?;
+    let prefix = match ip {
+        IpAddr::V4(_) => 32,
+        IpAddr::V6(_) => 128,
+    };
+
+    IpNet::new(ip, prefix)
+        .with_context(|| format!("invalid {field}"))
+        .map(Some)
+}
+
+fn parse_optional_ip(value: &str, field: &str) -> Result<Option<IpAddr>> {
+    if value.is_empty() {
+        return Ok(None);
+    }
+
+    value
+        .parse::<IpAddr>()
+        .with_context(|| format!("invalid {field}"))
+        .map(Some)
+}
+
+fn parse_optional_port(value: Option<u32>, field: &str) -> Result<Option<u16>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+
+    if value == 0 {
+        bail!("{field} must be between 1 and 65535");
+    }
+
+    u16::try_from(value)
+        .with_context(|| format!("{field} must be between 1 and 65535"))
+        .map(Some)
+}
+
+fn net_to_string(value: Option<IpNet>) -> String {
+    match value {
+        Some(IpNet::V4(net)) if net.prefix_len() == 32 => net.addr().to_string(),
+        Some(IpNet::V6(net)) if net.prefix_len() == 128 => net.addr().to_string(),
+        Some(net) => net.to_string(),
+        None => String::new(),
     }
 }

--- a/crates/raptorgate/src/policy/nat/nat_rules.rs
+++ b/crates/raptorgate/src/policy/nat/nat_rules.rs
@@ -1,4 +1,11 @@
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use tokio::fs;
+
 use crate::policy::nat::nat_rule::NatRule;
+use crate::proto::{common, config};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct NatRules {
@@ -18,5 +25,134 @@ impl NatRules {
 
     pub fn is_empty(&self) -> bool {
         self.rules.is_empty()
+    }
+
+    pub fn try_from_proto(value: config::NatRuleSet) -> Result<Self, anyhow::Error> {
+        value
+            .items
+            .into_iter()
+            .map(NatRule::try_from_proto)
+            .collect::<Result<Vec<_>, _>>()
+            .map(Self::new)
+    }
+
+    pub fn into_proto(&self) -> config::NatRuleSet {
+        config::NatRuleSet {
+            items: self.rules.iter().map(NatRule::into_proto).collect(),
+        }
+    }
+
+    pub async fn from_disk(data_dir: impl AsRef<Path>) -> Result<Self> {
+        let path = data_dir.as_ref().join("nat_rules.json");
+        let raw = fs::read_to_string(&path)
+            .await
+            .with_context(|| format!("failed to load NAT rules from {}", path.display()))?;
+
+        Self::from_config_json(&raw)
+    }
+
+    fn from_config_json(raw: &str) -> Result<Self> {
+        let file = serde_json::from_str::<NatRulesFile>(raw)
+            .context("failed to parse NAT rules config")?;
+
+        file.items
+            .into_iter()
+            .filter(|item| item.is_active)
+            .map(NatRule::try_from)
+            .collect::<Result<Vec<_>>>()
+            .map(Self::new)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NatRulesFile {
+    items: Vec<NatRuleRecord>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NatRuleRecord {
+    id: String,
+    #[serde(rename = "type")]
+    rule_type: String,
+    is_active: bool,
+    src_ip: Option<String>,
+    dst_ip: Option<String>,
+    src_port: Option<u32>,
+    dst_port: Option<u32>,
+    translated_ip: Option<String>,
+    translated_port: Option<u32>,
+    priority: u32,
+}
+
+impl TryFrom<NatRuleRecord> for NatRule {
+    type Error = anyhow::Error;
+
+    fn try_from(value: NatRuleRecord) -> Result<Self> {
+        NatRule::try_from_proto(config::NatRule {
+            id: value.id,
+            r#type: nat_rule_type(&value.rule_type)? as i32,
+            src_ip: value.src_ip.unwrap_or_default(),
+            dst_ip: value.dst_ip.unwrap_or_default(),
+            src_port: value.src_port,
+            dst_port: value.dst_port,
+            translated_ip: value.translated_ip.unwrap_or_default(),
+            translated_port: value.translated_port,
+            priority: value.priority,
+        })
+    }
+}
+
+fn nat_rule_type(value: &str) -> Result<common::NatRuleType> {
+    match value {
+        "SNAT" => Ok(common::NatRuleType::Snat),
+        "DNAT" => Ok(common::NatRuleType::Dnat),
+        "PAT" => Ok(common::NatRuleType::Pat),
+        other => bail!("unsupported NAT rule type: {other}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_active_backend_nat_rules() {
+        let raw = r#"{
+            "items": [
+                {
+                    "id": "snat-web",
+                    "type": "SNAT",
+                    "isActive": true,
+                    "srcIp": "192.168.1.10",
+                    "dstIp": null,
+                    "srcPort": null,
+                    "dstPort": null,
+                    "translatedIp": "203.0.113.10",
+                    "translatedPort": null,
+                    "priority": 10,
+                    "createdAt": "2026-04-20T00:00:00.000Z",
+                    "updatedAt": "2026-04-20T00:00:00.000Z",
+                    "createdBy": "00000000-0000-4000-8000-000000000001"
+                },
+                {
+                    "id": "disabled",
+                    "type": "DNAT",
+                    "isActive": false,
+                    "dstIp": "203.0.113.20",
+                    "translatedIp": "192.168.1.20",
+                    "priority": 20,
+                    "createdAt": "2026-04-20T00:00:00.000Z",
+                    "updatedAt": "2026-04-20T00:00:00.000Z",
+                    "createdBy": "00000000-0000-4000-8000-000000000001"
+                }
+            ]
+        }"#;
+
+        let rules = NatRules::from_config_json(raw).unwrap();
+
+        assert_eq!(rules.rules().len(), 1);
+        assert_eq!(rules.rules()[0].id(), "snat-web");
     }
 }

--- a/crates/raptorgate/src/query_server.rs
+++ b/crates/raptorgate/src/query_server.rs
@@ -20,6 +20,7 @@ use crate::data_plane::ips::ips::Ips;
 use crate::data_plane::ips::provider::IpsConfigProvider;
 use crate::data_plane::nat::NatEngine;
 use crate::data_plane::tcp_session_tracker::TcpSessionTracker;
+use crate::policy::nat::nat_rules::NatRules;
 use crate::policy::provider::PolicyManager;
 use crate::policy::{Policy, PolicyId};
 use crate::proto::services::firewall_query_service_server::{
@@ -31,13 +32,15 @@ use crate::proto::services::firewall_config_snapshot_service_server::{
 use crate::proto::services::{
     GetConfigRequest, GetConfigResponse, GetDnsInspectionConfigRequest,
     GetDnsInspectionConfigResponse, GetIpsConfigRequest, GetIpsConfigResponse,
-    GetNatBindingsRequest, GetNatBindingsResponse, GetPoliciesRequest, GetPoliciesResponse,
-    GetPolicyRequest, GetPolicyResponse, GetTcpSessionsRequest, GetTcpSessionsResponse,
+    GetNatBindingsRequest, GetNatBindingsResponse, GetNatConfigRequest, GetNatConfigResponse,
+    GetPoliciesRequest, GetPoliciesResponse, GetPolicyRequest, GetPolicyResponse,
+    GetTcpSessionsRequest, GetTcpSessionsResponse,
     GetZonePairRequest, GetZonePairResponse, GetZonePairsRequest, GetZonePairsResponse,
     GetZoneRequest, GetZoneResponse, GetZonesRequest, GetZonesResponse, SwapConfigRequest,
     SwapConfigResponse, SwapDnsInspectionConfigRequest, SwapDnsInspectionConfigResponse,
-    SwapIpsConfigRequest, SwapIpsConfigResponse, GetSystemTimeRequest, GetSystemTimeResponse,
-    PushActiveConfigSnapshotRequest, PushActiveConfigSnapshotResponse,
+    SwapIpsConfigRequest, SwapIpsConfigResponse, SwapNatConfigRequest, SwapNatConfigResponse,
+    GetSystemTimeRequest, GetSystemTimeResponse, PushActiveConfigSnapshotRequest,
+    PushActiveConfigSnapshotResponse,
 };
 use crate::zones::Zone;
 use crate::zones::provider::{ZonePairProvider, ZoneProvider};
@@ -205,6 +208,52 @@ where
         _request: Request<GetNatBindingsRequest>,
     ) -> Result<Response<GetNatBindingsResponse>, Status> {
         Err(Status::unimplemented("not yet implemented"))
+    }
+
+    async fn swap_nat_config(
+        &self,
+        request: Request<SwapNatConfigRequest>,
+    ) -> Result<Response<SwapNatConfigResponse>, Status> {
+        let proto_config = request
+            .into_inner()
+            .config
+            .ok_or_else(|| Status::invalid_argument("missing config field in request"))?;
+
+        let new_config = NatRules::try_from_proto(proto_config)
+            .map_err(|e| Status::invalid_argument(format!("invalid nat config: {e}")))?;
+        let rule_count = new_config.rules().len();
+
+        tracing::info!(
+            event = "nat.swap.started",
+            rules = rule_count,
+            "received NAT config swap request"
+        );
+
+        self.nat_engine.lock().await.replace_rules(new_config);
+
+        tracing::info!(
+            event = "nat.swap.succeeded",
+            rules = rule_count,
+            "NAT config applied"
+        );
+
+        Ok(Response::new(SwapNatConfigResponse {}))
+    }
+
+    async fn get_nat_config(
+        &self,
+        _request: Request<GetNatConfigRequest>,
+    ) -> Result<Response<GetNatConfigResponse>, Status> {
+        let engine = self.nat_engine.lock().await;
+        let config = engine
+            .nat_rules()
+            .as_deref()
+            .map(NatRules::into_proto)
+            .unwrap_or_else(|| crate::proto::config::NatRuleSet { items: vec![] });
+
+        Ok(Response::new(GetNatConfigResponse {
+            config: Some(config),
+        }))
     }
 
     async fn get_zones(
@@ -444,6 +493,7 @@ where
             correlation_id,
             snapshot_id,
             rules = bundle.rules.len(),
+            nat_rules = bundle.nat_rules.len(),
             zones = bundle.zones.len(),
             zone_pairs = bundle.zone_pairs.len(),
             zone_interfaces = bundle.zone_interfaces.len(),
@@ -460,6 +510,10 @@ where
             ZoneInterface::try_from_proto,
             "zone interface",
         )?;
+        let nat_rules = NatRules::try_from_proto(crate::proto::config::NatRuleSet {
+            items: bundle.nat_rules,
+        })
+        .map_err(|e| Status::invalid_argument(format!("invalid nat config: {e}")))?;
 
         // 2. Validate referential integrity across the entire bundle
         let errors =
@@ -504,6 +558,8 @@ where
             .swap_policies(policies.into_iter().collect())
             .await
             .map_err(|e| Status::internal(format!("failed to swap policies: {e}")))?;
+
+        self.nat_engine.lock().await.replace_rules(nat_rules);
 
         tracing::info!(
             event = "config_snapshot.push.succeeded",

--- a/crates/raptorgate/tests/test_query_server.rs
+++ b/crates/raptorgate/tests/test_query_server.rs
@@ -15,9 +15,9 @@ use ngfw::proto::config::{Rule, Zone, ZonePair};
 use ngfw::proto::services::firewall_config_snapshot_service_client::FirewallConfigSnapshotServiceClient;
 use ngfw::proto::services::firewall_query_service_client::FirewallQueryServiceClient;
 use ngfw::proto::services::{
-    ActiveConfigSnapshot, ConfigBundle, GetConfigRequest, GetIpsConfigRequest,
+    ActiveConfigSnapshot, ConfigBundle, GetConfigRequest, GetIpsConfigRequest, GetNatConfigRequest,
     GetPoliciesRequest, GetZonePairsRequest, GetZonesRequest, PushActiveConfigSnapshotRequest,
-    SwapConfigRequest, SwapIpsConfigRequest,
+    SwapConfigRequest, SwapIpsConfigRequest, SwapNatConfigRequest,
 };
 use ngfw::query_server::{QueryHandler, QueryServer};
 use ngfw::zones::provider::ZoneInterfaceProvider;
@@ -480,4 +480,84 @@ async fn swap_and_get_ips_config_roundtrip() {
     assert_eq!(config.signatures.len(), 1);
     assert_eq!(config.signatures[0].id, "sig-http-sqli");
     assert_eq!(config.signatures[0].dst_ports, vec![80, 8080]);
+}
+
+#[tokio::test]
+#[serial(nat_config)]
+async fn swap_and_get_nat_config_roundtrip() {
+    let mut client = connect(&shared_server().socket).await;
+
+    let swapped = ngfw::proto::config::NatRuleSet {
+        items: vec![ngfw::proto::config::NatRule {
+            id: "dnat-http".into(),
+            r#type: ngfw::proto::common::NatRuleType::Dnat as i32,
+            src_ip: String::new(),
+            dst_ip: "203.0.113.10".into(),
+            src_port: None,
+            dst_port: Some(8080),
+            translated_ip: "192.168.10.10".into(),
+            translated_port: Some(80),
+            priority: 10,
+        }],
+    };
+
+    client
+        .swap_nat_config(SwapNatConfigRequest {
+            config: Some(swapped.clone()),
+        })
+        .await
+        .unwrap();
+
+    let response = client
+        .get_nat_config(GetNatConfigRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    let config = response.config.expect("get_nat_config returned no config");
+
+    assert_eq!(config.items.len(), 1);
+    assert_eq!(config.items[0].id, "dnat-http");
+    assert_eq!(
+        config.items[0].r#type,
+        ngfw::proto::common::NatRuleType::Dnat as i32
+    );
+    assert_eq!(config.items[0].dst_ip, "203.0.113.10");
+    assert_eq!(config.items[0].dst_port, Some(8080));
+    assert_eq!(config.items[0].translated_ip, "192.168.10.10");
+    assert_eq!(config.items[0].translated_port, Some(80));
+}
+
+#[tokio::test]
+#[serial(nat_config)]
+async fn swap_nat_config_rejects_missing_config() {
+    let mut client = connect(&shared_server().socket).await;
+
+    let err = client
+        .swap_nat_config(SwapNatConfigRequest { config: None })
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+}
+
+#[tokio::test]
+#[serial(nat_config)]
+async fn swap_nat_config_accepts_empty_rule_set() {
+    let mut client = connect(&shared_server().socket).await;
+
+    client
+        .swap_nat_config(SwapNatConfigRequest {
+            config: Some(ngfw::proto::config::NatRuleSet { items: vec![] }),
+        })
+        .await
+        .unwrap();
+
+    let response = client
+        .get_nat_config(GetNatConfigRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    let config = response.config.expect("get_nat_config returned no config");
+
+    assert!(config.items.is_empty());
 }

--- a/proto/services/query_service.proto
+++ b/proto/services/query_service.proto
@@ -11,6 +11,8 @@ service FirewallQueryService {
   rpc GetPolicies   (GetPoliciesRequest)       returns (GetPoliciesResponse);
   rpc GetPolicy     (GetPolicyRequest)         returns (GetPolicyResponse);
   rpc GetNatBindings(GetNatBindingsRequest)    returns (GetNatBindingsResponse);
+  rpc SwapNatConfig (SwapNatConfigRequest)     returns (SwapNatConfigResponse);
+  rpc GetNatConfig  (GetNatConfigRequest)      returns (GetNatConfigResponse);
 
   rpc GetZones      (GetZonesRequest)          returns (GetZonesResponse);
   rpc GetZone       (GetZoneRequest)           returns (GetZoneResponse);
@@ -45,6 +47,20 @@ message GetPolicyResponse {
 
 message GetNatBindingsRequest {}
 message GetNatBindingsResponse {}
+
+// ── NAT Config ──────────────────────────────────────────────────────────────
+
+message SwapNatConfigRequest {
+  config.NatRuleSet config = 1;
+}
+
+message SwapNatConfigResponse {}
+
+message GetNatConfigRequest {}
+
+message GetNatConfigResponse {
+  config.NatRuleSet config = 1;
+}
 
 message GetZonesRequest {}
 

--- a/vagrant/deploy.sh
+++ b/vagrant/deploy.sh
@@ -49,6 +49,9 @@ rm -rf .router_sync/nginx && mkdir -p .router_sync/nginx
 rm -rf .router_sync/vector && mkdir -p .router_sync/vector
 cp -f ../bin/"$PROJECT_NAME" .router_sync/"$PROJECT_NAME"/"$PROJECT_NAME"
 cp -rf ../bin/backend/* .router_sync/backend/
+rm -rf .router_sync/backend/data/json-db
+mkdir -p .router_sync/backend/data
+cp -rf ../backend/data/json-db .router_sync/backend/data/
 cp -rf ../bin/frontend/dist .router_sync/frontend/
 cd "$SCRIPT_DIR"
 rm -rf .router_sync/backend/devCerts && mkdir -p .router_sync/backend/devCerts


### PR DESCRIPTION
Load NAT rules from persisted JSON instead of the hard-coded test rule. Expose swap/get RPCs so backend config changes can update the data plane. Copy backend json-db into Vagrant deploy so seeded auth data exists in the VM.