### PR TITLE
fix(config): align gRPC adapters with zone interface proto

### DIFF
--- a/backend/src/application/ports/firewall-zone-query-service.interface.ts
+++ b/backend/src/application/ports/firewall-zone-query-service.interface.ts
@@ -16,7 +16,7 @@ export interface IFirewallZoneQueryService {
   getZoneInterface(id: string): Promise<ZoneInterface | null>;
   getLiveZoneInterfaces(): Promise<ZoneInterface[]>;
   setInterfaceState(id: string, isActive: boolean): Promise<void>;
-  updateZoneInterfaceProperties(
+  updatePhysicalInterfaceProperties(
     input: UpdateZoneInterfacePropertiesInput,
   ): Promise<void>;
   getZonePairs(): Promise<ZonePair[]>;

--- a/backend/src/application/use-cases/edit-zone-interface.use-case.ts
+++ b/backend/src/application/use-cases/edit-zone-interface.use-case.ts
@@ -77,7 +77,7 @@ export class EditZoneInterfaceUseCase {
     // const firewallAddress = this.getFirewallAddress(dto, addresses);
 
     // if (this.shouldUpdateFirewallProperties(dto)) {
-    //   await this.firewallZoneQueryService.updateZoneInterfaceProperties({
+    //   await this.firewallZoneQueryService.updatePhysicalInterfaceProperties({
     //     id: dto.id,
     //     interfaceName: savedZoneInterface.getInterfaceName(),
     //     vlanId: dto.vlanId === null ? undefined : dto.vlanId,

--- a/backend/src/domain/entities/zone-interface.entity.ts
+++ b/backend/src/domain/entities/zone-interface.entity.ts
@@ -14,6 +14,8 @@ export class ZoneInterface {
     private status: ZoneInterfaceStatus,
     private addresses: string[],
     private readonly createdAt: Date,
+    private sniffed: boolean,
+    private parentInterfaceId: string | null,
   ) {}
 
   public static create(
@@ -24,6 +26,8 @@ export class ZoneInterface {
     status: ZoneInterfaceStatus,
     addresses: string[],
     createdAt: Date,
+    sniffed: boolean = false,
+    parentInterfaceId: string | null = null,
   ): ZoneInterface {
     return new ZoneInterface(
       id,
@@ -33,6 +37,8 @@ export class ZoneInterface {
       status,
       addresses,
       createdAt,
+      sniffed,
+      parentInterfaceId,
     );
   }
 
@@ -62,5 +68,17 @@ export class ZoneInterface {
 
   public getAddresses(): string[] {
     return this.addresses;
+  }
+
+  public getSniffed(): boolean {
+    return this.sniffed;
+  }
+
+  public getParentInterfaceId(): string | null {
+    return this.parentInterfaceId;
+  }
+
+  public getKind(): "physical" | "vlan" {
+    return this.vlanId === null ? "physical" : "vlan";
   }
 }

--- a/backend/src/infrastructure/adapters/grpc-config-snapshot-push.service.ts
+++ b/backend/src/infrastructure/adapters/grpc-config-snapshot-push.service.ts
@@ -29,8 +29,8 @@ import {
 import type { Timestamp } from "../grpc/generated/google/protobuf/timestamp.js";
 import {
   type ConfigBundle,
-  FIREWALL_CONFIG_SNAPSHOT_SERVICE_NAME,
   type FactoryResetRequest,
+  FIREWALL_CONFIG_SNAPSHOT_SERVICE_NAME,
   type FirewallConfigSnapshotServiceClient,
   type PushActiveConfigSnapshotRequest,
 } from "../grpc/generated/services/config_snapshot_service.js";
@@ -57,18 +57,20 @@ export class GrpcConfigSnapshotPushService
       );
   }
 
-  async factoryReset(command: FactoryResetCommand): Promise<FactoryResetResult> {
+  async factoryReset(
+    command: FactoryResetCommand,
+  ): Promise<FactoryResetResult> {
     const correlationId = randomUUID();
     const request: FactoryResetRequest = {
       correlationId,
-      reason: command.reason ?? 'factory_reset',
+      reason: command.reason ?? "factory_reset",
       clearPki: command.clearPki,
       clearServerKeys: command.clearServerKeys,
     };
 
     this.logger.warn({
-      event: 'firewall.factory_reset.started',
-      message: 'requesting firewall factory reset',
+      event: "firewall.factory_reset.started",
+      message: "requesting firewall factory reset",
       correlationId,
       clearPki: request.clearPki ?? true,
       clearServerKeys: request.clearServerKeys ?? true,
@@ -81,19 +83,19 @@ export class GrpcConfigSnapshotPushService
 
       if (!response.accepted) {
         this.logger.warn({
-          event: 'firewall.factory_reset.rejected',
-          message: response.message || 'firewall rejected factory reset',
+          event: "firewall.factory_reset.rejected",
+          message: response.message || "firewall rejected factory reset",
           correlationId,
           safeStateApplied: response.safeStateApplied,
         });
         throw new Error(
-          `Firewall rejected factory reset: ${response.message || 'unknown reason'}`,
+          `Firewall rejected factory reset: ${response.message || "unknown reason"}`,
         );
       }
 
       this.logger.warn({
-        event: 'firewall.factory_reset.succeeded',
-        message: 'firewall factory reset completed',
+        event: "firewall.factory_reset.succeeded",
+        message: "firewall factory reset completed",
         correlationId,
         removedServerKeys: response.removedServerKeys,
         removedServerKeyFiles: response.removedServerKeyFiles,
@@ -103,12 +105,12 @@ export class GrpcConfigSnapshotPushService
       return response;
     } catch (error) {
       const reasonText =
-        error instanceof Error ? error.message : 'Unknown gRPC error';
+        error instanceof Error ? error.message : "Unknown gRPC error";
 
       this.logger.error(
         {
-          event: 'firewall.factory_reset.failed',
-          message: 'failed to request firewall factory reset',
+          event: "firewall.factory_reset.failed",
+          message: "failed to request firewall factory reset",
           correlationId,
           error: reasonText,
         },
@@ -216,15 +218,16 @@ export class GrpcConfigSnapshotPushService
       zones: b.zones.items.map((z) => ({
         id: z.getId(),
         name: z.getName(),
-        interfaceIds: [],
       })),
       zoneInterfaces: b.zone_interfaces.items.map((zi) => ({
         id: zi.getId(),
         zoneId: zi.getZoneId(),
-        interfaceName: zi.getInterfaceName(),
-        vlanId: zi.getVlanId() ?? undefined,
+        kind: zi.getVlanId() == null
+          ? { $case: "physical" as const, physical: { interfaceName: zi.getInterfaceName() } }
+          : { $case: "vlan" as const, vlan: { parentInterfaceId: zi.getParentInterfaceId() ?? "", vlanId: zi.getVlanId()! } },
         status: this.toZoneInterfaceStatus(zi.getStatus()),
         addresses: zi.getAddresses(),
+        sniffed: zi.getSniffed(),
       })),
       zonePairs: b.zone_pairs.items.map((zp) => ({
         id: zp.getId(),

--- a/backend/src/infrastructure/adapters/grpc-firewall-zone-query.service.spec.ts
+++ b/backend/src/infrastructure/adapters/grpc-firewall-zone-query.service.spec.ts
@@ -44,7 +44,6 @@ describe("GrpcFirewallZoneQueryService", () => {
           {
             id: "zone-1",
             name: "inside",
-            interfaceIds: ["if-1", "if-2"],
           },
         ],
       }),
@@ -60,7 +59,6 @@ describe("GrpcFirewallZoneQueryService", () => {
     expect(zones[0].getIsActive()).toBe(true);
     expect(zones[0].getCreatedBy()).toBe("");
     expect(zones[0].getCreatedAt()).toBeInstanceOf(Date);
-    expect(zones[0].getInterfaceIds()).toEqual(["if-1", "if-2"]);
   });
 
   it("calls getZone and maps a single zone", async () => {
@@ -69,7 +67,6 @@ describe("GrpcFirewallZoneQueryService", () => {
         zone: {
           id: "zone-2",
           name: "dmz",
-          interfaceIds: ["if-3"],
         },
       }),
     );
@@ -78,7 +75,6 @@ describe("GrpcFirewallZoneQueryService", () => {
 
     expect(client.getZone).toHaveBeenCalledWith({ id: "zone-2" });
     expect(zone?.getId()).toBe("zone-2");
-    expect(zone?.getInterfaceIds()).toEqual(["if-3"]);
   });
 
   it("calls getZoneInterfaces and maps interface fields", async () => {
@@ -88,38 +84,42 @@ describe("GrpcFirewallZoneQueryService", () => {
           {
             id: "zi-1",
             zoneId: "zone-1",
-            interfaceName: "eth0",
+            kind: { $case: "physical", physical: { interfaceName: "eth0" } },
             status: InterfaceStatus.INTERFACE_STATUS_UNSPECIFIED,
             addresses: ["192.168.50.10/24"],
+            sniffed: false,
           },
           {
             id: "zi-2",
             zoneId: "zone-1",
-            interfaceName: "eth1",
-            vlanId: 20,
+            kind: { $case: "vlan", vlan: { parentInterfaceId: "zi-1", vlanId: 20 } },
             status: InterfaceStatus.INTERFACE_STATUS_ACTIVE,
             addresses: ["2001:db8::1/64"],
+            sniffed: false,
           },
           {
             id: "zi-3",
             zoneId: "zone-2",
-            interfaceName: "eth2",
+            kind: { $case: "physical", physical: { interfaceName: "eth2" } },
             status: InterfaceStatus.INTERFACE_STATUS_INACTIVE,
             addresses: [],
+            sniffed: false,
           },
           {
             id: "zi-4",
             zoneId: "zone-2",
-            interfaceName: "eth3",
+            kind: { $case: "physical", physical: { interfaceName: "eth3" } },
             status: InterfaceStatus.INTERFACE_STATUS_MISSING,
             addresses: [],
+            sniffed: false,
           },
           {
             id: "zi-5",
             zoneId: "zone-3",
-            interfaceName: "eth4",
+            kind: { $case: "physical", physical: { interfaceName: "eth4" } },
             status: InterfaceStatus.INTERFACE_STATUS_UNKNOWN,
             addresses: [],
+            sniffed: false,
           },
         ],
       }),
@@ -143,10 +143,10 @@ describe("GrpcFirewallZoneQueryService", () => {
         zoneInterface: {
           id: "zi-1",
           zoneId: "zone-1",
-          interfaceName: "eth0",
-          vlanId: 10,
+          kind: { $case: "vlan", vlan: { parentInterfaceId: "zi-parent", vlanId: 10 } },
           status: InterfaceStatus.INTERFACE_STATUS_ACTIVE,
           addresses: ["10.0.0.1/24"],
+          sniffed: false,
         },
       }),
     );
@@ -166,9 +166,10 @@ describe("GrpcFirewallZoneQueryService", () => {
           {
             id: "live-1",
             zoneId: "zone-1",
-            interfaceName: "eth9",
+            kind: { $case: "physical", physical: { interfaceName: "eth9" } },
             status: InterfaceStatus.INTERFACE_STATUS_ACTIVE,
             addresses: ["172.16.0.1/16"],
+            sniffed: false,
           },
         ],
       }),
@@ -290,7 +291,7 @@ describe("GrpcFirewallZoneQueryService", () => {
     );
   });
 
-  it("keeps existing JSON zone records compatible with default interfaceIds", () => {
+  it("keeps existing JSON zone records compatible with default values", () => {
     const zone = ZoneJsonMapper.toDomain({
       id: "5d375e76-b212-4c9e-8da0-601e5ebb3cd3",
       name: "inside",
@@ -300,6 +301,7 @@ describe("GrpcFirewallZoneQueryService", () => {
       createdBy: "77144f8f-c7b8-4ff4-988f-700f8cd3f937",
     });
 
-    expect(zone.getInterfaceIds()).toEqual([]);
+    expect(zone.getId()).toBe("5d375e76-b212-4c9e-8da0-601e5ebb3cd3");
+    expect(zone.getName()).toBe("inside");
   });
 });

--- a/backend/src/infrastructure/adapters/grpc-firewall-zone-query.service.ts
+++ b/backend/src/infrastructure/adapters/grpc-firewall-zone-query.service.ts
@@ -167,21 +167,20 @@ export class GrpcFirewallZoneQueryService
     }
   }
 
-  async updateZoneInterfaceProperties(
+  async updatePhysicalInterfaceProperties(
     input: UpdateZoneInterfacePropertiesInput,
   ): Promise<void> {
     try {
       await firstValueFrom(
-        this.firewallQueryClient.updateZoneInterfaceProperties({
+        this.firewallQueryClient.updatePhysicalInterfaceProperties({
           id: input.id,
-          interfaceName: input.interfaceName,
-          vlanId: input.vlanId,
-          address: input.address,
+          newName: input.interfaceName,
+          newAddress: input.address,
         }),
       );
     } catch (error) {
       throw this.toTransportException(
-        "update zone interface properties",
+        "update physical interface properties",
         error,
       );
     }
@@ -216,22 +215,35 @@ export class GrpcFirewallZoneQueryService
   }
 
   private toZoneEntity(zone: GrpcZone): Zone {
-    return Zone.create(zone.id, zone.name, null, true, new Date(), "", [
-      ...zone.interfaceIds,
-    ]);
+    return Zone.create(zone.id, zone.name, null, true, new Date(), "");
   }
 
   private toZoneInterfaceEntity(
     zoneInterface: GrpcZoneInterface,
   ): ZoneInterface {
+    const interfaceName =
+      zoneInterface.kind?.$case === "physical"
+        ? zoneInterface.kind.physical.interfaceName
+        : "";
+    const vlanId =
+      zoneInterface.kind?.$case === "vlan"
+        ? zoneInterface.kind.vlan.vlanId ?? null
+        : null;
+    const parentInterfaceId =
+      zoneInterface.kind?.$case === "vlan"
+        ? zoneInterface.kind.vlan.parentInterfaceId
+        : null;
+
     return ZoneInterface.create(
       zoneInterface.id,
       zoneInterface.zoneId,
-      zoneInterface.interfaceName,
-      zoneInterface.vlanId ?? null,
+      interfaceName,
+      vlanId,
       this.toZoneInterfaceStatus(zoneInterface.status),
       [...zoneInterface.addresses],
       new Date(),
+      zoneInterface.sniffed,
+      parentInterfaceId,
     );
   }
 

--- a/backend/src/infrastructure/grpc/raptorgate-grpc.integration.spec.ts
+++ b/backend/src/infrastructure/grpc/raptorgate-grpc.integration.spec.ts
@@ -1,23 +1,23 @@
-import type { ConfigSnapshotPayload } from '../../domain/value-objects/config-snapshot-payload.interface.js';
-import { CONFIG_SNAPSHOT_REPOSITORY_TOKEN } from '../../domain/repositories/config-snapshot.repository.js';
-import { ConfigurationSnapshot } from '../../domain/entities/configuration-snapshot.entity.js';
-import { SnapshotType } from '../../domain/value-objects/snapshot-type.vo.js';
-import { MicroserviceOptions, Transport } from '@nestjs/microservices';
-import { Checksum } from '../../domain/value-objects/checksum.vo.js';
-import { type LoggerService, type LogLevel } from '@nestjs/common';
-import { type ChildProcess, spawn } from 'node:child_process';
-import { Test, type TestingModule } from '@nestjs/testing';
-import { mkdtempSync, rmSync } from 'node:fs';
-import { GrpcModule } from './grpc.module.js';
-import { join, resolve } from 'node:path';
-import { jest } from '@jest/globals';
-import { tmpdir } from 'node:os';
+import { type ChildProcess, spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { jest } from "@jest/globals";
+import { type LoggerService, type LogLevel } from "@nestjs/common";
+import { MicroserviceOptions, Transport } from "@nestjs/microservices";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { ConfigurationSnapshot } from "../../domain/entities/configuration-snapshot.entity.js";
+import { CONFIG_SNAPSHOT_REPOSITORY_TOKEN } from "../../domain/repositories/config-snapshot.repository.js";
+import { Checksum } from "../../domain/value-objects/checksum.vo.js";
+import type { ConfigSnapshotPayload } from "../../domain/value-objects/config-snapshot-payload.interface.js";
+import { SnapshotType } from "../../domain/value-objects/snapshot-type.vo.js";
+import { GrpcModule } from "./grpc.module.js";
 
-const runIntegration = process.env.RUN_FIREWALL_INTEGRATION === '1';
+const runIntegration = process.env.RUN_FIREWALL_INTEGRATION === "1";
 const describeIntegration = runIntegration ? describe : describe.skip;
 
-const repoRoot = resolve(__dirname, '../../../../');
-const firewallBinaryPath = join(repoRoot, 'target', 'debug', 'ngfw');
+const repoRoot = resolve(__dirname, "../../../../");
+const firewallBinaryPath = join(repoRoot, "target", "debug", "ngfw");
 
 jest.setTimeout(30_000);
 
@@ -36,7 +36,7 @@ const TEST_PAYLOAD: ConfigSnapshotPayload = {
     identity: 1,
   },
   bundle: {
-    rules: { checksum: 'abc', items: [] },
+    rules: { checksum: "abc", items: [] },
     zones: { items: [] },
     zone_interfaces: { items: [] },
     zone_pairs: { items: [] },
@@ -45,10 +45,10 @@ const TEST_PAYLOAD: ConfigSnapshotPayload = {
     ssl_bypass_list: { items: [] },
     ips_signatures: { items: [] },
     ml_model: {
-      id: 'ml-1',
-      name: 'noop',
-      artifact_path: '/dev/null',
-      checksum: 'none',
+      id: "ml-1",
+      name: "noop",
+      artifact_path: "/dev/null",
+      checksum: "none",
     },
     firewall_certificates: { items: [] },
     identity: {
@@ -60,61 +60,61 @@ const TEST_PAYLOAD: ConfigSnapshotPayload = {
   },
 };
 
-const TEST_CHECKSUM = 'a'.repeat(64);
+const TEST_CHECKSUM = "a".repeat(64);
 
 const TEST_SNAPSHOT = ConfigurationSnapshot.create(
-  '00000000-0000-0000-0000-000000000001',
+  "00000000-0000-0000-0000-000000000001",
   1,
-  SnapshotType.create('manual_import'),
+  SnapshotType.create("manual_import"),
   Checksum.create(TEST_CHECKSUM),
   true,
   TEST_PAYLOAD,
   null,
   new Date(),
-  '00000000-0000-0000-0000-000000000099',
+  "00000000-0000-0000-0000-000000000099",
 );
 
 class TestLogger implements LoggerService {
   readonly messages: string[] = [];
 
   log(message: unknown, ...optionalParams: unknown[]) {
-    this.capture('LOG', message, optionalParams);
+    this.capture("LOG", message, optionalParams);
   }
   error(message: unknown, ...optionalParams: unknown[]) {
-    this.capture('ERROR', message, optionalParams);
+    this.capture("ERROR", message, optionalParams);
   }
   warn(message: unknown, ...optionalParams: unknown[]) {
-    this.capture('WARN', message, optionalParams);
+    this.capture("WARN", message, optionalParams);
   }
   debug(message: unknown, ...optionalParams: unknown[]) {
-    this.capture('DEBUG', message, optionalParams);
+    this.capture("DEBUG", message, optionalParams);
   }
   verbose(message: unknown, ...optionalParams: unknown[]) {
-    this.capture('VERBOSE', message, optionalParams);
+    this.capture("VERBOSE", message, optionalParams);
   }
 
   setLogLevels(_levels: LogLevel[]) {}
 
   private capture(level: string, message: unknown, params: unknown[]) {
-    const context = params.length > 0 ? ` [${params[params.length - 1]}]` : '';
+    const context = params.length > 0 ? ` [${params[params.length - 1]}]` : "";
     this.messages.push(`${level}${context} ${message}`);
   }
 }
 
-describeIntegration('gRPC integration: firewall ↔ backend', () => {
-  let app: ReturnType<TestingModule['createNestMicroservice']> extends Promise<
+describeIntegration("gRPC integration: firewall ↔ backend", () => {
+  let app: ReturnType<TestingModule["createNestMicroservice"]> extends Promise<
     infer T
   >
     ? T
     : never;
   let firewallProcess: ChildProcess | null = null;
   let runtimeDir: string;
-  let firewallLogs = '';
+  let firewallLogs = "";
   let testLogger: TestLogger;
 
   beforeAll(async () => {
-    runtimeDir = mkdtempSync(join(tmpdir(), 'raptorgate-grpc-it-'));
-    const backendSocketPath = join(runtimeDir, 'backend.sock');
+    runtimeDir = mkdtempSync(join(tmpdir(), "raptorgate-grpc-it-"));
+    const backendSocketPath = join(runtimeDir, "backend.sock");
 
     testLogger = new TestLogger();
 
@@ -130,9 +130,9 @@ describeIntegration('gRPC integration: firewall ↔ backend', () => {
     app = await moduleRef.createNestMicroservice<MicroserviceOptions>({
       transport: Transport.GRPC,
       options: {
-        package: ['raptorgate', 'raptorgate.config', 'raptorgate.events'],
-        protoPath: join(repoRoot, 'proto', 'raptorgate.proto'),
-        loader: { includeDirs: [join(repoRoot, 'proto')] },
+        package: ["raptorgate", "raptorgate.config", "raptorgate.events"],
+        protoPath: join(repoRoot, "proto", "raptorgate.proto"),
+        loader: { includeDirs: [join(repoRoot, "proto")] },
         url: `unix://${backendSocketPath}`,
       },
     });
@@ -142,7 +142,7 @@ describeIntegration('gRPC integration: firewall ↔ backend', () => {
 
     firewallProcess = spawnFirewall(runtimeDir, backendSocketPath);
 
-    await waitForFirewallLog('Config loaded, entering NORMAL mode', 15_000);
+    await waitForFirewallLog("Config loaded, entering NORMAL mode", 15_000);
 
     // Give time for the immediate heartbeat + EventStream setup
     await delay(3_000);
@@ -158,35 +158,35 @@ describeIntegration('gRPC integration: firewall ↔ backend', () => {
     rmSync(runtimeDir, { recursive: true, force: true });
   });
 
-  it('should complete GetActiveConfig flow on startup', () => {
-    const backendLogs = testLogger.messages.join('\n');
+  it("should complete GetActiveConfig flow on startup", () => {
+    const backendLogs = testLogger.messages.join("\n");
 
     // Backend should have logged the GetActiveConfig call with STARTUP reason
-    expect(backendLogs).toContain('[GetActiveConfig]');
+    expect(backendLogs).toContain("[GetActiveConfig]");
     expect(backendLogs).toMatch(/\[GetActiveConfig\].*reason=1/); // 1 = STARTUP
 
     // Firewall should have entered NORMAL mode
-    expect(firewallLogs).toContain('Config loaded, entering NORMAL mode');
+    expect(firewallLogs).toContain("Config loaded, entering NORMAL mode");
   });
 
-  it('should establish EventStream and receive heartbeats', () => {
-    const backendLogs = testLogger.messages.join('\n');
+  it("should establish EventStream and receive heartbeats", () => {
+    const backendLogs = testLogger.messages.join("\n");
 
-    expect(backendLogs).toContain('[EventStream] Firewall connected');
-    expect(backendLogs).toContain('fw.heartbeat');
+    expect(backendLogs).toContain("[EventStream] Firewall connected");
+    expect(backendLogs).toContain("fw.heartbeat");
   });
 
-  it('should follow correct bootstrap sequence', () => {
-    const lines = firewallLogs.split('\n');
+  it("should follow correct bootstrap sequence", () => {
+    const lines = firewallLogs.split("\n");
 
     const connectingIdx = lines.findIndex((l) =>
-      l.includes('Connecting to backend'),
+      l.includes("Connecting to backend"),
     );
     const fetchingIdx = lines.findIndex((l) =>
-      l.includes('Connected to backend, fetching config'),
+      l.includes("Connected to backend, fetching config"),
     );
     const normalIdx = lines.findIndex((l) =>
-      l.includes('Config loaded, entering NORMAL mode'),
+      l.includes("Config loaded, entering NORMAL mode"),
     );
 
     expect(connectingIdx).toBeGreaterThanOrEqual(0);
@@ -204,23 +204,23 @@ describeIntegration('gRPC integration: firewall ↔ backend', () => {
       cwd: repoRoot,
       env: {
         ...process.env,
-        DISABLE_DATA_PLANE: 'true',
+        DISABLE_DATA_PLANE: "true",
         GRPC_SOCKET_PATH: backendSocketPath,
         CONTROL_PLANE_GRPC_SOCKET_PATH: join(
           tmpRuntimeDir,
-          'control-plane.sock',
+          "control-plane.sock",
         ),
-        REDB_SNAPSHOT_PATH: join(tmpRuntimeDir, 'snapshot.redb'),
-        RAPTORGATE_PKI_DIR: join(tmpRuntimeDir, 'pki'),
-        HEARTBEAT_INTERVAL_SECS: '2',
+        REDB_SNAPSHOT_PATH: join(tmpRuntimeDir, "snapshot.redb"),
+        RAPTORGATE_PKI_DIR: join(tmpRuntimeDir, "pki"),
+        HEARTBEAT_INTERVAL_SECS: "2",
       },
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ["ignore", "pipe", "pipe"],
     });
 
-    child.stdout?.on('data', (chunk: Buffer | string) => {
+    child.stdout?.on("data", (chunk: Buffer | string) => {
       firewallLogs += chunk.toString();
     });
-    child.stderr?.on('data', (chunk: Buffer | string) => {
+    child.stderr?.on("data", (chunk: Buffer | string) => {
       firewallLogs += chunk.toString();
     });
 
@@ -250,7 +250,7 @@ describeIntegration('gRPC integration: firewall ↔ backend', () => {
     throw new Error(
       `Timed out (${timeoutMs}ms) waiting for firewall log: "${needle}"\n` +
         `--- Firewall logs ---\n${firewallLogs}\n` +
-        `--- Backend logs ---\n${testLogger.messages.join('\n')}`,
+        `--- Backend logs ---\n${testLogger.messages.join("\n")}`,
     );
   }
 
@@ -268,16 +268,16 @@ describeIntegration('gRPC integration: firewall ↔ backend', () => {
       return;
     }
 
-    child.kill('SIGTERM');
+    child.kill("SIGTERM");
 
     await Promise.race([
       new Promise<void>((resolveExit) => {
-        child.once('exit', () => resolveExit());
+        child.once("exit", () => resolveExit());
       }),
       new Promise<void>((resolveTimeout) =>
         setTimeout(() => {
           if (child.exitCode === null) {
-            child.kill('SIGKILL');
+            child.kill("SIGKILL");
           }
           resolveTimeout();
         }, 3_000),

--- a/backend/src/infrastructure/grpc/raptorgate.controller.ts
+++ b/backend/src/infrastructure/grpc/raptorgate.controller.ts
@@ -1,8 +1,8 @@
-import { status } from '@grpc/grpc-js';
-import { Controller, Inject, Logger } from '@nestjs/common';
-import { RpcException } from '@nestjs/microservices';
-import { GetActiveConfigUseCase } from '../../application/use-cases/get-active-config.use-case.js';
-import { EntityNotFoundException } from '../../domain/exceptions/entity-not-found-exception.js';
+import { status } from "@grpc/grpc-js";
+import { Controller, Inject, Logger } from "@nestjs/common";
+import { RpcException } from "@nestjs/microservices";
+import { GetActiveConfigUseCase } from "../../application/use-cases/get-active-config.use-case.js";
+import { EntityNotFoundException } from "../../domain/exceptions/entity-not-found-exception.js";
 import {
   FactoryResetRequest,
   FactoryResetResponse,
@@ -10,23 +10,25 @@ import {
   FirewallConfigSnapshotServiceControllerMethods,
   PushActiveConfigSnapshotRequest,
   PushActiveConfigSnapshotResponse,
-} from './generated/services/config_snapshot_service';
+} from "./generated/services/config_snapshot_service";
 
 @Controller()
 @FirewallConfigSnapshotServiceControllerMethods()
-export class RaptorGateController implements FirewallConfigSnapshotServiceController {
+export class RaptorGateController
+  implements FirewallConfigSnapshotServiceController
+{
   private readonly logger = new Logger(RaptorGateController.name);
 
   private static readonly ALLOWED_REASONS = new Set([
-    'apply',
-    'rollback',
-    'manual_sync',
+    "apply",
+    "rollback",
+    "manual_sync",
   ]);
 
   private static readonly ALLOWED_SNAPSHOT_TYPES = new Set([
-    'manual_import',
-    'rollback_point',
-    'auto_save',
+    "manual_import",
+    "rollback_point",
+    "auto_save",
   ]);
 
   constructor(
@@ -44,7 +46,7 @@ export class RaptorGateController implements FirewallConfigSnapshotServiceContro
     return {
       correlationId,
       accepted: false,
-      message: 'Factory reset must be executed by firewall gRPC service',
+      message: "Factory reset must be executed by firewall gRPC service",
       safeStateApplied: false,
       removedServerKeys: 0,
       removedServerKeyFiles: 0,
@@ -60,39 +62,39 @@ export class RaptorGateController implements FirewallConfigSnapshotServiceContro
     try {
       const snapshot = request.snapshot;
       if (!snapshot) {
-        return this.reject(correlationId, 'Missing snapshot payload');
+        return this.reject(correlationId, "Missing snapshot payload");
       }
 
       const reason = this.normalize(request.reason).toLowerCase();
       if (!this.isAllowedReason(reason)) {
-        return this.reject(correlationId, 'Invalid reason');
+        return this.reject(correlationId, "Invalid reason");
       }
 
       if (!this.isUuid(snapshot.id)) {
-        return this.reject(correlationId, 'Invalid snapshot id');
+        return this.reject(correlationId, "Invalid snapshot id");
       }
 
       if (!this.isUuid(snapshot.createdBy)) {
-        return this.reject(correlationId, 'Invalid createdBy');
+        return this.reject(correlationId, "Invalid createdBy");
       }
 
       if (
         !Number.isInteger(snapshot.versionNumber) ||
         snapshot.versionNumber < 1
       ) {
-        return this.reject(correlationId, 'Invalid versionNumber');
+        return this.reject(correlationId, "Invalid versionNumber");
       }
 
       if (!this.isAllowedSnapshotType(snapshot.snapshotType)) {
-        return this.reject(correlationId, 'Invalid snapshotType');
+        return this.reject(correlationId, "Invalid snapshotType");
       }
 
       if (!this.isSha256(snapshot.checksum)) {
-        return this.reject(correlationId, 'Invalid checksum format');
+        return this.reject(correlationId, "Invalid checksum format");
       }
 
       if (!snapshot.bundle) {
-        return this.reject(correlationId, 'Missing bundle');
+        return this.reject(correlationId, "Missing bundle");
       }
 
       try {
@@ -107,7 +109,7 @@ export class RaptorGateController implements FirewallConfigSnapshotServiceContro
           return {
             correlationId,
             accepted: true,
-            message: 'Snapshot already active',
+            message: "Snapshot already active",
             appliedSnapshotId: snapshot.id,
           };
         }
@@ -125,7 +127,7 @@ reason=${reason} snapshotId=${snapshot.id} version=${snapshot.versionNumber}`,
       return {
         correlationId,
         accepted: true,
-        message: 'Snapshot validated',
+        message: "Snapshot validated",
         appliedSnapshotId: snapshot.id,
       };
     } catch (error) {
@@ -136,7 +138,7 @@ reason=${reason} snapshotId=${snapshot.id} version=${snapshot.versionNumber}`,
 
       throw new RpcException({
         code: status.INTERNAL,
-        message: 'Failed to process pushed config snapshot',
+        message: "Failed to process pushed config snapshot",
       });
     }
   }
@@ -149,7 +151,7 @@ reason=${reason} snapshotId=${snapshot.id} version=${snapshot.versionNumber}`,
       correlationId,
       accepted: false,
       message,
-      appliedSnapshotId: '',
+      appliedSnapshotId: "",
     };
   }
 
@@ -172,6 +174,6 @@ reason=${reason} snapshotId=${snapshot.id} version=${snapshot.versionNumber}`,
   }
 
   private normalize(value: string | null | undefined): string {
-    return value?.trim() ?? '';
+    return value?.trim() ?? "";
   }
 }

--- a/backend/src/infrastructure/persistence/mappers/zone-interface-json.mapper.ts
+++ b/backend/src/infrastructure/persistence/mappers/zone-interface-json.mapper.ts
@@ -11,6 +11,8 @@ export class ZoneInterfaceJsonMapper {
       record.status,
       record.addresses,
       new Date(record.createdAt),
+      record.sniffed,
+      record.parentInterfaceId,
     );
   }
 
@@ -22,6 +24,8 @@ export class ZoneInterfaceJsonMapper {
       vlanId: zoneInterface.getVlanId(),
       status: zoneInterface.getStatus(),
       addresses: zoneInterface.getAddresses(),
+      sniffed: zoneInterface.getSniffed(),
+      parentInterfaceId: zoneInterface.getParentInterfaceId(),
       createdAt: zoneInterface.getCreatedAt().toISOString(),
     };
   }

--- a/backend/src/infrastructure/persistence/schemas/zone-interfaces.schema.ts
+++ b/backend/src/infrastructure/persistence/schemas/zone-interfaces.schema.ts
@@ -16,6 +16,8 @@ export const ZoneInterfaceRecordSchema = z
     vlanId: z.number().int().nullable(),
     status: z.enum(['unspecified', 'active', 'inactive', 'missing', 'unknown']),
     addresses: z.array(z.string()),
+    sniffed: z.boolean(),
+    parentInterfaceId: z.string().nullable(),
     createdAt: isoDateTimeSchema,
   })
   .strict();


### PR DESCRIPTION
  ZoneInterface proto moved interface details into oneof kind and added
  sniffed. Zone no longer carries interfaceIds, and firewall RPC renamed
  physical interface updates.

Fixes BE-113