### PR TITLE
feat(firewall): add factory reset

### DIFF
--- a/backend/src/application/ports/config-snapshot-push-service.interface.ts
+++ b/backend/src/application/ports/config-snapshot-push-service.interface.ts
@@ -6,11 +6,29 @@ export type ConfigSnapshotPushReason =
   | 'manual_sync'
   | 'import';
 
+export interface FactoryResetCommand {
+  reason?: string;
+  clearPki?: boolean;
+  clearServerKeys?: boolean;
+}
+
+export interface FactoryResetResult {
+  correlationId: string;
+  accepted: boolean;
+  message: string;
+  safeStateApplied: boolean;
+  removedServerKeys: number;
+  removedServerKeyFiles: number;
+  removedCaFiles: number;
+}
+
 export interface IConfigSnapshotPushService {
   pushActiveConfigSnapshot(
     snapshot: ConfigurationSnapshot,
     reason: ConfigSnapshotPushReason,
   ): Promise<void>;
+
+  factoryReset(command: FactoryResetCommand): Promise<FactoryResetResult>;
 }
 
 export const CONFIG_SNAPSHOT_PUSH_SERVICE_TOKEN = Symbol(

--- a/backend/src/application/use-cases/factory-reset.use-case.ts
+++ b/backend/src/application/use-cases/factory-reset.use-case.ts
@@ -1,0 +1,19 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  CONFIG_SNAPSHOT_PUSH_SERVICE_TOKEN,
+  type FactoryResetCommand,
+  type FactoryResetResult,
+  type IConfigSnapshotPushService,
+} from '../ports/config-snapshot-push-service.interface.js';
+
+@Injectable()
+export class FactoryResetUseCase {
+  constructor(
+    @Inject(CONFIG_SNAPSHOT_PUSH_SERVICE_TOKEN)
+    private readonly configSnapshotPushService: IConfigSnapshotPushService,
+  ) {}
+
+  execute(command: FactoryResetCommand): Promise<FactoryResetResult> {
+    return this.configSnapshotPushService.factoryReset(command);
+  }
+}

--- a/backend/src/infrastructure/adapters/grpc-config-snapshot-push.service.ts
+++ b/backend/src/infrastructure/adapters/grpc-config-snapshot-push.service.ts
@@ -10,6 +10,8 @@ import type { ClientGrpc } from "@nestjs/microservices";
 import { firstValueFrom } from "rxjs";
 import type {
   ConfigSnapshotPushReason,
+  FactoryResetCommand,
+  FactoryResetResult,
   IConfigSnapshotPushService,
 } from "../../application/ports/config-snapshot-push-service.interface.js";
 import type { ConfigurationSnapshot } from "../../domain/entities/configuration-snapshot.entity.js";
@@ -28,6 +30,7 @@ import type { Timestamp } from "../grpc/generated/google/protobuf/timestamp.js";
 import {
   type ConfigBundle,
   FIREWALL_CONFIG_SNAPSHOT_SERVICE_NAME,
+  type FactoryResetRequest,
   type FirewallConfigSnapshotServiceClient,
   type PushActiveConfigSnapshotRequest,
 } from "../grpc/generated/services/config_snapshot_service.js";
@@ -52,6 +55,70 @@ export class GrpcConfigSnapshotPushService
       this.grpcClient.getService<FirewallConfigSnapshotServiceClient>(
         FIREWALL_CONFIG_SNAPSHOT_SERVICE_NAME,
       );
+  }
+
+  async factoryReset(command: FactoryResetCommand): Promise<FactoryResetResult> {
+    const correlationId = randomUUID();
+    const request: FactoryResetRequest = {
+      correlationId,
+      reason: command.reason ?? 'factory_reset',
+      clearPki: command.clearPki,
+      clearServerKeys: command.clearServerKeys,
+    };
+
+    this.logger.warn({
+      event: 'firewall.factory_reset.started',
+      message: 'requesting firewall factory reset',
+      correlationId,
+      clearPki: request.clearPki ?? true,
+      clearServerKeys: request.clearServerKeys ?? true,
+    });
+
+    try {
+      const response = await firstValueFrom(
+        this.configSnapshotPushClient.factoryReset(request),
+      );
+
+      if (!response.accepted) {
+        this.logger.warn({
+          event: 'firewall.factory_reset.rejected',
+          message: response.message || 'firewall rejected factory reset',
+          correlationId,
+          safeStateApplied: response.safeStateApplied,
+        });
+        throw new Error(
+          `Firewall rejected factory reset: ${response.message || 'unknown reason'}`,
+        );
+      }
+
+      this.logger.warn({
+        event: 'firewall.factory_reset.succeeded',
+        message: 'firewall factory reset completed',
+        correlationId,
+        removedServerKeys: response.removedServerKeys,
+        removedServerKeyFiles: response.removedServerKeyFiles,
+        removedCaFiles: response.removedCaFiles,
+      });
+
+      return response;
+    } catch (error) {
+      const reasonText =
+        error instanceof Error ? error.message : 'Unknown gRPC error';
+
+      this.logger.error(
+        {
+          event: 'firewall.factory_reset.failed',
+          message: 'failed to request firewall factory reset',
+          correlationId,
+          error: reasonText,
+        },
+        error instanceof Error ? error.stack : undefined,
+      );
+
+      throw new ServiceUnavailableException(
+        `Firewall factory reset service is unavailable. ${reasonText}`,
+      );
+    }
   }
 
   async pushActiveConfigSnapshot(

--- a/backend/src/infrastructure/grpc/raptorgate.controller.ts
+++ b/backend/src/infrastructure/grpc/raptorgate.controller.ts
@@ -4,6 +4,8 @@ import { RpcException } from '@nestjs/microservices';
 import { GetActiveConfigUseCase } from '../../application/use-cases/get-active-config.use-case.js';
 import { EntityNotFoundException } from '../../domain/exceptions/entity-not-found-exception.js';
 import {
+  FactoryResetRequest,
+  FactoryResetResponse,
   FirewallConfigSnapshotServiceController,
   FirewallConfigSnapshotServiceControllerMethods,
   PushActiveConfigSnapshotRequest,
@@ -31,6 +33,24 @@ export class RaptorGateController implements FirewallConfigSnapshotServiceContro
     @Inject(GetActiveConfigUseCase)
     private readonly getActiveConfigUseCase: GetActiveConfigUseCase,
   ) {}
+
+  factoryReset(request: FactoryResetRequest): FactoryResetResponse {
+    const correlationId = this.normalize(request.correlationId);
+
+    this.logger.warn(
+      `[FactoryReset] rejected on backend gRPC controller correlationId=${correlationId} reason=${this.normalize(request.reason)}`,
+    );
+
+    return {
+      correlationId,
+      accepted: false,
+      message: 'Factory reset must be executed by firewall gRPC service',
+      safeStateApplied: false,
+      removedServerKeys: 0,
+      removedServerKeyFiles: 0,
+      removedCaFiles: 0,
+    };
+  }
 
   async pushActiveConfigSnapshot(
     request: PushActiveConfigSnapshotRequest,

--- a/backend/src/modules/config-snapshot.module.ts
+++ b/backend/src/modules/config-snapshot.module.ts
@@ -9,6 +9,7 @@ import { TOKEN_SERVICE_TOKEN } from '../application/ports/token-service.interfac
 import { ConfigSnapshotDiffService } from '../application/services/config-snapshot-diff.service.js';
 import { ApplyConfigSnapshotUseCase } from '../application/use-cases/apply-config-snapshot.use-case.js';
 import { ExportConfigUseCase } from '../application/use-cases/export-config.use-case.js';
+import { FactoryResetUseCase } from '../application/use-cases/factory-reset.use-case.js';
 import { GetConfigDiffUseCase } from '../application/use-cases/get-config-diff.use-case.js';
 import { GetConfigHistoryUseCase } from '../application/use-cases/get-config-history.use-case.js';
 import { ImportConfigUseCase } from '../application/use-cases/import-config.use-case.js';
@@ -150,6 +151,7 @@ import { Env } from '../shared/config/env.validation.js';
     RollbackConfigUseCase,
     ExportConfigUseCase,
     ImportConfigUseCase,
+    FactoryResetUseCase,
     ConfigSnapshotDiffService,
     GrpcConfigSnapshotPushService,
     FileStore,

--- a/backend/src/presentation/controllers/config.controller.ts
+++ b/backend/src/presentation/controllers/config.controller.ts
@@ -13,6 +13,7 @@ import { ApiBody, ApiOperation, ApiQuery } from '@nestjs/swagger';
 import type { GetConfigDiffDto } from '../../application/dtos/get-config-diff.dto.js';
 import { ApplyConfigSnapshotUseCase } from '../../application/use-cases/apply-config-snapshot.use-case.js';
 import { ExportConfigUseCase } from '../../application/use-cases/export-config.use-case.js';
+import { FactoryResetUseCase } from '../../application/use-cases/factory-reset.use-case.js';
 import { GetConfigDiffUseCase } from '../../application/use-cases/get-config-diff.use-case.js';
 import { GetConfigHistoryUseCase } from '../../application/use-cases/get-config-history.use-case.js';
 import { ImportConfigUseCase } from '../../application/use-cases/import-config.use-case.js';
@@ -40,6 +41,10 @@ import { ResponseMessage } from '../decorators/response-message.decorator.js';
 import { ApplyConfigSnapshotDto } from '../dtos/apply-config-snapshot.dto.js';
 import { ApplyConfigSnapshotResponseDto } from '../dtos/apply-config-snapshot-response.dto.js';
 import { ExportConfigResponseDto } from '../dtos/export-config-response.dto.js';
+import {
+  FactoryResetDto,
+  FactoryResetResponseDto,
+} from '../dtos/factory-reset.dto.js';
 import { GetConfigDiffQueryDto } from '../dtos/get-config-diff-query.dto.js';
 import { GetConfigDiffResponseDto } from '../dtos/get-config-diff-response.dto.js';
 import { GetConfigHistoryResponseDto } from '../dtos/get-config-history-response.dto.js';
@@ -61,6 +66,8 @@ export class ConfigController {
     private readonly exportConfigUseCase: ExportConfigUseCase,
     @Inject(ImportConfigUseCase)
     private readonly importConfigUseCase: ImportConfigUseCase,
+    @Inject(FactoryResetUseCase)
+    private readonly factoryResetUseCase: FactoryResetUseCase,
   ) {}
 
   @ApiOperation({
@@ -176,6 +183,29 @@ export class ConfigController {
   ): Promise<RollbackConfigSnapshotResponseDto> {
     const config = await this.rollbackConfigUseCase.execute({ id });
     return config;
+  }
+
+  @ApiOperation({
+    summary: 'Factory reset firewall configuration',
+    description:
+      'Resets firewall local configuration to safe defaults and removes working key material on the firewall.',
+  })
+  @Roles(Role.Operator)
+  @RequirePermissions(Permission.SNAPSHOTS_RESTORE)
+  @Post('factory-reset')
+  @HttpCode(HttpStatus.OK)
+  @ApiBody({ type: FactoryResetDto, required: false })
+  @ResponseMessage('Firewall factory reset completed')
+  @ApiOkEnvelope(FactoryResetResponseDto, 'Firewall factory reset completed')
+  @ApiError400('Validation failed')
+  @ApiError401('Access token is missing, invalid, or expired')
+  @ApiError403('Insufficient permissions to factory reset firewall')
+  @ApiError429('Too many requests')
+  @ApiError500('Internal server error while factory resetting firewall')
+  async factoryReset(
+    @Body() dto: FactoryResetDto = {},
+  ): Promise<FactoryResetResponseDto> {
+    return this.factoryResetUseCase.execute(dto);
   }
 
   @ApiOperation({

--- a/backend/src/presentation/dtos/factory-reset.dto.ts
+++ b/backend/src/presentation/dtos/factory-reset.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
+
+export class FactoryResetDto {
+  @ApiPropertyOptional({ example: 'operator requested reset' })
+  @IsOptional()
+  @IsString()
+  reason?: string;
+
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  clearPki?: boolean;
+
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  clearServerKeys?: boolean;
+}
+
+export class FactoryResetResponseDto {
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  correlationId: string;
+
+  @ApiProperty({ example: true })
+  accepted: boolean;
+
+  @ApiProperty({ example: '' })
+  message: string;
+
+  @ApiProperty({ example: true })
+  safeStateApplied: boolean;
+
+  @ApiProperty({ example: 2 })
+  removedServerKeys: number;
+
+  @ApiProperty({ example: 4 })
+  removedServerKeyFiles: number;
+
+  @ApiProperty({ example: 6 })
+  removedCaFiles: number;
+}

--- a/crates/raptorgate/src/factory_reset.rs
+++ b/crates/raptorgate/src/factory_reset.rs
@@ -1,0 +1,23 @@
+use crate::config::AppConfig;
+
+#[derive(Debug, Clone, Copy)]
+pub struct FactoryResetOptions {
+    pub clear_pki: bool,
+    pub clear_server_keys: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FactoryResetReport {
+    pub safe_state_applied: bool,
+    pub removed_server_keys: u64,
+    pub removed_server_key_files: u64,
+    pub removed_ca_files: u64,
+}
+
+pub fn safe_app_config(current: &AppConfig) -> AppConfig {
+    let mut config = current.clone();
+    config.ssl_inspection_enabled = false;
+    config.ssl_bypass_domains.clear();
+    config.block_tls_on_undeclared_ports = false;
+    config
+}

--- a/crates/raptorgate/src/lib.rs
+++ b/crates/raptorgate/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod data_plane;
 pub mod dpi;
 pub mod events;
+pub mod factory_reset;
 pub mod integrity;
 pub mod interfaces;
 pub mod ip_defrag;

--- a/crates/raptorgate/src/main.rs
+++ b/crates/raptorgate/src/main.rs
@@ -4,6 +4,7 @@ mod data_plane;
 mod disk_store;
 mod dpi;
 mod events;
+mod factory_reset;
 mod interfaces;
 mod ip_defrag;
 mod logging;
@@ -267,6 +268,7 @@ async fn main() {
             interface_monitor,
             interface_controller,
             metrics_collector: Arc::clone(&metrics_collector),
+            reset_lock: Arc::new(Mutex::new(())),
         },
         &config.query_socket_path,
         CancellationToken::new(),

--- a/crates/raptorgate/src/policy/provider.rs
+++ b/crates/raptorgate/src/policy/provider.rs
@@ -39,6 +39,21 @@ impl PolicyManager for DiskPolicyProvider {
     }
 }
 
+pub fn default_drop_policy() -> anyhow::Result<(PolicyId, Policy)> {
+    let policy = Policy {
+        name: "Default policy".into(),
+        zone_pair_id: Uuid::now_v7().into(),
+        priority: 0,
+        rule_tree: RuleTree::new(MatchBuilder::with_arm(
+                MatchKind::IpVer,
+                Pattern::Wildcard,
+                ArmEnd::Verdict(Verdict::DropWarn("Using default drop all policy".into())
+                )).build()?)
+    };
+
+    Ok((Uuid::now_v7().into(), policy))
+}
+
 impl DiskPolicyProvider {
     /// # Panics
     /// if dev config cannot be applied
@@ -73,18 +88,7 @@ impl DiskPolicyProvider {
             return Ok(Self { swapper: Swapper::new(policies, store), evaluator })
         }
 
-        let default_policy = Policy {
-            name: "Default policy".into(),
-            zone_pair_id: Uuid::now_v7().into(),
-            priority: 0,
-            rule_tree: RuleTree::new(MatchBuilder::with_arm(
-                    MatchKind::IpVer,
-                    Pattern::Wildcard,
-                    ArmEnd::Verdict(Verdict::DropWarn("Using default drop all policy".into())
-                    )).build()?)
-        };
-
-        let policies = HashMap::from([(Uuid::now_v7().into(), default_policy)]);
+        let policies = HashMap::from([default_drop_policy()?]);
         let evaluator = PolicyEvaluator::new(policies.iter().next().unwrap().1.rule_tree.clone(), crate::rule_tree::Verdict::Drop);
 
         tracing::info!("No policies found on disk, using default drop all policy.");

--- a/crates/raptorgate/src/query_server.rs
+++ b/crates/raptorgate/src/query_server.rs
@@ -22,12 +22,13 @@ use crate::data_plane::ips::config::IpsConfig;
 use crate::data_plane::ips::ips::Ips;
 use crate::data_plane::ips::provider::IpsConfigProvider;
 use crate::data_plane::nat::{NatConfigProvider, NatEngine};
+use crate::factory_reset::{safe_app_config, FactoryResetOptions, FactoryResetReport};
 use crate::data_plane::tcp_session_tracker::{
     EndpointIdentifier, TcpClosingState, TcpHandshakeState, TcpSessionState, TcpSessionTracker,
 };
 use crate::metrics::{MetricsCollector, MetricsService};
 use crate::policy::nat::nat_rules::NatRules;
-use crate::policy::provider::PolicyManager;
+use crate::policy::provider::{default_drop_policy, PolicyManager};
 use crate::policy::{Policy, PolicyId};
 use crate::proto::common::CertificateType;
 use crate::proto::services::firewall_query_service_server::{
@@ -49,11 +50,13 @@ use crate::proto::services::{
     GetZoneRequest, GetZoneResponse, GetZonesRequest, GetZonesResponse, SwapConfigRequest,
     SwapConfigResponse, SwapDnsInspectionConfigRequest, SwapDnsInspectionConfigResponse,
     SwapIpsConfigRequest, SwapIpsConfigResponse, SwapNatConfigRequest, SwapNatConfigResponse,
-    GetSystemTimeRequest, GetSystemTimeResponse, PushActiveConfigSnapshotRequest,
-    PushActiveConfigSnapshotResponse, SetInterfaceStateRequest, SetInterfaceStateResponse,
+    FactoryResetRequest, FactoryResetResponse, GetSystemTimeRequest, GetSystemTimeResponse,
+    PushActiveConfigSnapshotRequest, PushActiveConfigSnapshotResponse, SetInterfaceStateRequest,
+    SetInterfaceStateResponse,
     UpdateZoneInterfacePropertiesRequest, UpdateZoneInterfacePropertiesResponse,
 };
 use crate::tls::pinning_detector::PinningDetector;
+use crate::tls::cert_storage::clear_ca_files;
 use crate::tls::{EchTlsPolicy, ServerKeyStore, TlsDecisionEngine};
 use crate::zones::Zone;
 use crate::interfaces::{InterfaceController, InterfaceMonitor};
@@ -151,6 +154,7 @@ where
     pub interface_monitor: Arc<Monitor>,
     pub interface_controller: Arc<InterfaceController>,
     pub metrics_collector: Arc<MetricsCollector>,
+    pub reset_lock: Arc<Mutex<()>>,
 }
 
 impl<PolicySwap, Monitor> Clone for QueryHandler<PolicySwap, Monitor>
@@ -178,6 +182,7 @@ where
             interface_monitor: Arc::clone(&self.interface_monitor),
             interface_controller: Arc::clone(&self.interface_controller),
             metrics_collector: Arc::clone(&self.metrics_collector),
+            reset_lock: Arc::clone(&self.reset_lock),
         }
     }
 }
@@ -712,6 +717,78 @@ where
     Swapper: PolicyManager + Send + Sync + 'static,
     Monitor: InterfaceMonitor + Send + Sync + 'static,
 {
+    async fn factory_reset(
+        &self,
+        request: Request<FactoryResetRequest>,
+    ) -> Result<Response<FactoryResetResponse>, Status> {
+        let inner = request.into_inner();
+        let correlation_id = inner.correlation_id.clone();
+        let options = FactoryResetOptions {
+            clear_pki: inner.clear_pki.unwrap_or(true),
+            clear_server_keys: inner.clear_server_keys.unwrap_or(true),
+        };
+        let _reset_guard = self.reset_lock.lock().await;
+
+        tracing::warn!(
+            event = "factory_reset.started",
+            correlation_id,
+            reason = %inner.reason,
+            clear_pki = options.clear_pki,
+            clear_server_keys = options.clear_server_keys,
+            "factory reset requested"
+        );
+
+        if let Err(e) = self.apply_factory_safe_state().await {
+            tracing::error!(event = "factory_reset.failed", correlation_id, error = %e, "failed to apply factory safe state");
+            return Ok(Response::new(FactoryResetResponse {
+                correlation_id,
+                accepted: false,
+                message: format!("failed to apply safe state: {e}"),
+                safe_state_applied: false,
+                removed_server_keys: 0,
+                removed_server_key_files: 0,
+                removed_ca_files: 0,
+            }));
+        }
+
+        let mut report = FactoryResetReport {
+            safe_state_applied: true,
+            ..FactoryResetReport::default()
+        };
+
+        if let Err(e) = self.clear_factory_reset_materials(options, &mut report) {
+            tracing::error!(event = "factory_reset.failed", correlation_id, error = %e, "failed to clear factory reset materials");
+            return Ok(Response::new(FactoryResetResponse {
+                correlation_id,
+                accepted: false,
+                message: format!("safe state applied, cleanup failed: {e}"),
+                safe_state_applied: true,
+                removed_server_keys: report.removed_server_keys,
+                removed_server_key_files: report.removed_server_key_files,
+                removed_ca_files: report.removed_ca_files,
+            }));
+        }
+
+        tracing::warn!(
+            event = "factory_reset.completed",
+            correlation_id,
+            removed_server_keys = report.removed_server_keys,
+            removed_server_key_files = report.removed_server_key_files,
+            removed_ca_files = report.removed_ca_files,
+            "factory reset completed"
+        );
+
+        Ok(Response::new(FactoryResetResponse {
+            correlation_id,
+            accepted: true,
+            message: String::new(),
+            safe_state_applied: report.safe_state_applied,
+            removed_server_keys: report.removed_server_keys,
+            removed_server_key_files: report.removed_server_key_files,
+            removed_ca_files: report.removed_ca_files,
+        }))
+    }
+
     #[allow(clippy::too_many_lines)]
     async fn push_active_config_snapshot(
         &self,
@@ -719,6 +796,7 @@ where
     ) -> Result<Response<PushActiveConfigSnapshotResponse>, Status> {
         let inner = request.into_inner();
         let correlation_id = inner.correlation_id.clone();
+        let _reset_guard = self.reset_lock.lock().await;
 
         // Extract snapshot_id before consuming the snapshot
         let snapshot = inner
@@ -864,6 +942,65 @@ where
     PolicySwap: PolicyManager,
     Monitor: InterfaceMonitor,
 {
+    async fn apply_factory_safe_state(&self) -> anyhow::Result<()> {
+        self.policy_store
+            .swap_policies(vec![default_drop_policy()?])
+            .await?;
+
+        let empty_domains: Vec<String> = Vec::new();
+        self.decision_engine.reload_bypass(&empty_domains);
+        self.decision_engine
+            .reload_known_pinned_domains(&empty_domains);
+        self.decision_engine.reload_ech_policy(EchTlsPolicy::default());
+
+        self.apply_nat_rules(&[]).await?;
+
+        let dns_config = DnsInspectionConfig::default();
+        self.dns_inspection_store
+            .swap_config(dns_config.clone())
+            .await?;
+        self.dns_inspection.update_config(&dns_config)?;
+
+        let ips_config = IpsConfig::default();
+        self.ips_store.swap_config(ips_config.clone()).await?;
+        self.ips.update_config(&ips_config)?;
+
+        self.zone_store.swap_zones(Vec::new()).await?;
+        self.zone_interface_store
+            .swap_zone_interfaces(Vec::new())
+            .await?;
+        self.zone_pair_store.swap_zone_pairs(Vec::new()).await?;
+
+        let safe_config = {
+            let current = self.config_provider.get_config();
+            safe_app_config(current.as_ref())
+        };
+        self.config_provider.swap_config(safe_config).await?;
+
+        tracing::warn!(event = "factory_reset.safe_state_applied", "factory reset safe state applied");
+        Ok(())
+    }
+
+    fn clear_factory_reset_materials(
+        &self,
+        options: FactoryResetOptions,
+        report: &mut FactoryResetReport,
+    ) -> anyhow::Result<()> {
+        if options.clear_server_keys {
+            let key_report = self.server_key_store.clear_all()?;
+            report.removed_server_keys = key_report.removed_entries;
+            report.removed_server_key_files = key_report.removed_files;
+        }
+
+        if options.clear_pki {
+            let config = self.config_provider.get_config();
+            let ca_report = clear_ca_files(Path::new(&config.pki_dir))?;
+            report.removed_ca_files = ca_report.removed_files;
+        }
+
+        Ok(())
+    }
+
     async fn apply_nat_rules(
         &self,
         rules: &[crate::proto::config::NatRule],

--- a/crates/raptorgate/src/tls/cert_storage.rs
+++ b/crates/raptorgate/src/tls/cert_storage.rs
@@ -212,6 +212,32 @@ pub fn save_untrust_ca(
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CaClearReport {
+    pub removed_files: u64,
+}
+
+pub fn clear_ca_files(dir: &Path) -> anyhow::Result<CaClearReport> {
+    let mut removed_files = 0;
+    for name in [
+        "ca.key.enc",
+        "ca.crt",
+        "ca.meta.json",
+        "untrust_ca.key.enc",
+        "untrust_ca.crt",
+        "untrust_ca.meta.json",
+    ] {
+        let path = dir.join(name);
+        match fs::remove_file(&path) {
+            Ok(()) => removed_files += 1,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e).with_context(|| format!("Failed to remove {name}")),
+        }
+    }
+
+    Ok(CaClearReport { removed_files })
+}
+
 // Wczytuje Untrust CA z dysku. Zwraca None gdy pliki nie istnieją.
 pub fn load_untrust_ca(dir: &Path) -> anyhow::Result<Option<LoadedCa>> {
     let key_path = dir.join("untrust_ca.key.enc");
@@ -352,6 +378,22 @@ mod tests {
             .permissions()
             .mode();
         assert_eq!(mode & 0o777, 0o600);
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn clear_ca_files_removes_only_known_ca_files() {
+        let dir = temp_dir();
+        save_ca(&dir, "key", "cert", "fp", 0).unwrap();
+        save_untrust_ca(&dir, "untrust-key", "untrust-cert", "untrust-fp", 0).unwrap();
+        std::fs::write(dir.join("foreign.pem"), "keep").unwrap();
+
+        let report = clear_ca_files(&dir).unwrap();
+
+        assert_eq!(report.removed_files, 6);
+        assert!(!dir.join("ca.key.enc").exists());
+        assert!(!dir.join("untrust_ca.key.enc").exists());
+        assert!(dir.join("foreign.pem").exists());
         std::fs::remove_dir_all(&dir).unwrap();
     }
 }

--- a/crates/raptorgate/src/tls/server_key_store.rs
+++ b/crates/raptorgate/src/tls/server_key_store.rs
@@ -53,9 +53,9 @@ fn save_meta(pki_dir: &Path, id: &str, meta: &ServerKeyMeta) -> anyhow::Result<(
     Ok(())
 }
 
-fn delete_meta(pki_dir: &Path, id: &str) {
+fn delete_meta(pki_dir: &Path, id: &str) -> bool {
     let path = meta_path(pki_dir, id);
-    let _ = fs::remove_file(path);
+    fs::remove_file(path).is_ok()
 }
 
 fn save_key_to_disk(pki_dir: &Path, id: &str, key_pem: &str) -> anyhow::Result<()> {
@@ -83,12 +83,13 @@ fn load_key_from_disk(pki_dir: &Path, id: &str) -> anyhow::Result<String> {
     String::from_utf8(decrypted).context("Server key contains invalid UTF-8")
 }
 
-fn delete_key_from_disk(pki_dir: &Path, id: &str) -> anyhow::Result<()> {
+fn delete_key_from_disk(pki_dir: &Path, id: &str) -> anyhow::Result<bool> {
     let path = key_path(pki_dir, id);
-    if path.exists() {
-        fs::remove_file(&path).with_context(|| format!("Failed to delete server key {id}"))?;
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e).with_context(|| format!("Failed to delete server key {id}")),
     }
-    Ok(())
 }
 
 // Wpis inbound TLS dla jednego serwera.
@@ -112,6 +113,12 @@ pub struct InboundServerInfo {
     pub key_ref: String,
     pub bypass: bool,
     pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ServerKeyClearReport {
+    pub removed_entries: u64,
+    pub removed_files: u64,
 }
 
 // Wynik get_entry, ServerConfig + flagi runtime.
@@ -296,6 +303,66 @@ impl ServerKeyStore {
             tracing::info!(%addr, "Inbound TLS server key removed");
         }
         Ok(removed)
+    }
+
+    pub fn clear_all(&self) -> anyhow::Result<ServerKeyClearReport> {
+        let pki = Path::new(&self.pki_dir);
+        let mut report = ServerKeyClearReport::default();
+
+        for entry in self.list() {
+            if self.entries.remove(&entry.addr).is_some() {
+                report.removed_entries += 1;
+                if delete_key_from_disk(pki, &entry.key_ref)? {
+                    report.removed_files += 1;
+                }
+                if delete_meta(pki, &entry.key_ref) {
+                    report.removed_files += 1;
+                }
+            }
+        }
+
+        let dir = pki.join(SERVER_KEYS_DIR);
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(report),
+            Err(e) => return Err(e).context("Failed to read server_keys directory"),
+        };
+
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_file() {
+                continue;
+            }
+
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            let Some(key_ref) = name.strip_suffix(".meta.json") else {
+                continue;
+            };
+
+            let Ok(meta_content) = fs::read_to_string(&path) else {
+                continue;
+            };
+            let Ok(meta) = serde_json::from_str::<ServerKeyMeta>(&meta_content) else {
+                continue;
+            };
+            if meta.key_ref != key_ref {
+                continue;
+            }
+
+            if delete_key_from_disk(pki, key_ref)? {
+                report.removed_files += 1;
+            }
+            if delete_meta(pki, key_ref) {
+                report.removed_files += 1;
+            }
+        }
+
+        Ok(report)
     }
 
     // Zwraca liste zarejestrowanych serwerow inbound.
@@ -644,6 +711,45 @@ mod tests {
         let store = ServerKeyStore::new(&dir);
         let ok = store.set_enabled(test_addr(), false).unwrap();
         assert!(!ok);
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn clear_all_removes_runtime_and_orphaned_key_material_only() {
+        let dir = temp_dir();
+        let store = ServerKeyStore::new(&dir);
+        let (cert, key) = make_server_cert();
+        let addr = test_addr();
+
+        store
+            .add(addr, &cert, &key, "live-ref", "cn", "FP", false, true)
+            .unwrap();
+        save_key_to_disk(Path::new(&dir), "orphan-ref", &key).unwrap();
+        save_meta(
+            Path::new(&dir),
+            "orphan-ref",
+            &ServerKeyMeta {
+                addr: "10.0.0.10".into(),
+                port: 443,
+                common_name: "orphan".into(),
+                fingerprint: "ORPHAN".into(),
+                certificate_pem: cert,
+                key_ref: "orphan-ref".into(),
+                bypass: false,
+                enabled: true,
+            },
+        )
+        .unwrap();
+        std::fs::write(Path::new(&dir).join(SERVER_KEYS_DIR).join("foreign.pem"), "keep").unwrap();
+
+        let report = store.clear_all().unwrap();
+
+        assert_eq!(report.removed_entries, 1);
+        assert_eq!(report.removed_files, 4);
+        assert!(store.list().is_empty());
+        assert!(!key_path(Path::new(&dir), "live-ref").exists());
+        assert!(!meta_path(Path::new(&dir), "orphan-ref").exists());
+        assert!(Path::new(&dir).join(SERVER_KEYS_DIR).join("foreign.pem").exists());
         std::fs::remove_dir_all(&dir).unwrap();
     }
 }

--- a/crates/raptorgate/tests/test_query_server.rs
+++ b/crates/raptorgate/tests/test_query_server.rs
@@ -16,7 +16,7 @@ use ngfw::proto::config::{InterfaceStatus, Rule, Zone, ZoneInterface, ZonePair};
 use ngfw::proto::services::firewall_config_snapshot_service_client::FirewallConfigSnapshotServiceClient;
 use ngfw::proto::services::firewall_query_service_client::FirewallQueryServiceClient;
 use ngfw::proto::services::{
-    ActiveConfigSnapshot, ConfigBundle, GetConfigRequest, GetIpsConfigRequest,
+    ActiveConfigSnapshot, ConfigBundle, FactoryResetRequest, GetConfigRequest, GetIpsConfigRequest,
     GetLiveZoneInterfacesRequest, GetNatConfigRequest, GetPinningBypassRequest,
     GetPinningStatsRequest, GetPoliciesRequest, GetZoneInterfaceRequest,
     GetZoneInterfacesRequest, GetZonePairsRequest, GetZonesRequest,
@@ -165,6 +165,7 @@ fn shared_server() -> &'static SharedServer {
                     interface_monitor,
                     interface_controller,
                     metrics_collector: Arc::new(ngfw::metrics::MetricsCollector::new()),
+                    reset_lock: Arc::new(Mutex::new(())),
                 };
 
                 let socket = "/tmp/test-query-shared.sock".to_string();
@@ -429,6 +430,54 @@ async fn fetch_policies_returns_ok() {
         expected_rule_name,
         inner.rules.iter().map(|r| &r.name).collect::<Vec<_>>()
     );
+}
+
+#[tokio::test]
+#[serial(snapshot_bundle, nat_config)]
+async fn factory_reset_restores_safe_defaults() {
+    let mut snapshot_client = connect_snapshot(&shared_server().socket).await;
+    let mut query_client = connect(&shared_server().socket).await;
+    let valid = create_valid_bundle(
+        "factory_reset_rule",
+        "match ip_ver { =v4: match protocol { |(=icmp =tcp): verdict allow } =v6: verdict drop }",
+    );
+    let (request, _, _) = create_snapshot_request(valid.bundle);
+
+    let push_response = snapshot_client
+        .push_active_config_snapshot(request)
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(push_response.accepted);
+
+    let reset_response = snapshot_client
+        .factory_reset(FactoryResetRequest {
+            correlation_id: Uuid::now_v7().to_string(),
+            reason: "test".into(),
+            clear_pki: Some(false),
+            clear_server_keys: Some(true),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(reset_response.accepted);
+    assert!(reset_response.safe_state_applied);
+
+    let policies = query_client
+        .get_policies(GetPoliciesRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(policies.rules.len(), 1);
+    assert_eq!(policies.rules[0].name, "Default policy");
+
+    let nat = query_client
+        .get_nat_config(GetNatConfigRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(nat.config.unwrap().items.is_empty());
 }
 
 #[tokio::test]

--- a/proto/services/config_snapshot_service.proto
+++ b/proto/services/config_snapshot_service.proto
@@ -9,6 +9,9 @@ syntax = "proto3";
     // backend -> firewall
     rpc PushActiveConfigSnapshot(PushActiveConfigSnapshotRequest)
         returns (PushActiveConfigSnapshotResponse);
+
+    rpc FactoryReset(FactoryResetRequest)
+        returns (FactoryResetResponse);
   }
 
   message PushActiveConfigSnapshotRequest {
@@ -49,5 +52,22 @@ syntax = "proto3";
     bool accepted = 2;
     string message = 3;
     string applied_snapshot_id = 4;
+  }
+
+  message FactoryResetRequest {
+    string correlation_id = 1;
+    string reason = 2;
+    optional bool clear_pki = 3;
+    optional bool clear_server_keys = 4;
+  }
+
+  message FactoryResetResponse {
+    string correlation_id = 1;
+    bool accepted = 2;
+    string message = 3;
+    bool safe_state_applied = 4;
+    uint64 removed_server_keys = 5;
+    uint64 removed_server_key_files = 6;
+    uint64 removed_ca_files = 7;
   }
 


### PR DESCRIPTION
Reset applies deny-all safe state before clearing local config, server keys, and RaptorGate-managed CA material.